### PR TITLE
Add suspension velocity histogram analysis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ check = { sequence = ["lint", "typecheck", "lint-notebooks", "typecheck-notebook
 test = { cmd = "pytest tests/ --cov=motorsports_data_notebook --cov-report=term-missing --cov-report=html:coverage_html", help = "Run tests with coverage" }
 
 # Workspace tasks
-clean = { shell = "rm -f workspace/*.* && cp workspace_template/basics.ipynb workspace/ && cp workspace_template/tire_analysis.ipynb workspace/ && cp workspace_template/track_analysis.ipynb workspace/ && cp workspace_template/consistency_analysis.ipynb workspace/ && cp workspace_template/'CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz' workspace/", help = "Clean workspace and copy fresh notebooks" }
+clean = { shell = "rm -f workspace/*.* && cp workspace_template/basics.ipynb workspace/ && cp workspace_template/tire_analysis.ipynb workspace/ && cp workspace_template/track_analysis.ipynb workspace/ && cp workspace_template/consistency_analysis.ipynb workspace/ && cp workspace_template/suspension_analysis.ipynb workspace/ && cp workspace_template/'CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz' workspace/", help = "Clean workspace and copy fresh notebooks" }
 run = { cmd = "jupyter lab workspace/", help = "Start Jupyter notebook" }
 run_clean = ["clean", "run"]
 
@@ -101,7 +101,7 @@ build_libxrk_pyodide = { sequence = ["_download_libxrk", "_build_libxrk_pyodide"
 build_wheels_lite = ["build_wheel", "build_libxrk_pyodide"]
 
 # JupyterLite site building tasks
-_prepare_lite_contents = { shell = "rm -rf .lite_contents dist && mkdir -p .lite_contents && cp workspace_template/*.xrz .lite_contents/ && VERSION=$(poetry version -s) && for nb in basics tire_analysis track_analysis consistency_analysis; do cp workspace_template/${nb}.ipynb \".lite_contents/${nb}_v${VERSION}.ipynb\"; done", help = "Prepare .lite_contents directory with versioned notebooks" }
+_prepare_lite_contents = { shell = "rm -rf .lite_contents dist && mkdir -p .lite_contents && cp workspace_template/*.xrz .lite_contents/ && VERSION=$(poetry version -s) && for nb in basics tire_analysis track_analysis consistency_analysis suspension_analysis; do cp workspace_template/${nb}.ipynb \".lite_contents/${nb}_v${VERSION}.ipynb\"; done", help = "Prepare .lite_contents directory with versioned notebooks" }
 _execute_lite_notebooks = { shell = "cd .lite_contents && python ../scripts/execute_notebooks.py", help = "Execute notebooks in .lite_contents to populate outputs" }
 _build_lite_site = { shell = "jupyter lite build --contents .lite_contents --output-dir dist && rm -rf .lite_contents", help = "Build JupyterLite site from .lite_contents" }
 build_lite = ["_prepare_lite_contents", "_execute_lite_notebooks", "_build_lite_site"]

--- a/src/motorsports_data_notebook/suspension.py
+++ b/src/motorsports_data_notebook/suspension.py
@@ -1,0 +1,798 @@
+"""Suspension velocity analysis module.
+
+This module provides functions for computing wheel velocity from shock pot
+displacement data and analyzing velocity distributions for suspension setup.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+
+from .channels import get_lap_channels, interpolate_channels
+
+if TYPE_CHECKING:
+    from libxrk.base import LogFile
+
+
+@dataclass
+class MotionRatios:
+    """Motion ratios for converting shock velocity to wheel velocity.
+
+    Motion ratio = shock_travel / wheel_travel
+    wheel_velocity = shock_velocity / motion_ratio
+
+    Attributes
+    ----------
+    front_left : float
+        Front left motion ratio.
+    front_right : float
+        Front right motion ratio.
+    rear_left : float
+        Rear left motion ratio.
+    rear_right : float
+        Rear right motion ratio.
+    """
+
+    front_left: float = 0.997
+    front_right: float = 0.997
+    rear_left: float = 0.768
+    rear_right: float = 0.768
+
+    @classmethod
+    def toyota_86_zn6(cls) -> "MotionRatios":
+        """Return default motion ratios for Toyota 86 ZN6.
+
+        Front (MacPherson strut): 0.997 (nearly 1:1)
+        Rear (Multi-link): 0.768
+        """
+        return cls(
+            front_left=0.997,
+            front_right=0.997,
+            rear_left=0.768,
+            rear_right=0.768,
+        )
+
+
+@dataclass
+class VelocityRanges:
+    """Velocity thresholds for categorizing suspension motion.
+
+    All values are in mm/s (absolute velocity).
+
+    Attributes
+    ----------
+    friction : float
+        Velocities below this are in the friction/static range.
+    slow : float
+        Velocities below this (but above friction) are in the slow range.
+    fast : float
+        Velocities below this (but above slow) are in the fast range.
+        Velocities above this are in the curb/high-speed range.
+    """
+
+    friction: float = 5.0
+    slow: float = 25.0
+    fast: float = 200.0
+
+
+@dataclass
+class CornerVelocityData:
+    """Velocity histogram and statistics for a single corner.
+
+    Attributes
+    ----------
+    corner_name : str
+        Name of the corner (e.g., "FL", "FR", "RL", "RR").
+    velocity : np.ndarray
+        Raw velocity values in mm/s.
+    bin_edges : np.ndarray
+        Histogram bin edges in mm/s.
+    bin_centers : np.ndarray
+        Histogram bin centers in mm/s.
+    histogram : np.ndarray
+        Histogram values as percentage of time.
+    skew : float
+        Distribution skewness (positive = more rebound, negative = more bump).
+    kurtosis : float
+        Distribution kurtosis (excess kurtosis, 0 for normal).
+    mean : float
+        Mean velocity in mm/s.
+    std : float
+        Standard deviation in mm/s.
+    pct_friction : float
+        Percentage of time in friction range (|v| < friction threshold).
+    pct_slow_bump : float
+        Percentage of time in slow bump range.
+    pct_slow_rebound : float
+        Percentage of time in slow rebound range.
+    pct_fast_bump : float
+        Percentage of time in fast bump range.
+    pct_fast_rebound : float
+        Percentage of time in fast rebound range.
+    pct_curb : float
+        Percentage of time in curb/high-speed range (|v| > fast threshold).
+    pct_zero_bin : float
+        Percentage of time in the center histogram bin (centered at 0).
+    """
+
+    corner_name: str
+    velocity: np.ndarray
+    bin_edges: np.ndarray
+    bin_centers: np.ndarray
+    histogram: np.ndarray
+    skew: float
+    kurtosis: float
+    mean: float
+    std: float
+    pct_friction: float
+    pct_slow_bump: float
+    pct_slow_rebound: float
+    pct_fast_bump: float
+    pct_fast_rebound: float
+    pct_curb: float
+    pct_zero_bin: float
+
+
+@dataclass
+class VelocityHistogramResult:
+    """Complete velocity histogram analysis for all four corners.
+
+    Attributes
+    ----------
+    front_left : CornerVelocityData
+        Front left corner data.
+    front_right : CornerVelocityData
+        Front right corner data.
+    rear_left : CornerVelocityData
+        Rear left corner data.
+    rear_right : CornerVelocityData
+        Rear right corner data.
+    velocity_ranges : VelocityRanges
+        Velocity thresholds used for categorization.
+    """
+
+    front_left: CornerVelocityData
+    front_right: CornerVelocityData
+    rear_left: CornerVelocityData
+    rear_right: CornerVelocityData
+    velocity_ranges: VelocityRanges = field(default_factory=VelocityRanges)
+
+
+# Default channel names for suspension analysis
+SUSPENSION_CHANNEL_NAMES = {
+    "shock_fl": "LF_Shock_Pot",
+    "shock_fr": "RF_Shock_Pot",
+    "shock_rl": "LR_Shock_Pot",
+    "shock_rr": "RR_Shock_Pot",
+}
+
+
+def compute_shock_velocity(
+    displacement: np.ndarray,
+    timecodes: np.ndarray,
+    smoothing_window: int = 5,
+) -> np.ndarray:
+    """Compute shock velocity from displacement data.
+
+    Uses numpy gradient with time-based differentiation to handle varying
+    sample rates. Optional smoothing reduces noise from differentiation.
+
+    Parameters
+    ----------
+    displacement : np.ndarray
+        Shock pot displacement values in mm.
+    timecodes : np.ndarray
+        Timestamps in milliseconds.
+    smoothing_window : int, default=5
+        Rolling average window size for smoothing. Set to 1 to disable.
+
+    Returns
+    -------
+    np.ndarray
+        Shock velocity in mm/s. Positive = bump (compression),
+        negative = rebound (extension).
+
+    Examples
+    --------
+    >>> displacement = np.array([0, 1, 3, 6, 10])
+    >>> timecodes = np.array([0, 100, 200, 300, 400])
+    >>> velocity = compute_shock_velocity(displacement, timecodes, smoothing_window=1)
+    """
+    # Convert timecodes from ms to seconds for proper velocity units
+    time_seconds = timecodes / 1000.0
+
+    # Compute velocity using numpy gradient (handles varying sample rates)
+    velocity: np.ndarray = np.gradient(displacement, time_seconds)
+
+    # Apply smoothing if requested
+    if smoothing_window > 1 and len(velocity) >= smoothing_window:
+        kernel = np.ones(smoothing_window) / smoothing_window
+        # Use 'same' mode and handle edges by padding
+        velocity_padded = np.pad(
+            velocity, (smoothing_window // 2, smoothing_window // 2), mode="edge"
+        )
+        velocity = np.asarray(np.convolve(velocity_padded, kernel, mode="valid"))
+
+    return velocity
+
+
+def compute_wheel_velocity(
+    shock_velocity: np.ndarray,
+    motion_ratio: float,
+) -> np.ndarray:
+    """Convert shock velocity to wheel velocity using motion ratio.
+
+    Parameters
+    ----------
+    shock_velocity : np.ndarray
+        Shock velocity in mm/s.
+    motion_ratio : float
+        Motion ratio (shock_travel / wheel_travel).
+
+    Returns
+    -------
+    np.ndarray
+        Wheel velocity in mm/s.
+
+    Examples
+    --------
+    >>> shock_vel = np.array([10, 20, 30])
+    >>> wheel_vel = compute_wheel_velocity(shock_vel, motion_ratio=0.768)
+    >>> # wheel_vel = [13.02, 26.04, 39.06] (approximately)
+    """
+    return shock_velocity / motion_ratio
+
+
+def compute_velocity_histogram(
+    velocity: np.ndarray,
+    bin_size: float = 5.0,
+    max_velocity: float = 300.0,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute zero-centered velocity histogram.
+
+    Creates bins centered on zero (e.g., -5 to 5, not 0 to 10).
+
+    Parameters
+    ----------
+    velocity : np.ndarray
+        Velocity values in mm/s.
+    bin_size : float, default=5.0
+        Size of each histogram bin in mm/s.
+    max_velocity : float, default=300.0
+        Maximum velocity to include in histogram.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, np.ndarray]
+        (histogram, bin_edges, bin_centers)
+        - histogram: Percentage of time in each bin (sums to 100).
+        - bin_edges: Bin edge values in mm/s.
+        - bin_centers: Bin center values in mm/s.
+
+    Examples
+    --------
+    >>> velocity = np.random.normal(0, 50, 1000)
+    >>> hist, edges, centers = compute_velocity_histogram(velocity)
+    >>> assert np.isclose(hist.sum(), 100.0)
+    """
+    # Create zero-centered bins
+    # Bins are arranged so that zero is at the center of a bin
+    # e.g., with bin_size=10: edges at -5, 5, 15, ... so centers are at 0, 10, 20, ...
+    half_bin = bin_size / 2
+    n_bins_half = int(max_velocity / bin_size)
+    # Create edges: -max - half_bin, ..., -half_bin, half_bin, ..., max + half_bin
+    positive_edges = np.arange(half_bin, max_velocity + bin_size, bin_size)
+    negative_edges = -positive_edges[::-1]
+    bin_edges = np.concatenate([negative_edges, positive_edges])
+
+    # Clip velocities to the histogram range
+    clipped_velocity = np.clip(velocity, -max_velocity, max_velocity)
+
+    # Compute histogram
+    counts, _ = np.histogram(clipped_velocity, bins=bin_edges)
+
+    # Convert to percentage of time
+    total_samples = len(velocity)
+    if total_samples > 0:
+        histogram = counts / total_samples * 100.0
+    else:
+        histogram = counts.astype(float)
+
+    # Compute bin centers
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+
+    return histogram, bin_edges, bin_centers
+
+
+def compute_velocity_stats(
+    velocity: np.ndarray,
+    ranges: VelocityRanges,
+) -> dict[str, float]:
+    """Compute velocity distribution statistics.
+
+    Parameters
+    ----------
+    velocity : np.ndarray
+        Velocity values in mm/s.
+    ranges : VelocityRanges
+        Velocity thresholds for categorization.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary with keys:
+        - skew: Distribution skewness
+        - kurtosis: Excess kurtosis (0 for normal distribution)
+        - mean: Mean velocity
+        - std: Standard deviation
+        - pct_friction: % time in friction range
+        - pct_slow_bump: % time in slow bump range
+        - pct_slow_rebound: % time in slow rebound range
+        - pct_fast_bump: % time in fast bump range
+        - pct_fast_rebound: % time in fast rebound range
+        - pct_curb: % time in curb/high-speed range
+
+    Examples
+    --------
+    >>> velocity = np.random.normal(0, 50, 1000)
+    >>> stats = compute_velocity_stats(velocity, VelocityRanges())
+    >>> print(f"Skew: {stats['skew']:.2f}")
+    """
+    n = len(velocity)
+    if n == 0:
+        return {
+            "skew": 0.0,
+            "kurtosis": 0.0,
+            "mean": 0.0,
+            "std": 0.0,
+            "pct_friction": 0.0,
+            "pct_slow_bump": 0.0,
+            "pct_slow_rebound": 0.0,
+            "pct_fast_bump": 0.0,
+            "pct_fast_rebound": 0.0,
+            "pct_curb": 0.0,
+        }
+
+    # Basic statistics
+    mean = float(np.mean(velocity))
+    std = float(np.std(velocity))
+
+    # Skewness and kurtosis
+    if std > 0:
+        centered = velocity - mean
+        skew = float(np.mean((centered / std) ** 3))
+        kurtosis = float(np.mean((centered / std) ** 4) - 3)  # Excess kurtosis
+    else:
+        skew = 0.0
+        kurtosis = 0.0
+
+    # Velocity categorization
+    abs_velocity = np.abs(velocity)
+
+    # Friction range: |v| < friction threshold
+    friction_mask = abs_velocity < ranges.friction
+    pct_friction = float(np.sum(friction_mask) / n * 100)
+
+    # Slow range: friction <= |v| < slow
+    slow_mask = (abs_velocity >= ranges.friction) & (abs_velocity < ranges.slow)
+    slow_bump_mask = slow_mask & (velocity > 0)
+    slow_rebound_mask = slow_mask & (velocity < 0)
+    pct_slow_bump = float(np.sum(slow_bump_mask) / n * 100)
+    pct_slow_rebound = float(np.sum(slow_rebound_mask) / n * 100)
+
+    # Fast range: slow <= |v| < fast
+    fast_mask = (abs_velocity >= ranges.slow) & (abs_velocity < ranges.fast)
+    fast_bump_mask = fast_mask & (velocity > 0)
+    fast_rebound_mask = fast_mask & (velocity < 0)
+    pct_fast_bump = float(np.sum(fast_bump_mask) / n * 100)
+    pct_fast_rebound = float(np.sum(fast_rebound_mask) / n * 100)
+
+    # Curb range: |v| >= fast
+    curb_mask = abs_velocity >= ranges.fast
+    pct_curb = float(np.sum(curb_mask) / n * 100)
+
+    return {
+        "skew": skew,
+        "kurtosis": kurtosis,
+        "mean": mean,
+        "std": std,
+        "pct_friction": pct_friction,
+        "pct_slow_bump": pct_slow_bump,
+        "pct_slow_rebound": pct_slow_rebound,
+        "pct_fast_bump": pct_fast_bump,
+        "pct_fast_rebound": pct_fast_rebound,
+        "pct_curb": pct_curb,
+    }
+
+
+def _validate_channel_names(channel_names: dict, required_keys: list[str], func_name: str) -> None:
+    """Validate that required keys are present in channel_names dict."""
+    missing = [key for key in required_keys if key not in channel_names]
+    if missing:
+        raise KeyError(
+            f"{func_name}() requires channel_names to have keys: {required_keys}. "
+            f"Missing: {missing}"
+        )
+
+
+def _process_corner(
+    displacement: np.ndarray,
+    timecodes: np.ndarray,
+    motion_ratio: float,
+    corner_name: str,
+    smoothing_window: int,
+    bin_size: float,
+    max_velocity: float,
+    ranges: VelocityRanges,
+) -> CornerVelocityData:
+    """Process a single corner's suspension data."""
+    # Compute shock velocity
+    shock_velocity = compute_shock_velocity(displacement, timecodes, smoothing_window)
+
+    # Convert to wheel velocity
+    wheel_velocity = compute_wheel_velocity(shock_velocity, motion_ratio)
+
+    # Compute histogram
+    histogram, bin_edges, bin_centers = compute_velocity_histogram(
+        wheel_velocity, bin_size, max_velocity
+    )
+
+    # Find zero bin percentage (the bin centered at 0)
+    zero_bin_idx = int(np.argmin(np.abs(bin_centers)))
+    pct_zero_bin = float(histogram[zero_bin_idx]) if len(histogram) > 0 else 0.0
+
+    # Compute statistics
+    stats = compute_velocity_stats(wheel_velocity, ranges)
+
+    return CornerVelocityData(
+        corner_name=corner_name,
+        velocity=wheel_velocity,
+        bin_edges=bin_edges,
+        bin_centers=bin_centers,
+        histogram=histogram,
+        skew=stats["skew"],
+        kurtosis=stats["kurtosis"],
+        mean=stats["mean"],
+        std=stats["std"],
+        pct_friction=stats["pct_friction"],
+        pct_slow_bump=stats["pct_slow_bump"],
+        pct_slow_rebound=stats["pct_slow_rebound"],
+        pct_fast_bump=stats["pct_fast_bump"],
+        pct_fast_rebound=stats["pct_fast_rebound"],
+        pct_curb=stats["pct_curb"],
+        pct_zero_bin=pct_zero_bin,
+    )
+
+
+def analyze_suspension_velocity(
+    log: "LogFile",
+    lap_start: int,
+    lap_end: int,
+    channel_names: dict | None = None,
+    motion_ratios: MotionRatios | None = None,
+    velocity_ranges: VelocityRanges | None = None,
+    smoothing_window: int = 5,
+    bin_size: float = 10.0,
+    max_velocity: float = 300.0,
+) -> VelocityHistogramResult:
+    """Analyze suspension velocity distribution for a lap.
+
+    Main analysis function that processes all four corners and returns
+    comprehensive velocity histogram data and statistics.
+
+    Parameters
+    ----------
+    log : LogFile
+        The loaded log file with channels dict.
+    lap_start : int
+        Start timestamp in milliseconds.
+    lap_end : int
+        End timestamp in milliseconds.
+    channel_names : dict, optional
+        Channel name mapping. Required keys:
+        - "shock_fl": Front left shock pot channel
+        - "shock_fr": Front right shock pot channel
+        - "shock_rl": Rear left shock pot channel
+        - "shock_rr": Rear right shock pot channel
+        If None, uses SUSPENSION_CHANNEL_NAMES defaults.
+    motion_ratios : MotionRatios, optional
+        Motion ratios for each corner. If None, uses Toyota 86 ZN6 defaults.
+    velocity_ranges : VelocityRanges, optional
+        Velocity thresholds for categorization. If None, uses defaults.
+    smoothing_window : int, default=5
+        Rolling average window size for velocity smoothing.
+    bin_size : float, default=10.0
+        Histogram bin size in mm/s.
+    max_velocity : float, default=300.0
+        Maximum velocity for histogram range.
+
+    Returns
+    -------
+    VelocityHistogramResult
+        Complete analysis results for all four corners.
+
+    Raises
+    ------
+    KeyError
+        If required channel names are missing.
+
+    Examples
+    --------
+    >>> from motorsports_data_notebook.channels import get_best_lap
+    >>> best_lap = get_best_lap(laps)
+    >>> result = analyze_suspension_velocity(
+    ...     log,
+    ...     lap_start=best_lap["start_time"],
+    ...     lap_end=best_lap["end_time"],
+    ... )
+    >>> print(f"FL skew: {result.front_left.skew:.2f}")
+    """
+    # Use defaults if not provided
+    if channel_names is None:
+        channel_names = SUSPENSION_CHANNEL_NAMES.copy()
+    if motion_ratios is None:
+        motion_ratios = MotionRatios.toyota_86_zn6()
+    if velocity_ranges is None:
+        velocity_ranges = VelocityRanges()
+
+    # Validate channel names
+    required_keys = ["shock_fl", "shock_fr", "shock_rl", "shock_rr"]
+    _validate_channel_names(channel_names, required_keys, "analyze_suspension_velocity")
+
+    # Extract channel data
+    shock_fl_name = channel_names["shock_fl"]
+    shock_fr_name = channel_names["shock_fr"]
+    shock_rl_name = channel_names["shock_rl"]
+    shock_rr_name = channel_names["shock_rr"]
+
+    channels = get_lap_channels(
+        log,
+        [shock_fl_name, shock_fr_name, shock_rl_name, shock_rr_name],
+        lap_start,
+        lap_end,
+    )
+
+    # Use front left as reference for interpolation (all shocks typically same rate)
+    aligned = interpolate_channels(channels, reference_channel=shock_fl_name)
+
+    # Extract timecodes and displacement arrays
+    timecodes = aligned[shock_fl_name].column("timecodes").to_numpy()
+    fl_disp = aligned[shock_fl_name].column(shock_fl_name).to_numpy()
+    fr_disp = aligned[shock_fr_name].column(shock_fr_name).to_numpy()
+    rl_disp = aligned[shock_rl_name].column(shock_rl_name).to_numpy()
+    rr_disp = aligned[shock_rr_name].column(shock_rr_name).to_numpy()
+
+    # Process each corner
+    fl_data = _process_corner(
+        fl_disp,
+        timecodes,
+        motion_ratios.front_left,
+        "FL",
+        smoothing_window,
+        bin_size,
+        max_velocity,
+        velocity_ranges,
+    )
+    fr_data = _process_corner(
+        fr_disp,
+        timecodes,
+        motion_ratios.front_right,
+        "FR",
+        smoothing_window,
+        bin_size,
+        max_velocity,
+        velocity_ranges,
+    )
+    rl_data = _process_corner(
+        rl_disp,
+        timecodes,
+        motion_ratios.rear_left,
+        "RL",
+        smoothing_window,
+        bin_size,
+        max_velocity,
+        velocity_ranges,
+    )
+    rr_data = _process_corner(
+        rr_disp,
+        timecodes,
+        motion_ratios.rear_right,
+        "RR",
+        smoothing_window,
+        bin_size,
+        max_velocity,
+        velocity_ranges,
+    )
+
+    return VelocityHistogramResult(
+        front_left=fl_data,
+        front_right=fr_data,
+        rear_left=rl_data,
+        rear_right=rr_data,
+        velocity_ranges=velocity_ranges,
+    )
+
+
+def format_suspension_stats_table(
+    result: VelocityHistogramResult,
+) -> pd.DataFrame:
+    """Format suspension statistics as a DataFrame.
+
+    Creates a summary table with per-corner statistics for easy comparison.
+
+    Parameters
+    ----------
+    result : VelocityHistogramResult
+        Analysis results from analyze_suspension_velocity().
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns for each corner and rows for each statistic.
+
+    Examples
+    --------
+    >>> result = analyze_suspension_velocity(log, lap_start, lap_end)
+    >>> stats_df = format_suspension_stats_table(result)
+    >>> display(stats_df)
+    """
+    corners = {
+        "FL": result.front_left,
+        "FR": result.front_right,
+        "RL": result.rear_left,
+        "RR": result.rear_right,
+    }
+
+    data = []
+    for corner_name, corner_data in corners.items():
+        data.append(
+            {
+                "Corner": corner_name,
+                "Skew": corner_data.skew,
+                "Kurtosis": corner_data.kurtosis,
+                "Mean (mm/s)": corner_data.mean,
+                "Std (mm/s)": corner_data.std,
+                "Zero Bin %": corner_data.pct_zero_bin,
+                "Friction %": corner_data.pct_friction,
+                "Slow Bump %": corner_data.pct_slow_bump,
+                "Slow Rebound %": corner_data.pct_slow_rebound,
+                "Fast Bump %": corner_data.pct_fast_bump,
+                "Fast Rebound %": corner_data.pct_fast_rebound,
+                "Curb %": corner_data.pct_curb,
+            }
+        )
+
+    return pd.DataFrame(data)
+
+
+def format_symmetry_table(result: VelocityHistogramResult) -> pd.DataFrame:
+    """Format bump vs rebound symmetry comparison.
+
+    Parameters
+    ----------
+    result : VelocityHistogramResult
+        Analysis results from analyze_suspension_velocity().
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame comparing bump and rebound percentages for each corner.
+    """
+    corners = {
+        "FL": result.front_left,
+        "FR": result.front_right,
+        "RL": result.rear_left,
+        "RR": result.rear_right,
+    }
+
+    data = []
+    for corner_name, corner_data in corners.items():
+        total_bump = corner_data.pct_slow_bump + corner_data.pct_fast_bump
+        total_rebound = corner_data.pct_slow_rebound + corner_data.pct_fast_rebound
+        symmetry = (
+            total_bump / (total_bump + total_rebound) * 100
+            if (total_bump + total_rebound) > 0
+            else 50.0
+        )
+
+        data.append(
+            {
+                "Corner": corner_name,
+                "Total Bump %": total_bump,
+                "Total Rebound %": total_rebound,
+                "Bump/Total %": symmetry,
+                "Slow Bump %": corner_data.pct_slow_bump,
+                "Slow Rebound %": corner_data.pct_slow_rebound,
+                "Fast Bump %": corner_data.pct_fast_bump,
+                "Fast Rebound %": corner_data.pct_fast_rebound,
+            }
+        )
+
+    return pd.DataFrame(data)
+
+
+def format_comparison_table(result: VelocityHistogramResult) -> pd.DataFrame:
+    """Format left/right and front/rear comparison table.
+
+    Combines wheels into groups and shows the difference in velocity range
+    percentages between groups:
+    - Left (FL + RL) vs Right (FR + RR)
+    - Front (FL + FR) vs Rear (RL + RR)
+
+    Parameters
+    ----------
+    result : VelocityHistogramResult
+        Analysis results from analyze_suspension_velocity().
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with combined group comparisons showing percentage differences.
+    """
+    fl = result.front_left
+    fr = result.front_right
+    rl = result.rear_left
+    rr = result.rear_right
+
+    # Compute averages for each group
+    # Left (FL + RL) vs Right (FR + RR)
+    left_zero = (fl.pct_zero_bin + rl.pct_zero_bin) / 2
+    right_zero = (fr.pct_zero_bin + rr.pct_zero_bin) / 2
+    left_friction = (fl.pct_friction + rl.pct_friction) / 2
+    right_friction = (fr.pct_friction + rr.pct_friction) / 2
+    left_slow_bump = (fl.pct_slow_bump + rl.pct_slow_bump) / 2
+    right_slow_bump = (fr.pct_slow_bump + rr.pct_slow_bump) / 2
+    left_slow_rebound = (fl.pct_slow_rebound + rl.pct_slow_rebound) / 2
+    right_slow_rebound = (fr.pct_slow_rebound + rr.pct_slow_rebound) / 2
+    left_fast_bump = (fl.pct_fast_bump + rl.pct_fast_bump) / 2
+    right_fast_bump = (fr.pct_fast_bump + rr.pct_fast_bump) / 2
+    left_fast_rebound = (fl.pct_fast_rebound + rl.pct_fast_rebound) / 2
+    right_fast_rebound = (fr.pct_fast_rebound + rr.pct_fast_rebound) / 2
+    left_curb = (fl.pct_curb + rl.pct_curb) / 2
+    right_curb = (fr.pct_curb + rr.pct_curb) / 2
+
+    # Front (FL + FR) vs Rear (RL + RR)
+    front_zero = (fl.pct_zero_bin + fr.pct_zero_bin) / 2
+    rear_zero = (rl.pct_zero_bin + rr.pct_zero_bin) / 2
+    front_friction = (fl.pct_friction + fr.pct_friction) / 2
+    rear_friction = (rl.pct_friction + rr.pct_friction) / 2
+    front_slow_bump = (fl.pct_slow_bump + fr.pct_slow_bump) / 2
+    rear_slow_bump = (rl.pct_slow_bump + rr.pct_slow_bump) / 2
+    front_slow_rebound = (fl.pct_slow_rebound + fr.pct_slow_rebound) / 2
+    rear_slow_rebound = (rl.pct_slow_rebound + rr.pct_slow_rebound) / 2
+    front_fast_bump = (fl.pct_fast_bump + fr.pct_fast_bump) / 2
+    rear_fast_bump = (rl.pct_fast_bump + rr.pct_fast_bump) / 2
+    front_fast_rebound = (fl.pct_fast_rebound + fr.pct_fast_rebound) / 2
+    rear_fast_rebound = (rl.pct_fast_rebound + rr.pct_fast_rebound) / 2
+    front_curb = (fl.pct_curb + fr.pct_curb) / 2
+    rear_curb = (rl.pct_curb + rr.pct_curb) / 2
+
+    data = [
+        {
+            "Comparison": "Left vs Right",
+            "Zero Bin Diff": left_zero - right_zero,
+            "Friction Diff": left_friction - right_friction,
+            "Slow Bump Diff": left_slow_bump - right_slow_bump,
+            "Slow Rebound Diff": left_slow_rebound - right_slow_rebound,
+            "Fast Bump Diff": left_fast_bump - right_fast_bump,
+            "Fast Rebound Diff": left_fast_rebound - right_fast_rebound,
+            "Curb Diff": left_curb - right_curb,
+        },
+        {
+            "Comparison": "Front vs Rear",
+            "Zero Bin Diff": front_zero - rear_zero,
+            "Friction Diff": front_friction - rear_friction,
+            "Slow Bump Diff": front_slow_bump - rear_slow_bump,
+            "Slow Rebound Diff": front_slow_rebound - rear_slow_rebound,
+            "Fast Bump Diff": front_fast_bump - rear_fast_bump,
+            "Fast Rebound Diff": front_fast_rebound - rear_fast_rebound,
+            "Curb Diff": front_curb - rear_curb,
+        },
+    ]
+
+    return pd.DataFrame(data)

--- a/src/motorsports_data_notebook/visualization.py
+++ b/src/motorsports_data_notebook/visualization.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from libxrk.base import LogFile
 
     from .corners import Corner
+    from .suspension import VelocityHistogramResult
     from .zones import TrackSegment
 
 
@@ -31,6 +32,7 @@ __all__ = [
     "plot_corner_inputs",
     "plot_gps_channels",
     "plot_lap_gps",
+    "plot_suspension_velocity_histogram",
     "plot_tire_thermography",
     "plot_track_segments",
     "show_fig",
@@ -1067,5 +1069,254 @@ def plot_track_segments(
         width=width,
         height=height,
     )
+
+    return fig
+
+
+def plot_suspension_velocity_histogram(
+    result: "VelocityHistogramResult",
+    title: str = "Suspension Velocity Distribution",
+    width: int = 1000,
+    height: int = 800,
+) -> go.Figure:
+    """Create 4-quadrant suspension velocity histogram with velocity range shading.
+
+    Creates a 2x2 subplot grid showing velocity histograms for all four corners
+    (FL, FR, RL, RR) with background shading indicating velocity ranges:
+    - Gray: Friction range (< 5mm/s)
+    - Light blue: Slow range (5-25mm/s)
+    - Light green: Fast range (25-200mm/s)
+    - Light coral: Curb range (> 200mm/s)
+
+    Parameters
+    ----------
+    result : VelocityHistogramResult
+        Analysis results from analyze_suspension_velocity().
+    title : str, default="Suspension Velocity Distribution"
+        Plot title.
+    width : int, default=1000
+        Figure width in pixels.
+    height : int, default=800
+        Figure height in pixels.
+
+    Returns
+    -------
+    go.Figure
+        Plotly figure with 4 velocity histogram subplots.
+
+    Examples
+    --------
+    >>> from motorsports_data_notebook.suspension import analyze_suspension_velocity
+    >>> result = analyze_suspension_velocity(log, lap_start, lap_end)
+    >>> fig = plot_suspension_velocity_histogram(result)
+    >>> show_fig(fig)
+    """
+    # Get velocity ranges for shading
+    ranges = result.velocity_ranges
+
+    # Create 2x2 subplot grid
+    fig = make_subplots(
+        rows=2,
+        cols=2,
+        shared_xaxes=True,
+        shared_yaxes=True,
+        vertical_spacing=0.1,
+        horizontal_spacing=0.08,
+        subplot_titles=("Front Left (FL)", "Front Right (FR)", "Rear Left (RL)", "Rear Right (RR)"),
+    )
+
+    # Define corner data and positions
+    corners = [
+        (result.front_left, 1, 1),
+        (result.front_right, 1, 2),
+        (result.rear_left, 2, 1),
+        (result.rear_right, 2, 2),
+    ]
+
+    # Get max y value across all histograms for consistent scaling
+    max_y = max(
+        corner_data.histogram.max()
+        for corner_data, _, _ in corners
+        if len(corner_data.histogram) > 0
+    )
+
+    # Add velocity range shading to each subplot
+    for corner_data, row, col in corners:
+        # Add background shading for velocity ranges
+        # Determine axis references for this subplot
+        subplot_idx = (row - 1) * 2 + col
+        xref = "x" if subplot_idx == 1 else f"x{subplot_idx}"
+        yref = "y" if subplot_idx == 1 else f"y{subplot_idx}"
+
+        # Friction range (gray) - center
+        fig.add_shape(
+            type="rect",
+            x0=-ranges.friction,
+            x1=ranges.friction,
+            y0=0,
+            y1=1,
+            xref=xref,
+            yref=f"{yref} domain",
+            fillcolor="gray",
+            opacity=0.15,
+            line_width=0,
+            layer="below",
+        )
+
+        # Slow range (light blue) - positive
+        fig.add_shape(
+            type="rect",
+            x0=ranges.friction,
+            x1=ranges.slow,
+            y0=0,
+            y1=1,
+            xref=xref,
+            yref=f"{yref} domain",
+            fillcolor="lightblue",
+            opacity=0.2,
+            line_width=0,
+            layer="below",
+        )
+
+        # Slow range (light blue) - negative
+        fig.add_shape(
+            type="rect",
+            x0=-ranges.slow,
+            x1=-ranges.friction,
+            y0=0,
+            y1=1,
+            xref=xref,
+            yref=f"{yref} domain",
+            fillcolor="lightblue",
+            opacity=0.2,
+            line_width=0,
+            layer="below",
+        )
+
+        # Fast range (light green) - positive
+        fig.add_shape(
+            type="rect",
+            x0=ranges.slow,
+            x1=ranges.fast,
+            y0=0,
+            y1=1,
+            xref=xref,
+            yref=f"{yref} domain",
+            fillcolor="lightgreen",
+            opacity=0.2,
+            line_width=0,
+            layer="below",
+        )
+
+        # Fast range (light green) - negative
+        fig.add_shape(
+            type="rect",
+            x0=-ranges.fast,
+            x1=-ranges.slow,
+            y0=0,
+            y1=1,
+            xref=xref,
+            yref=f"{yref} domain",
+            fillcolor="lightgreen",
+            opacity=0.2,
+            line_width=0,
+            layer="below",
+        )
+
+        # Curb range (light coral) - positive
+        fig.add_shape(
+            type="rect",
+            x0=ranges.fast,
+            x1=300,
+            y0=0,
+            y1=1,
+            xref=xref,
+            yref=f"{yref} domain",
+            fillcolor="lightcoral",
+            opacity=0.2,
+            line_width=0,
+            layer="below",
+        )
+
+        # Curb range (light coral) - negative
+        fig.add_shape(
+            type="rect",
+            x0=-300,
+            x1=-ranges.fast,
+            y0=0,
+            y1=1,
+            xref=xref,
+            yref=f"{yref} domain",
+            fillcolor="lightcoral",
+            opacity=0.2,
+            line_width=0,
+            layer="below",
+        )
+
+        # Add histogram bars
+        # Color bars: positive (bump) = blue, negative (rebound) = red
+        bar_colors = [
+            "steelblue" if center >= 0 else "indianred" for center in corner_data.bin_centers
+        ]
+
+        fig.add_trace(
+            go.Bar(
+                x=corner_data.bin_centers,
+                y=corner_data.histogram,
+                marker_color=bar_colors,
+                name=corner_data.corner_name,
+                showlegend=False,
+                hovertemplate=("Velocity: %{x:.0f} mm/s<br>" "Time: %{y:.1f}%<extra></extra>"),
+            ),
+            row=row,
+            col=col,
+        )
+
+        # Add zero reference line
+        fig.add_vline(
+            x=0,
+            line_dash="dash",
+            line_color="black",
+            line_width=1,
+            opacity=0.5,
+            row=row,
+            col=col,
+        )
+
+        # Add statistics annotation
+        stats_text = f"Skew: {corner_data.skew:.2f}<br>" f"Std: {corner_data.std:.0f} mm/s"
+        # Add annotation at top right of subplot
+        fig.add_annotation(
+            x=0.95,
+            y=0.95,
+            xref=f"x{row * 2 - 2 + col} domain" if row > 1 or col > 1 else "x domain",
+            yref=f"y{row * 2 - 2 + col} domain" if row > 1 or col > 1 else "y domain",
+            text=stats_text,
+            showarrow=False,
+            font=dict(size=10),
+            align="right",
+            bgcolor="rgba(255,255,255,0.7)",
+            row=row,
+            col=col,
+        )
+
+    # Update layout
+    fig.update_layout(
+        title=title,
+        width=width,
+        height=height,
+        bargap=0.05,
+    )
+
+    # Update x-axes labels (only bottom row)
+    fig.update_xaxes(title_text="Velocity (mm/s)", row=2, col=1)
+    fig.update_xaxes(title_text="Velocity (mm/s)", row=2, col=2)
+
+    # Update y-axes labels (only left column)
+    fig.update_yaxes(title_text="Time (%)", row=1, col=1)
+    fig.update_yaxes(title_text="Time (%)", row=2, col=1)
+
+    # Set consistent y-axis range
+    fig.update_yaxes(range=[0, max_y * 1.1])
 
     return fig

--- a/tests/test_suspension.py
+++ b/tests/test_suspension.py
@@ -1,0 +1,619 @@
+"""Tests for suspension module."""
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+from dataclasses import dataclass
+from typing import Dict
+
+from motorsports_data_notebook.suspension import (
+    MotionRatios,
+    VelocityRanges,
+    CornerVelocityData,
+    VelocityHistogramResult,
+    SUSPENSION_CHANNEL_NAMES,
+    compute_shock_velocity,
+    compute_wheel_velocity,
+    compute_velocity_histogram,
+    compute_velocity_stats,
+    analyze_suspension_velocity,
+    format_suspension_stats_table,
+    format_symmetry_table,
+    format_comparison_table,
+)
+
+
+@dataclass
+class MockLogFile:
+    """Mock LogFile for testing."""
+
+    channels: Dict[str, pa.Table]
+    laps: pa.Table = None
+    metadata: Dict[str, str] = None
+    file_name: str = "test.xrk"
+
+    def __post_init__(self):
+        if self.laps is None:
+            self.laps = pa.table({"num": [], "start_time": [], "end_time": []})
+        if self.metadata is None:
+            self.metadata = {}
+
+
+class TestMotionRatios:
+    """Tests for MotionRatios dataclass."""
+
+    def test_default_values(self):
+        """Default values should be Toyota 86 ZN6 ratios."""
+        ratios = MotionRatios()
+        assert ratios.front_left == pytest.approx(0.997)
+        assert ratios.front_right == pytest.approx(0.997)
+        assert ratios.rear_left == pytest.approx(0.768)
+        assert ratios.rear_right == pytest.approx(0.768)
+
+    def test_toyota_86_zn6_classmethod(self):
+        """toyota_86_zn6() should return correct ratios."""
+        ratios = MotionRatios.toyota_86_zn6()
+        assert ratios.front_left == pytest.approx(0.997)
+        assert ratios.rear_left == pytest.approx(0.768)
+
+    def test_custom_values(self):
+        """Should accept custom motion ratios."""
+        ratios = MotionRatios(
+            front_left=0.9,
+            front_right=0.9,
+            rear_left=0.8,
+            rear_right=0.8,
+        )
+        assert ratios.front_left == pytest.approx(0.9)
+        assert ratios.rear_left == pytest.approx(0.8)
+
+
+class TestVelocityRanges:
+    """Tests for VelocityRanges dataclass."""
+
+    def test_default_values(self):
+        """Default velocity thresholds."""
+        ranges = VelocityRanges()
+        assert ranges.friction == pytest.approx(5.0)
+        assert ranges.slow == pytest.approx(25.0)
+        assert ranges.fast == pytest.approx(200.0)
+
+
+class TestComputeShockVelocity:
+    """Tests for compute_shock_velocity function."""
+
+    def test_constant_displacement_zero_velocity(self):
+        """Constant displacement should give zero velocity."""
+        displacement = np.array([10.0, 10.0, 10.0, 10.0, 10.0])
+        timecodes = np.array([0, 100, 200, 300, 400], dtype=np.int64)
+
+        velocity = compute_shock_velocity(displacement, timecodes, smoothing_window=1)
+
+        np.testing.assert_array_almost_equal(velocity, [0.0, 0.0, 0.0, 0.0, 0.0])
+
+    def test_linear_displacement_constant_velocity(self):
+        """Linear displacement should give constant velocity."""
+        # 10mm per 100ms = 100mm/s
+        displacement = np.array([0.0, 10.0, 20.0, 30.0, 40.0])
+        timecodes = np.array([0, 100, 200, 300, 400], dtype=np.int64)
+
+        velocity = compute_shock_velocity(displacement, timecodes, smoothing_window=1)
+
+        # All velocities should be 100 mm/s
+        np.testing.assert_array_almost_equal(velocity, [100.0, 100.0, 100.0, 100.0, 100.0])
+
+    def test_positive_velocity_for_bump(self):
+        """Increasing displacement (bump) should give positive velocity."""
+        displacement = np.array([0.0, 5.0, 10.0])
+        timecodes = np.array([0, 100, 200], dtype=np.int64)
+
+        velocity = compute_shock_velocity(displacement, timecodes, smoothing_window=1)
+
+        assert all(v > 0 for v in velocity)
+
+    def test_negative_velocity_for_rebound(self):
+        """Decreasing displacement (rebound) should give negative velocity."""
+        displacement = np.array([10.0, 5.0, 0.0])
+        timecodes = np.array([0, 100, 200], dtype=np.int64)
+
+        velocity = compute_shock_velocity(displacement, timecodes, smoothing_window=1)
+
+        assert all(v < 0 for v in velocity)
+
+    def test_smoothing_reduces_noise(self):
+        """Smoothing should reduce velocity variations."""
+        # Create noisy displacement
+        displacement = np.array([0.0, 10.0, 5.0, 15.0, 10.0, 20.0])
+        timecodes = np.array([0, 100, 200, 300, 400, 500], dtype=np.int64)
+
+        velocity_raw = compute_shock_velocity(displacement, timecodes, smoothing_window=1)
+        velocity_smooth = compute_shock_velocity(displacement, timecodes, smoothing_window=3)
+
+        # Smoothed velocity should have lower standard deviation
+        assert np.std(velocity_smooth) < np.std(velocity_raw)
+
+    def test_handles_varying_sample_rate(self):
+        """Should handle non-uniform time intervals."""
+        displacement = np.array([0.0, 10.0, 30.0])
+        # First interval: 100ms, second interval: 200ms
+        timecodes = np.array([0, 100, 300], dtype=np.int64)
+
+        velocity = compute_shock_velocity(displacement, timecodes, smoothing_window=1)
+
+        # First point: 10mm/0.1s = 100mm/s
+        # Third point: 20mm/0.2s = 100mm/s
+        # Middle point is gradient interpolation
+        assert velocity[0] == pytest.approx(100.0, rel=0.1)
+        assert velocity[2] == pytest.approx(100.0, rel=0.1)
+
+
+class TestComputeWheelVelocity:
+    """Tests for compute_wheel_velocity function."""
+
+    def test_motion_ratio_scaling(self):
+        """Wheel velocity should scale by inverse of motion ratio."""
+        shock_velocity = np.array([10.0, 20.0, 30.0])
+        motion_ratio = 0.5
+
+        wheel_velocity = compute_wheel_velocity(shock_velocity, motion_ratio)
+
+        # wheel_vel = shock_vel / motion_ratio
+        np.testing.assert_array_almost_equal(wheel_velocity, [20.0, 40.0, 60.0])
+
+    def test_unity_motion_ratio(self):
+        """Motion ratio of 1.0 should give same velocity."""
+        shock_velocity = np.array([10.0, 20.0, 30.0])
+
+        wheel_velocity = compute_wheel_velocity(shock_velocity, motion_ratio=1.0)
+
+        np.testing.assert_array_almost_equal(wheel_velocity, shock_velocity)
+
+    def test_toyota_86_front_ratio(self):
+        """Test with Toyota 86 front motion ratio."""
+        shock_velocity = np.array([100.0])
+        motion_ratio = 0.997
+
+        wheel_velocity = compute_wheel_velocity(shock_velocity, motion_ratio)
+
+        # 100 / 0.997 ≈ 100.3
+        assert wheel_velocity[0] == pytest.approx(100.3, rel=0.01)
+
+    def test_toyota_86_rear_ratio(self):
+        """Test with Toyota 86 rear motion ratio."""
+        shock_velocity = np.array([100.0])
+        motion_ratio = 0.768
+
+        wheel_velocity = compute_wheel_velocity(shock_velocity, motion_ratio)
+
+        # 100 / 0.768 ≈ 130.2
+        assert wheel_velocity[0] == pytest.approx(130.2, rel=0.01)
+
+
+class TestComputeVelocityHistogram:
+    """Tests for compute_velocity_histogram function."""
+
+    def test_percentages_sum_to_100(self):
+        """Histogram percentages should sum to 100%."""
+        velocity = np.random.normal(0, 50, 1000)
+
+        histogram, _, _ = compute_velocity_histogram(velocity)
+
+        assert histogram.sum() == pytest.approx(100.0, rel=0.001)
+
+    def test_zero_centered_bins(self):
+        """Bins should be centered on zero."""
+        velocity = np.array([0.0])
+
+        _, bin_edges, bin_centers = compute_velocity_histogram(velocity, bin_size=10.0)
+
+        # Check that 0 is at a bin center
+        assert any(np.isclose(bin_centers, 0.0, atol=1e-10))
+        # Check bin edges are symmetric
+        assert bin_edges[0] == pytest.approx(-bin_edges[-1])
+
+    def test_symmetric_distribution_symmetric_histogram(self):
+        """Symmetric velocity distribution should give symmetric histogram."""
+        # Create perfectly symmetric distribution
+        np.random.seed(42)
+        positive_vel = np.abs(np.random.normal(50, 20, 500))
+        velocity = np.concatenate([positive_vel, -positive_vel])
+
+        histogram, _, bin_centers = compute_velocity_histogram(velocity, bin_size=10.0)
+
+        # Find matching positive and negative bins
+        n_bins = len(histogram)
+        for i in range(n_bins // 2):
+            left_idx = i
+            right_idx = n_bins - 1 - i
+            assert histogram[left_idx] == pytest.approx(histogram[right_idx], rel=0.1)
+
+    def test_all_positive_velocity(self):
+        """All positive velocity should have zeros on negative side."""
+        velocity = np.array([50.0, 60.0, 70.0, 80.0])
+
+        histogram, _, bin_centers = compute_velocity_histogram(velocity)
+
+        # Negative velocity bins should be zero
+        negative_mask = bin_centers < 0
+        assert all(histogram[negative_mask] == 0)
+
+    def test_max_velocity_clipping(self):
+        """Velocities beyond max should be clipped to edge bins."""
+        velocity = np.array([500.0, -500.0])  # Beyond default max of 300
+
+        histogram, bin_edges, _ = compute_velocity_histogram(velocity, max_velocity=300.0)
+
+        # Should still sum to 100%
+        assert histogram.sum() == pytest.approx(100.0)
+        # Edge bins should have the clipped values
+        assert histogram[0] > 0  # -500 clipped to -300
+        assert histogram[-1] > 0  # 500 clipped to 300
+
+
+class TestComputeVelocityStats:
+    """Tests for compute_velocity_stats function."""
+
+    def test_symmetric_distribution_zero_skew(self):
+        """Symmetric distribution should have near-zero skew."""
+        np.random.seed(42)
+        positive_vel = np.abs(np.random.normal(50, 20, 1000))
+        velocity = np.concatenate([positive_vel, -positive_vel])
+
+        stats = compute_velocity_stats(velocity, VelocityRanges())
+
+        assert stats["skew"] == pytest.approx(0.0, abs=0.1)
+
+    def test_right_tailed_distribution_positive_skew(self):
+        """Right-tailed distribution should have positive skew."""
+        # Distribution with tail toward positive (high bump velocities)
+        np.random.seed(42)
+        # Use an exponential-like distribution shifted to be asymmetric
+        velocity = np.concatenate([
+            np.random.exponential(50, 500),  # Right-tailed positive
+            np.random.normal(-10, 5, 500),  # Concentrated negative
+        ])
+
+        stats = compute_velocity_stats(velocity, VelocityRanges())
+
+        assert stats["skew"] > 0
+
+    def test_left_tailed_distribution_negative_skew(self):
+        """Left-tailed distribution should have negative skew."""
+        # Distribution with tail toward negative (high rebound velocities)
+        np.random.seed(42)
+        velocity = np.concatenate([
+            -np.random.exponential(50, 500),  # Left-tailed negative
+            np.random.normal(10, 5, 500),  # Concentrated positive
+        ])
+
+        stats = compute_velocity_stats(velocity, VelocityRanges())
+
+        assert stats["skew"] < 0
+
+    def test_friction_range_percentage(self):
+        """Friction range should count |v| < friction threshold."""
+        ranges = VelocityRanges(friction=5.0)
+        velocity = np.array([0.0, 2.0, -2.0, 4.0, -4.0, 10.0, -10.0])
+        # 5 out of 7 values are in friction range
+
+        stats = compute_velocity_stats(velocity, ranges)
+
+        expected_pct = 5 / 7 * 100
+        assert stats["pct_friction"] == pytest.approx(expected_pct, rel=0.01)
+
+    def test_slow_range_percentages(self):
+        """Slow range should count friction <= |v| < slow threshold."""
+        ranges = VelocityRanges(friction=5.0, slow=25.0)
+        # All in slow range (bump)
+        velocity = np.array([10.0, 15.0, 20.0])
+
+        stats = compute_velocity_stats(velocity, ranges)
+
+        assert stats["pct_slow_bump"] == pytest.approx(100.0)
+        assert stats["pct_slow_rebound"] == pytest.approx(0.0)
+
+    def test_fast_range_percentages(self):
+        """Fast range should count slow <= |v| < fast threshold."""
+        ranges = VelocityRanges(slow=25.0, fast=200.0)
+        # All in fast range (rebound)
+        velocity = np.array([-50.0, -100.0, -150.0])
+
+        stats = compute_velocity_stats(velocity, ranges)
+
+        assert stats["pct_fast_bump"] == pytest.approx(0.0)
+        assert stats["pct_fast_rebound"] == pytest.approx(100.0)
+
+    def test_curb_range_percentage(self):
+        """Curb range should count |v| >= fast threshold."""
+        ranges = VelocityRanges(fast=200.0)
+        velocity = np.array([250.0, -250.0, 300.0])  # All in curb range
+
+        stats = compute_velocity_stats(velocity, ranges)
+
+        assert stats["pct_curb"] == pytest.approx(100.0)
+
+    def test_empty_array_returns_zeros(self):
+        """Empty velocity array should return zero stats."""
+        velocity = np.array([])
+
+        stats = compute_velocity_stats(velocity, VelocityRanges())
+
+        assert stats["skew"] == 0.0
+        assert stats["kurtosis"] == 0.0
+        assert stats["mean"] == 0.0
+        assert stats["std"] == 0.0
+        assert stats["pct_friction"] == 0.0
+
+    def test_percentages_sum_to_100(self):
+        """All percentage categories should sum to 100%."""
+        np.random.seed(42)
+        velocity = np.random.normal(0, 100, 1000)
+
+        stats = compute_velocity_stats(velocity, VelocityRanges())
+
+        total_pct = (
+            stats["pct_friction"]
+            + stats["pct_slow_bump"]
+            + stats["pct_slow_rebound"]
+            + stats["pct_fast_bump"]
+            + stats["pct_fast_rebound"]
+            + stats["pct_curb"]
+        )
+        assert total_pct == pytest.approx(100.0, rel=0.01)
+
+
+class TestAnalyzeSuspensionVelocity:
+    """Tests for analyze_suspension_velocity function."""
+
+    def _create_mock_log(self, timecodes, displacement):
+        """Create a mock log file with shock pot channels."""
+        channels = {}
+        for shock_name in SUSPENSION_CHANNEL_NAMES.values():
+            channels[shock_name] = pa.table(
+                {
+                    "timecodes": pa.array(timecodes, type=pa.int64()),
+                    shock_name: pa.array(displacement),
+                }
+            )
+        return MockLogFile(channels=channels)
+
+    def test_returns_velocity_histogram_result(self):
+        """Should return VelocityHistogramResult with all corners."""
+        timecodes = np.arange(0, 1000, 10, dtype=np.int64)
+        displacement = np.cumsum(np.random.randn(len(timecodes))) + 50
+        log = self._create_mock_log(timecodes, displacement)
+
+        result = analyze_suspension_velocity(log, lap_start=0, lap_end=999)
+
+        assert isinstance(result, VelocityHistogramResult)
+        assert result.front_left is not None
+        assert result.front_right is not None
+        assert result.rear_left is not None
+        assert result.rear_right is not None
+
+    def test_uses_default_channel_names(self):
+        """Should use SUSPENSION_CHANNEL_NAMES if not provided."""
+        timecodes = np.arange(0, 500, 10, dtype=np.int64)
+        displacement = np.cumsum(np.random.randn(len(timecodes)))
+        log = self._create_mock_log(timecodes, displacement)
+
+        # Should not raise KeyError with default channel names
+        result = analyze_suspension_velocity(log, lap_start=0, lap_end=499)
+
+        assert result is not None
+
+    def test_custom_channel_names(self):
+        """Should accept custom channel names."""
+        timecodes = np.arange(0, 500, 10, dtype=np.int64)
+        displacement = np.ones(len(timecodes)) * 50
+
+        custom_names = {
+            "shock_fl": "Custom_FL",
+            "shock_fr": "Custom_FR",
+            "shock_rl": "Custom_RL",
+            "shock_rr": "Custom_RR",
+        }
+        channels = {
+            name: pa.table({
+                "timecodes": pa.array(timecodes, type=pa.int64()),
+                name: pa.array(displacement),
+            })
+            for name in custom_names.values()
+        }
+        log = MockLogFile(channels=channels)
+
+        result = analyze_suspension_velocity(
+            log, lap_start=0, lap_end=499, channel_names=custom_names
+        )
+
+        assert result is not None
+
+    def test_missing_channel_raises_key_error(self):
+        """Should raise KeyError if required channel is missing."""
+        log = MockLogFile(channels={})
+
+        with pytest.raises(KeyError):
+            analyze_suspension_velocity(log, lap_start=0, lap_end=100)
+
+    def test_custom_motion_ratios(self):
+        """Should use custom motion ratios when provided."""
+        timecodes = np.arange(0, 500, 10, dtype=np.int64)
+        # Linear displacement for predictable velocity
+        displacement = np.arange(len(timecodes), dtype=float)
+        log = self._create_mock_log(timecodes, displacement)
+
+        custom_ratios = MotionRatios(
+            front_left=0.5,
+            front_right=0.5,
+            rear_left=0.5,
+            rear_right=0.5,
+        )
+
+        result = analyze_suspension_velocity(
+            log, lap_start=0, lap_end=499, motion_ratios=custom_ratios
+        )
+
+        # Wheel velocity should be shock_velocity / motion_ratio
+        # With motion_ratio=0.5, wheel velocity should be doubled
+        assert result is not None
+
+
+class TestFormatSuspensionStatsTable:
+    """Tests for format_suspension_stats_table function."""
+
+    def test_returns_dataframe(self):
+        """Should return a pandas DataFrame."""
+        # Create a simple result
+        corner_data = CornerVelocityData(
+            corner_name="FL",
+            velocity=np.array([0.0]),
+            bin_edges=np.array([-10, 0, 10]),
+            bin_centers=np.array([-5, 5]),
+            histogram=np.array([50.0, 50.0]),
+            skew=0.0,
+            kurtosis=0.0,
+            mean=0.0,
+            std=10.0,
+            pct_friction=20.0,
+            pct_slow_bump=20.0,
+            pct_slow_rebound=20.0,
+            pct_fast_bump=15.0,
+            pct_fast_rebound=15.0,
+            pct_curb=10.0,
+            pct_zero_bin=20.0,
+        )
+
+        result = VelocityHistogramResult(
+            front_left=corner_data,
+            front_right=corner_data,
+            rear_left=corner_data,
+            rear_right=corner_data,
+        )
+
+        df = format_suspension_stats_table(result)
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 4  # Four corners
+        assert "Corner" in df.columns
+        assert "Skew" in df.columns
+        assert "Friction %" in df.columns
+        assert "Zero Bin %" in df.columns
+
+
+class TestFormatSymmetryTable:
+    """Tests for format_symmetry_table function."""
+
+    def test_returns_dataframe_with_symmetry(self):
+        """Should return DataFrame with bump/rebound symmetry."""
+        corner_data = CornerVelocityData(
+            corner_name="FL",
+            velocity=np.array([0.0]),
+            bin_edges=np.array([-10, 0, 10]),
+            bin_centers=np.array([-5, 5]),
+            histogram=np.array([50.0, 50.0]),
+            skew=0.0,
+            kurtosis=0.0,
+            mean=0.0,
+            std=10.0,
+            pct_friction=10.0,
+            pct_slow_bump=20.0,
+            pct_slow_rebound=20.0,
+            pct_fast_bump=25.0,
+            pct_fast_rebound=25.0,
+            pct_curb=0.0,
+            pct_zero_bin=10.0,
+        )
+
+        result = VelocityHistogramResult(
+            front_left=corner_data,
+            front_right=corner_data,
+            rear_left=corner_data,
+            rear_right=corner_data,
+        )
+
+        df = format_symmetry_table(result)
+
+        assert isinstance(df, pd.DataFrame)
+        assert "Total Bump %" in df.columns
+        assert "Total Rebound %" in df.columns
+        assert "Bump/Total %" in df.columns
+
+
+class TestFormatComparisonTable:
+    """Tests for format_comparison_table function."""
+
+    def test_returns_comparison_dataframe(self):
+        """Should return DataFrame with left/right and front/rear comparisons."""
+        corner_data = CornerVelocityData(
+            corner_name="FL",
+            velocity=np.array([0.0]),
+            bin_edges=np.array([-10, 0, 10]),
+            bin_centers=np.array([-5, 5]),
+            histogram=np.array([50.0, 50.0]),
+            skew=0.1,
+            kurtosis=0.0,
+            mean=0.0,
+            std=10.0,
+            pct_friction=20.0,
+            pct_slow_bump=20.0,
+            pct_slow_rebound=20.0,
+            pct_fast_bump=20.0,
+            pct_fast_rebound=20.0,
+            pct_curb=0.0,
+            pct_zero_bin=20.0,
+        )
+
+        result = VelocityHistogramResult(
+            front_left=corner_data,
+            front_right=corner_data,
+            rear_left=corner_data,
+            rear_right=corner_data,
+        )
+
+        df = format_comparison_table(result)
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 2  # Two comparisons: Left vs Right, Front vs Rear
+        assert "Comparison" in df.columns
+        assert "Zero Bin Diff" in df.columns
+        assert "Friction Diff" in df.columns
+        assert "Slow Bump Diff" in df.columns
+        assert "Fast Bump Diff" in df.columns
+        assert "Curb Diff" in df.columns
+
+    def test_comparison_differences_are_zero_when_identical(self):
+        """When all corners are identical, differences should be zero."""
+        corner_data = CornerVelocityData(
+            corner_name="FL",
+            velocity=np.array([0.0]),
+            bin_edges=np.array([-10, 0, 10]),
+            bin_centers=np.array([-5, 5]),
+            histogram=np.array([50.0, 50.0]),
+            skew=0.1,
+            kurtosis=0.0,
+            mean=0.0,
+            std=10.0,
+            pct_friction=20.0,
+            pct_slow_bump=20.0,
+            pct_slow_rebound=20.0,
+            pct_fast_bump=20.0,
+            pct_fast_rebound=20.0,
+            pct_curb=0.0,
+            pct_zero_bin=20.0,
+        )
+
+        result = VelocityHistogramResult(
+            front_left=corner_data,
+            front_right=corner_data,
+            rear_left=corner_data,
+            rear_right=corner_data,
+        )
+
+        df = format_comparison_table(result)
+
+        # All differences should be zero when corners are identical
+        for col in df.columns:
+            if col != "Comparison":
+                for val in df[col]:
+                    assert val == pytest.approx(0.0)

--- a/workspace_template/suspension_analysis.ipynb
+++ b/workspace_template/suspension_analysis.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": "# Suspension Velocity Analysis\n\nThis notebook analyzes suspension velocity distributions from shock pot displacement data. Understanding how your dampers work across different velocity ranges is crucial for proper setup.\n\n## Interpretation Guide\n\n| Pattern | Possible Cause | Potential Action |\n|---------|----------------|------------------|\n| High friction % | Damper friction, insufficient low-speed valving | Check damper seals, consider softer low-speed settings |\n| Positive skew (more bump) | Nose dive, roll stiffness imbalance | Increase compression damping, check spring rates |\n| Negative skew (more rebound) | Rear squat, extension issues | Increase rebound damping, check spring preload |\n| High curb % | Aggressive kerb use, bottoming | Add bump stops, increase spring rate |\n| Left/Right asymmetry | Weight distribution, alignment | Check corner weights, alignment, damper settings |\n| Front/Rear asymmetry | Pitch balance issues | Adjust front/rear damping or spring ratio |\n\n## What You'll Find Here\n\n- **Velocity Histograms**: Distribution of wheel velocity for each corner (FL, FR, RL, RR)\n- **Velocity Range Shading**: Visual indication of damper operating ranges\n  - **Gray (Friction)**: < 5 mm/s - Static friction zone, damper may not move\n  - **Light Blue (Slow)**: 5-25 mm/s - Low speed damping, affects body control\n  - **Light Green (Fast)**: 25-200 mm/s - High speed damping, affects bump absorption\n  - **Light Coral (Curb)**: > 200 mm/s - Curb/kerb strikes, bottoming\n- **Statistics Tables**: Skew, symmetry, and corner comparisons\n\n## Using Your Own Data\n\n1. **Run the first cell** below to install packages and display the upload widget\n2. **Click \"Choose File\"** to select your `.xrk` or `.xrz` file\n3. **Configure channel names** if your shock pot channels have different names\n4. **Run all remaining cells** to analyze your data\n\n## Requirements\n\n- Shock pot displacement channels (e.g., `LF_Shock_Pot`, `RF_Shock_Pot`, etc.)\n\n**Note:** This notebook works in both JupyterLite (browser) and standard JupyterLab environments."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f6g7h8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
+    "%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n",
+    "\n",
+    "# Import helper functions\n",
+    "from motorsports_data_notebook.channels import get_best_lap\n",
+    "from motorsports_data_notebook.suspension import (\n",
+    "    MotionRatios,\n",
+    "    VelocityRanges,\n",
+    "    SUSPENSION_CHANNEL_NAMES,\n",
+    "    analyze_suspension_velocity,\n",
+    "    format_suspension_stats_table,\n",
+    "    format_symmetry_table,\n",
+    "    format_comparison_table,\n",
+    ")\n",
+    "from motorsports_data_notebook.visualization import (\n",
+    "    format_lap_time,\n",
+    "    plot_suspension_velocity_histogram,\n",
+    "    show_fig,\n",
+    ")\n",
+    "from motorsports_data_notebook.widgets import FileUpload, load_session\n",
+    "\n",
+    "# File picker - upload your own .xrk/.xrz file or use the sample data\n",
+    "file_upload = FileUpload(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\n",
+    "file_upload.display()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "i9j0k1l2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the data file with derived columns (speed_kmh, distance_m, lap_time)\n",
+    "log = load_session(file_upload.get_file_data())\n",
+    "\n",
+    "# Get laps as pandas DataFrame for display\n",
+    "laps = log.laps.to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "m3n4o5p6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display lap times table\n",
+    "laps.style.format({\"lap_time\": format_lap_time})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "q7r8s9t0",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "Configure your shock pot channel names and motion ratios below. The defaults are set for a Toyota 86 ZN6 with standard AIM channel naming."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "u1v2w3x4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Shock pot channel names - modify to match your data logger setup\n",
+    "channel_names = {\n",
+    "    \"shock_fl\": \"LF_Shock_Pot\",\n",
+    "    \"shock_fr\": \"RF_Shock_Pot\",\n",
+    "    \"shock_rl\": \"LR_Shock_Pot\",\n",
+    "    \"shock_rr\": \"RR_Shock_Pot\",\n",
+    "}\n",
+    "\n",
+    "# Motion ratios: wheel_velocity = shock_velocity / motion_ratio\n",
+    "# Default: Toyota 86 ZN6 (front MacPherson: 0.997, rear multi-link: 0.768)\n",
+    "motion_ratios = MotionRatios(\n",
+    "    front_left=0.997,\n",
+    "    front_right=0.997,\n",
+    "    rear_left=0.768,\n",
+    "    rear_right=0.768,\n",
+    ")\n",
+    "\n",
+    "# Velocity range thresholds (mm/s) - defines the shading regions\n",
+    "velocity_ranges = VelocityRanges(\n",
+    "    friction=5.0,  # Below: static friction zone\n",
+    "    slow=25.0,  # Below: low speed damping\n",
+    "    fast=200.0,  # Above: curb/high speed\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "g3h4i5j6",
+   "metadata": {},
+   "source": [
+    "## Analyze Best Lap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "k7l8m9n0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the best lap\n",
+    "best_lap = get_best_lap(laps)\n",
+    "print(f\"Analyzing lap {int(best_lap['num'])} - {format_lap_time(best_lap['lap_time'])}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "o1p2q3r4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Analyze suspension velocity\n",
+    "result = analyze_suspension_velocity(\n",
+    "    log,\n",
+    "    lap_start=int(best_lap[\"start_time\"]),\n",
+    "    lap_end=int(best_lap[\"end_time\"]),\n",
+    "    channel_names=channel_names,\n",
+    "    motion_ratios=motion_ratios,\n",
+    "    velocity_ranges=velocity_ranges,\n",
+    "    smoothing_window=5,  # Rolling average to reduce noise\n",
+    "    bin_size=10.0,  # Histogram bin size in mm/s\n",
+    ")\n",
+    "\n",
+    "print(\"Analysis complete!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s5t6u7v8",
+   "metadata": {},
+   "source": [
+    "## Velocity Histogram Visualization\n",
+    "\n",
+    "This 4-quadrant plot shows the velocity distribution for each corner:\n",
+    "- **Blue bars**: Bump (compression) - positive velocity\n",
+    "- **Red bars**: Rebound (extension) - negative velocity\n",
+    "- **Background shading**: Velocity range zones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "w9x0y1z2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot velocity histograms\n",
+    "fig = plot_suspension_velocity_histogram(\n",
+    "    result,\n",
+    "    title=f\"Suspension Velocity Distribution - Lap {int(best_lap['num'])} ({format_lap_time(best_lap['lap_time'])})\",\n",
+    ")\n",
+    "show_fig(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "source": [
+    "## Statistics Tables\n",
+    "\n",
+    "### Per-Corner Statistics\n",
+    "\n",
+    "Key metrics for each corner:\n",
+    "- **Skew**: Distribution asymmetry (0 = symmetric, + = more bump, - = more rebound)\n",
+    "- **Kurtosis**: Distribution \"tailedness\" (0 = normal, + = heavy tails)\n",
+    "- **Mean/Std**: Average velocity and spread\n",
+    "- **Range %**: Percentage of time spent in each velocity range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7f8g9h0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Per-corner statistics\n",
+    "stats_df = format_suspension_stats_table(result)\n",
+    "stats_df.style.format(\n",
+    "    {\n",
+    "        \"Skew\": \"{:.2f}\",\n",
+    "        \"Kurtosis\": \"{:.2f}\",\n",
+    "        \"Mean (mm/s)\": \"{:.1f}\",\n",
+    "        \"Std (mm/s)\": \"{:.1f}\",\n",
+    "        \"Zero Bin %\": \"{:.1f}\",\n",
+    "        \"Friction %\": \"{:.1f}\",\n",
+    "        \"Slow Bump %\": \"{:.1f}\",\n",
+    "        \"Slow Rebound %\": \"{:.1f}\",\n",
+    "        \"Fast Bump %\": \"{:.1f}\",\n",
+    "        \"Fast Rebound %\": \"{:.1f}\",\n",
+    "        \"Curb %\": \"{:.1f}\",\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i1j2k3l4",
+   "metadata": {},
+   "source": [
+    "### Bump vs Rebound Symmetry\n",
+    "\n",
+    "Compare bump (compression) vs rebound (extension) for each corner:\n",
+    "- **Bump/Total %**: Percentage of non-friction time spent in bump (50% = symmetric)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "m5n6o7p8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Bump vs rebound symmetry\n",
+    "symmetry_df = format_symmetry_table(result)\n",
+    "symmetry_df.style.format(\n",
+    "    {\n",
+    "        \"Total Bump %\": \"{:.1f}\",\n",
+    "        \"Total Rebound %\": \"{:.1f}\",\n",
+    "        \"Bump/Total %\": \"{:.1f}\",\n",
+    "        \"Slow Bump %\": \"{:.1f}\",\n",
+    "        \"Slow Rebound %\": \"{:.1f}\",\n",
+    "        \"Fast Bump %\": \"{:.1f}\",\n",
+    "        \"Fast Rebound %\": \"{:.1f}\",\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "q9r0s1t2",
+   "metadata": {},
+   "source": "### Left vs Right and Front vs Rear Comparison\n\nCompare combined wheel groups to identify balance issues:\n- **Left vs Right**: Combines (FL + RL) vs (FR + RR) - shows lateral balance\n- **Front vs Rear**: Combines (FL + FR) vs (RL + RR) - shows longitudinal balance\n\nPositive values mean more time in that range for Left/Front, negative for Right/Rear."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "u3v4w5x6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Left/Right and Front/Rear comparison\n",
+    "comparison_df = format_comparison_table(result)\n",
+    "comparison_df.style.format(\n",
+    "    {\n",
+    "        \"Zero Bin Diff\": \"{:+.1f}\",\n",
+    "        \"Friction Diff\": \"{:+.1f}\",\n",
+    "        \"Slow Bump Diff\": \"{:+.1f}\",\n",
+    "        \"Slow Rebound Diff\": \"{:+.1f}\",\n",
+    "        \"Fast Bump Diff\": \"{:+.1f}\",\n",
+    "        \"Fast Rebound Diff\": \"{:+.1f}\",\n",
+    "        \"Curb Diff\": \"{:+.1f}\",\n",
+    "    }\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- Add new `suspension.py` module for analyzing wheel velocity from shock pot displacement data
- Add `plot_suspension_velocity_histogram()` visualization with 4-quadrant histogram and velocity range shading
- Add `suspension_analysis.ipynb` notebook for user-facing analysis
- 37 unit tests with 98% coverage

## Features

**Core Analysis:**
- Compute shock velocity from displacement using `np.gradient()` with smoothing
- Convert to wheel velocity using configurable motion ratios (defaults for Toyota 86 ZN6)
- Zero-centered histogram bins showing % of time at each velocity
- Statistics: skew, kurtosis, mean, std, and % time in each velocity range

**Velocity Ranges (configurable):**
- Friction: < 5 mm/s (gray shading)
- Slow: 5-25 mm/s (light blue)
- Fast: 25-200 mm/s (light green)
- Curb: > 200 mm/s (light coral)

**Statistics Tables:**
- Per-corner stats with zero bin %, friction %, bump/rebound percentages
- Bump vs rebound symmetry comparison
- Left vs Right and Front vs Rear combined group comparison

## Test plan

- [x] `poetry run poe check` passes (lint, typecheck, 166 tests)
- [ ] Run notebook with sample data and verify histograms display correctly
- [ ] Verify velocity range shading appears behind histogram bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)