### PR TITLE
Fix stale libxrk wheels breaking JupyterLite builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ setup_emsdk = { shell = "EMSDK_VERSION=$(pyodide config get emscripten_version) 
 # JupyterLite wheel building tasks
 build_wheel = { shell = "poetry build -f wheel && python scripts/build_lite_wheel.py", help = "Build motorsports_data_notebook wheel (no deps for JupyterLite)" }
 _download_libxrk = { shell = "rm -rf build/libxrk && mkdir -p build/libxrk && pip download --no-deps --no-binary libxrk -d build/libxrk libxrk && cd build/libxrk && tar -xzf *.tar.gz --strip-components=1 && rm -f *.tar.gz", help = "Download and extract libxrk sdist from PyPI" }
-_copy_libxrk_wheel = { shell = "mkdir -p pypi && cp build/libxrk/dist/*.whl pypi/", help = "Copy libxrk wheel to pypi" }
+_copy_libxrk_wheel = { shell = "mkdir -p pypi && rm -f pypi/libxrk-*.whl && cp build/libxrk/dist/*.whl pypi/", help = "Copy libxrk wheel to pypi (removes old wheels first)" }
 build_libxrk_pyodide = { sequence = ["_download_libxrk", "_build_libxrk_pyodide", "_copy_libxrk_wheel"], help = "Build libxrk wheel for Pyodide (requires setup_emsdk)" }
 build_wheels_lite = ["build_wheel", "build_libxrk_pyodide"]
 


### PR DESCRIPTION
## Summary
- The `_copy_libxrk_wheel` poe task now removes existing `libxrk-*.whl` files from `pypi/` before copying the freshly built wheel
- Prevents stale wheels from a different Pyodide/Python version from accumulating and being picked by JupyterLite's index generator over the correct one
- Previously, having both a `cp312/pyodide_2024_0` and `cp313/pyodide_2025_0` wheel caused `all.json` to reference the wrong one, resulting in `ValueError: Can't find a pure Python 3 wheel for 'libxrk'` at runtime

## Test plan
- [ ] Run `poetry run poe build_and_serve_lite` and verify `pypi/` contains only one libxrk wheel
- [ ] Open basics.ipynb in the served JupyterLite and verify the first cell installs packages without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)