### PR TITLE
Add LapPicker and SessionPicker widgets for lap selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motorsports-data-notebook"
-version = "0.6.0"
+version = "0.7.0"
 description = ""
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/src/motorsports_data_notebook/widgets.py
+++ b/src/motorsports_data_notebook/widgets.py
@@ -3,14 +3,16 @@
 This module provides Jupyter widgets for interactive data loading and analysis.
 """
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
+import pandas as pd
 import pyarrow as pa  # type: ignore[import-untyped]
 import pyarrow.compute as pc  # type: ignore[import-untyped]
 from IPython.display import display
 
 from .corners import compute_lap_distance
+from .visualization import format_lap_time
 
 if TYPE_CHECKING:
     import ipywidgets as widgets
@@ -175,3 +177,393 @@ class FileUpload:
         if self._uploaded_data is not None:
             return self._uploaded_data
         return self._default_file
+
+
+class LapPicker:
+    """Dropdown widget for selecting a lap to analyze.
+
+    Provides a dropdown interface for lap selection with formatted lap times.
+    The fastest lap (excluding first/last pit laps) is pre-selected by default.
+
+    Parameters
+    ----------
+    laps : pd.DataFrame
+        Laps table with columns: 'num', 'start_time', 'end_time', 'lap_time'.
+        The 'lap_time' column should be a timedelta.
+
+    Examples
+    --------
+    >>> from motorsports_data_notebook.widgets import LapPicker, load_session
+    >>> log = load_session("sample.xrz")
+    >>> laps = log.laps.to_pandas()
+    >>> lap_picker = LapPicker(laps)
+    >>> lap_picker.display()
+    >>> selected_lap = lap_picker.get_selected_lap()
+    """
+
+    def __init__(self, laps: pd.DataFrame) -> None:
+        import ipywidgets as widgets
+
+        self._validate_laps(laps)
+        self._laps = laps.copy()
+        self._widgets = widgets
+
+        # Build dropdown options
+        options = self._build_options()
+
+        # Find fastest middle lap for default selection
+        default_value = self._get_default_lap_index()
+
+        # Create dropdown widget
+        self._dropdown = widgets.Dropdown(
+            options=options,
+            value=default_value,
+            description="Lap:",
+            style={"description_width": "auto"},
+        )
+
+        # Status label showing current selection
+        self._status_label = widgets.HTML(value=self._get_status_html())
+
+        # Update status when selection changes
+        self._dropdown.observe(self._on_selection_change, names="value")
+
+        # Container for layout
+        self._container = widgets.VBox([self._dropdown, self._status_label])
+
+    def _validate_laps(self, laps: pd.DataFrame) -> None:
+        """Validate required columns exist in laps DataFrame."""
+        required_columns = {"num", "start_time", "end_time", "lap_time"}
+        missing = required_columns - set(laps.columns)
+        if missing:
+            raise ValueError(f"Missing required columns: {missing}")
+        if len(laps) == 0:
+            raise ValueError("Laps DataFrame is empty")
+
+    def _build_options(self) -> list[tuple[str, Any]]:
+        """Build dropdown options with formatted labels."""
+        options: list[tuple[str, Any]] = []
+        n_laps = len(self._laps)
+        fastest_idx = self._find_fastest_middle_lap_index()
+
+        for idx, row in self._laps.iterrows():
+            lap_num = int(row["num"])
+            lap_time_str = format_lap_time(row["lap_time"])
+
+            # Build label with annotations
+            label = f"Lap {lap_num}: {lap_time_str}"
+
+            # Add annotations for special laps
+            annotations = []
+            if idx == self._laps.index[0]:
+                annotations.append("out lap")
+            if idx == self._laps.index[-1]:
+                annotations.append("in lap")
+            if n_laps > 2 and idx == fastest_idx:
+                annotations.append("fastest")
+
+            if annotations:
+                label += f" ({', '.join(annotations)})"
+
+            options.append((label, idx))
+
+        return options
+
+    def _find_fastest_middle_lap_index(self) -> Any:
+        """Find the index of the fastest lap, excluding first and last."""
+        if len(self._laps) <= 2:
+            return None
+
+        # Exclude first and last laps
+        middle_laps = self._laps.iloc[1:-1]
+        fastest_idx = middle_laps["lap_time"].idxmin()
+        return fastest_idx
+
+    def _get_default_lap_index(self) -> Any:
+        """Get the default lap index to select."""
+        fastest_idx = self._find_fastest_middle_lap_index()
+        if fastest_idx is not None:
+            return fastest_idx
+        # Fall back to first lap if not enough laps
+        return self._laps.index[0]
+
+    def _get_status_html(self) -> str:
+        """Generate status HTML for current selection."""
+        idx = self._dropdown.value
+        row = self._laps.loc[idx]
+        lap_num = int(row["num"])
+        lap_time_str = format_lap_time(row["lap_time"])
+        return f"<span style='color: #666;'>Selected: Lap {lap_num} ({lap_time_str})</span>"
+
+    def _on_selection_change(self, change: dict) -> None:  # type: ignore[type-arg]
+        """Handle dropdown selection change."""
+        self._status_label.value = self._get_status_html()
+
+    def display(self) -> None:
+        """Display the lap picker widget."""
+        display(self._container)
+
+    def get_selected_lap(self) -> "pd.Series[Any]":
+        """Return the selected lap row.
+
+        Returns
+        -------
+        pd.Series
+            The row from the laps DataFrame corresponding to the selected lap.
+            Contains columns: 'num', 'start_time', 'end_time', 'lap_time'.
+        """
+        idx = self._dropdown.value
+        result: pd.Series[Any] = self._laps.loc[idx]
+        return result
+
+    def update_laps(self, laps: pd.DataFrame) -> None:
+        """Update the lap picker with new laps data.
+
+        Parameters
+        ----------
+        laps : pd.DataFrame
+            New laps table with columns: 'num', 'start_time', 'end_time', 'lap_time'.
+        """
+        self._validate_laps(laps)
+        self._laps = laps.copy()
+
+        # Rebuild dropdown options
+        options = self._build_options()
+        default_value = self._get_default_lap_index()
+
+        # Update dropdown
+        self._dropdown.options = options
+        self._dropdown.value = default_value
+
+        # Update status
+        self._status_label.value = self._get_status_html()
+
+
+class SessionPicker:
+    """Combined file upload and lap picker widget.
+
+    Provides a unified interface for uploading telemetry files and selecting
+    laps to analyze. The lap picker automatically updates when a new file
+    is uploaded, without requiring additional cell execution.
+
+    Parameters
+    ----------
+    default_file : str
+        Path to the default file to use if no file is uploaded.
+
+    Examples
+    --------
+    >>> from motorsports_data_notebook.widgets import SessionPicker
+    >>> session = SessionPicker("sample.xrz")
+    >>> session.display()  # Shows file upload and lap picker in one widget
+    >>> # After selecting a lap:
+    >>> log = session.get_log()
+    >>> selected_lap = session.get_selected_lap()
+    """
+
+    def __init__(self, default_file: str) -> None:
+        import ipywidgets as widgets
+
+        self._default_file = default_file
+        self._widgets = widgets
+        self._log: "LogFile | None" = None
+        self._laps: pd.DataFrame | None = None
+
+        # File upload section
+        self._instruction = widgets.HTML(
+            value="<b>Upload your own .xrk/.xrz file:</b> (or use the sample data)"
+        )
+
+        self._upload_widget = widgets.FileUpload(
+            accept=".xrk,.xrz",
+            multiple=False,
+            description="Choose File",
+            button_style="primary",
+        )
+
+        self._file_status = widgets.HTML(
+            value=f"<span style='color: #666;'>Using: {default_file} (default)</span>"
+        )
+
+        # Loading indicator
+        self._loading_label = widgets.HTML(value="")
+
+        # Lap picker section (initially hidden until file loads)
+        self._lap_label = widgets.HTML(value="<b>Select lap to analyze:</b>")
+
+        self._lap_dropdown = widgets.Dropdown(
+            options=[("Loading...", 0)],
+            description="Lap:",
+            style={"description_width": "auto"},
+            disabled=True,
+        )
+
+        self._lap_status = widgets.HTML(value="")
+
+        # Set up callbacks
+        self._upload_widget.observe(self._on_upload, names="value")
+        self._lap_dropdown.observe(self._on_lap_change, names="value")
+
+        # Layout
+        self._container = widgets.VBox(
+            [
+                self._instruction,
+                self._upload_widget,
+                self._file_status,
+                self._loading_label,
+                widgets.HTML(value="<hr style='margin: 10px 0;'>"),
+                self._lap_label,
+                self._lap_dropdown,
+                self._lap_status,
+            ]
+        )
+
+        # Load default file
+        self._load_file(default_file)
+
+    def _load_file(self, file_data: Union[str, bytes]) -> None:
+        """Load a file and update the lap picker."""
+        self._loading_label.value = "<span style='color: #888;'>Loading session data...</span>"
+        self._lap_dropdown.disabled = True
+
+        try:
+            self._log = load_session(file_data)
+            self._laps = self._log.laps.to_pandas()
+            self._update_lap_dropdown()
+            self._loading_label.value = ""
+        except Exception as e:
+            self._loading_label.value = f"<span style='color: red;'>Error loading file: {e}</span>"
+            self._lap_dropdown.disabled = True
+
+    def _update_lap_dropdown(self) -> None:
+        """Update the lap dropdown with current laps data."""
+        if self._laps is None or len(self._laps) == 0:
+            self._lap_dropdown.options = [("No laps found", 0)]
+            self._lap_dropdown.disabled = True
+            return
+
+        # Build options
+        options: list[tuple[str, Any]] = []
+        n_laps = len(self._laps)
+        fastest_idx = self._find_fastest_middle_lap_index()
+
+        for idx, row in self._laps.iterrows():
+            lap_num = int(row["num"])
+            lap_time_str = format_lap_time(row["lap_time"])
+
+            label = f"Lap {lap_num}: {lap_time_str}"
+
+            annotations = []
+            if idx == self._laps.index[0]:
+                annotations.append("out lap")
+            if idx == self._laps.index[-1]:
+                annotations.append("in lap")
+            if n_laps > 2 and idx == fastest_idx:
+                annotations.append("fastest")
+
+            if annotations:
+                label += f" ({', '.join(annotations)})"
+
+            options.append((label, idx))
+
+        # Update dropdown
+        self._lap_dropdown.options = options
+        self._lap_dropdown.value = fastest_idx if fastest_idx is not None else self._laps.index[0]
+        self._lap_dropdown.disabled = False
+
+        # Update status
+        self._update_lap_status()
+
+    def _find_fastest_middle_lap_index(self) -> Any:
+        """Find the index of the fastest lap, excluding first and last."""
+        if self._laps is None or len(self._laps) <= 2:
+            return None
+        middle_laps = self._laps.iloc[1:-1]
+        return middle_laps["lap_time"].idxmin()
+
+    def _update_lap_status(self) -> None:
+        """Update the lap status label."""
+        if self._laps is None:
+            return
+        idx = self._lap_dropdown.value
+        row = self._laps.loc[idx]
+        lap_num = int(row["num"])
+        lap_time_str = format_lap_time(row["lap_time"])
+        self._lap_status.value = (
+            f"<span style='color: #666;'>Selected: Lap {lap_num} ({lap_time_str})</span>"
+        )
+
+    def _on_upload(self, change: dict) -> None:  # type: ignore[type-arg]
+        """Handle file upload event."""
+        if self._upload_widget.value:
+            uploaded = self._upload_widget.value[0]
+            filename = uploaded["name"]
+            file_data = uploaded["content"].tobytes()
+
+            self._file_status.value = (
+                f"<span style='color: green;'><b>✓ Using:</b> {filename}</span>"
+            )
+
+            # Load the new file and update lap picker
+            self._load_file(file_data)
+
+    def _on_lap_change(self, change: dict) -> None:  # type: ignore[type-arg]
+        """Handle lap selection change."""
+        self._update_lap_status()
+
+    def display(self) -> None:
+        """Display the combined session picker widget."""
+        display(self._container)
+
+    def get_log(self) -> "LogFile":
+        """Return the loaded LogFile.
+
+        Returns
+        -------
+        LogFile
+            The loaded and enriched LogFile object.
+
+        Raises
+        ------
+        RuntimeError
+            If no file has been loaded successfully.
+        """
+        if self._log is None:
+            raise RuntimeError("No session loaded. Upload a file first.")
+        return self._log
+
+    def get_laps(self) -> pd.DataFrame:
+        """Return the laps DataFrame.
+
+        Returns
+        -------
+        pd.DataFrame
+            The laps table with columns: 'num', 'start_time', 'end_time', 'lap_time'.
+
+        Raises
+        ------
+        RuntimeError
+            If no file has been loaded successfully.
+        """
+        if self._laps is None:
+            raise RuntimeError("No session loaded. Upload a file first.")
+        return self._laps.copy()
+
+    def get_selected_lap(self) -> "pd.Series[Any]":
+        """Return the selected lap row.
+
+        Returns
+        -------
+        pd.Series
+            The row from the laps DataFrame corresponding to the selected lap.
+
+        Raises
+        ------
+        RuntimeError
+            If no file has been loaded successfully.
+        """
+        if self._laps is None:
+            raise RuntimeError("No session loaded. Upload a file first.")
+        idx = self._lap_dropdown.value
+        result: pd.Series[Any] = self._laps.loc[idx]
+        return result

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from motorsports_data_notebook.widgets import load_session
+from motorsports_data_notebook.widgets import load_session, LapPicker, SessionPicker
 
 
 # Path to patch aim_xrk - it's imported inside the function
@@ -210,3 +210,288 @@ class TestLoadSessionEdgeCases:
 
         # Should complete without error
         assert result is mock_log
+
+
+# ============================================================================
+# Fixtures for LapPicker
+# ============================================================================
+
+
+@pytest.fixture
+def sample_laps_df():
+    """Create a sample laps DataFrame with 5 laps."""
+    return pd.DataFrame(
+        {
+            "num": [1, 2, 3, 4, 5],
+            "start_time": [0, 60000, 120000, 180000, 240000],
+            "end_time": [60000, 120000, 180000, 240000, 300000],
+            "lap_time": pd.to_timedelta([65, 62, 58, 61, 70], unit="s"),
+        }
+    )
+
+
+@pytest.fixture
+def few_laps_df():
+    """Create a laps DataFrame with only 2 laps."""
+    return pd.DataFrame(
+        {
+            "num": [1, 2],
+            "start_time": [0, 60000],
+            "end_time": [60000, 120000],
+            "lap_time": pd.to_timedelta([65, 62], unit="s"),
+        }
+    )
+
+
+@pytest.fixture
+def mock_ipywidgets():
+    """Create mock ipywidgets module."""
+    mock_widgets = MagicMock()
+
+    # Track the value passed to Dropdown constructor
+    def create_dropdown(**kwargs):
+        mock_dropdown = MagicMock()
+        mock_dropdown.value = kwargs.get("value")
+        mock_dropdown.observe = MagicMock()
+        return mock_dropdown
+
+    mock_widgets.Dropdown.side_effect = create_dropdown
+    mock_widgets.HTML.return_value = MagicMock()
+    mock_widgets.VBox.return_value = MagicMock()
+    return mock_widgets
+
+
+# ============================================================================
+# Tests for LapPicker
+# ============================================================================
+
+
+class TestLapPicker:
+    """Tests for LapPicker widget."""
+
+    def test_preselects_fastest_middle_lap(self, sample_laps_df, mock_ipywidgets):
+        """Test that the fastest lap (excluding first/last) is pre-selected."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets}):
+            picker = LapPicker(sample_laps_df)
+
+            # Lap 3 (index 2) has the fastest time (58s) among middle laps
+            # The Dropdown should be initialized with value=2
+            call_kwargs = mock_ipywidgets.Dropdown.call_args[1]
+            assert call_kwargs["value"] == 2
+
+    def test_excludes_first_last_from_fastest_selection(
+        self, sample_laps_df, mock_ipywidgets
+    ):
+        """Test that first and last laps are excluded from fastest selection."""
+        # Modify so first lap is fastest overall
+        modified_df = sample_laps_df.copy()
+        modified_df.loc[0, "lap_time"] = pd.Timedelta(seconds=50)
+
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets}):
+            picker = LapPicker(modified_df)
+
+            # Even though lap 1 (index 0) is fastest, it should select lap 3 (index 2)
+            # which is fastest among middle laps
+            call_kwargs = mock_ipywidgets.Dropdown.call_args[1]
+            assert call_kwargs["value"] == 2
+
+    def test_marks_pit_laps_in_labels(self, sample_laps_df, mock_ipywidgets):
+        """Test that first lap is marked as out lap and last as in lap."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets}):
+            picker = LapPicker(sample_laps_df)
+
+            call_kwargs = mock_ipywidgets.Dropdown.call_args[1]
+            options = call_kwargs["options"]
+
+            # First option should have "out lap"
+            assert "out lap" in options[0][0]
+            # Last option should have "in lap"
+            assert "in lap" in options[-1][0]
+
+    def test_marks_fastest_lap_in_labels(self, sample_laps_df, mock_ipywidgets):
+        """Test that fastest middle lap is marked in label."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets}):
+            picker = LapPicker(sample_laps_df)
+
+            call_kwargs = mock_ipywidgets.Dropdown.call_args[1]
+            options = call_kwargs["options"]
+
+            # Lap 3 (index 2) should have "fastest" in label
+            assert "fastest" in options[2][0]
+            # Other middle laps should not have "fastest"
+            assert "fastest" not in options[1][0]
+            assert "fastest" not in options[3][0]
+
+    def test_validates_required_columns(self, mock_ipywidgets):
+        """Test that validation fails for missing columns."""
+        invalid_df = pd.DataFrame({"num": [1, 2, 3]})
+
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets}):
+            with pytest.raises(ValueError, match="Missing required columns"):
+                LapPicker(invalid_df)
+
+    def test_validates_empty_dataframe(self, mock_ipywidgets):
+        """Test that validation fails for empty DataFrame."""
+        empty_df = pd.DataFrame(columns=["num", "start_time", "end_time", "lap_time"])
+
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets}):
+            with pytest.raises(ValueError, match="empty"):
+                LapPicker(empty_df)
+
+    def test_handles_few_laps(self, few_laps_df, mock_ipywidgets):
+        """Test handling when there are only 2 laps (no middle laps)."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets}):
+            picker = LapPicker(few_laps_df)
+
+            # Should fall back to first lap
+            call_kwargs = mock_ipywidgets.Dropdown.call_args[1]
+            assert call_kwargs["value"] == 0
+
+            # No lap should be marked as "fastest" since there are no middle laps
+            options = call_kwargs["options"]
+            for label, _ in options:
+                assert "fastest" not in label
+
+    def test_get_selected_lap_returns_correct_row(self, sample_laps_df, mock_ipywidgets):
+        """Test that get_selected_lap returns the correct lap row."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets}):
+            picker = LapPicker(sample_laps_df)
+            # The picker defaults to lap 3 (index 2) which is the fastest middle lap
+            selected = picker.get_selected_lap()
+
+            assert selected["num"] == 3
+            assert selected["start_time"] == 120000
+            assert selected["end_time"] == 180000
+
+    def test_lap_time_format_in_options(self, sample_laps_df, mock_ipywidgets):
+        """Test that lap times are formatted correctly in dropdown options."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets}):
+            picker = LapPicker(sample_laps_df)
+
+            call_kwargs = mock_ipywidgets.Dropdown.call_args[1]
+            options = call_kwargs["options"]
+
+            # Lap 3 has 58 seconds = 0:58.000
+            assert "0:58.000" in options[2][0]
+
+    def test_update_laps_changes_options(self, sample_laps_df, mock_ipywidgets):
+        """Test that update_laps updates the dropdown options."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets}):
+            picker = LapPicker(sample_laps_df)
+
+            # Create new laps data with different times
+            new_laps = pd.DataFrame(
+                {
+                    "num": [1, 2, 3],
+                    "start_time": [0, 60000, 120000],
+                    "end_time": [60000, 120000, 180000],
+                    "lap_time": pd.to_timedelta([70, 55, 80], unit="s"),
+                }
+            )
+
+            picker.update_laps(new_laps)
+
+            # Check that dropdown options were updated (3 laps now)
+            assert len(picker._dropdown.options) == 3
+            # Check that value was updated to new fastest (lap 2, index 1)
+            assert picker._dropdown.value == 1
+
+
+# ============================================================================
+# Tests for SessionPicker
+# ============================================================================
+
+
+@pytest.fixture
+def mock_ipywidgets_session():
+    """Create mock ipywidgets module for SessionPicker tests."""
+    mock_widgets = MagicMock()
+
+    def create_dropdown(**kwargs):
+        mock_dropdown = MagicMock()
+        mock_dropdown.value = kwargs.get("value", 0)
+        mock_dropdown.options = kwargs.get("options", [])
+        mock_dropdown.disabled = kwargs.get("disabled", False)
+        mock_dropdown.observe = MagicMock()
+        return mock_dropdown
+
+    mock_widgets.Dropdown.side_effect = create_dropdown
+    mock_widgets.HTML.return_value = MagicMock()
+    mock_widgets.VBox.return_value = MagicMock()
+    mock_widgets.FileUpload.return_value = MagicMock()
+    mock_widgets.FileUpload.return_value.observe = MagicMock()
+    mock_widgets.FileUpload.return_value.value = None
+    return mock_widgets
+
+
+class TestSessionPicker:
+    """Tests for SessionPicker widget."""
+
+    def test_loads_default_file_on_init(self, mock_log_file, mock_ipywidgets_session):
+        """Test that SessionPicker loads the default file on initialization."""
+        with (
+            patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_session}),
+            patch(AIM_XRK_PATCH_PATH, return_value=mock_log_file),
+        ):
+            picker = SessionPicker("test.xrz")
+
+            # Should have loaded the log
+            assert picker._log is not None
+            assert picker._laps is not None
+
+    def test_get_log_returns_loaded_log(self, mock_log_file, mock_ipywidgets_session):
+        """Test that get_log returns the loaded LogFile."""
+        with (
+            patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_session}),
+            patch(AIM_XRK_PATCH_PATH, return_value=mock_log_file),
+        ):
+            picker = SessionPicker("test.xrz")
+            log = picker.get_log()
+
+            assert log is mock_log_file
+
+    def test_get_laps_returns_dataframe(self, mock_log_file, mock_ipywidgets_session):
+        """Test that get_laps returns a DataFrame copy."""
+        with (
+            patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_session}),
+            patch(AIM_XRK_PATCH_PATH, return_value=mock_log_file),
+        ):
+            picker = SessionPicker("test.xrz")
+            laps = picker.get_laps()
+
+            assert isinstance(laps, pd.DataFrame)
+            assert "num" in laps.columns
+            assert "lap_time" in laps.columns
+
+    def test_get_selected_lap_returns_series(
+        self, mock_log_file, mock_ipywidgets_session
+    ):
+        """Test that get_selected_lap returns a Series."""
+        with (
+            patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_session}),
+            patch(AIM_XRK_PATCH_PATH, return_value=mock_log_file),
+        ):
+            picker = SessionPicker("test.xrz")
+            selected = picker.get_selected_lap()
+
+            assert isinstance(selected, pd.Series)
+            assert "num" in selected.index
+            assert "start_time" in selected.index
+            assert "end_time" in selected.index
+
+    def test_raises_error_when_no_session_loaded(self, mock_ipywidgets_session):
+        """Test that methods raise RuntimeError when no session is loaded."""
+        with (
+            patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_session}),
+            patch(AIM_XRK_PATCH_PATH, side_effect=Exception("File not found")),
+        ):
+            picker = SessionPicker("nonexistent.xrz")
+
+            with pytest.raises(RuntimeError, match="No session loaded"):
+                picker.get_log()
+
+            with pytest.raises(RuntimeError, match="No session loaded"):
+                picker.get_laps()
+
+            with pytest.raises(RuntimeError, match="No session loaded"):
+                picker.get_selected_lap()

--- a/workspace_template/basics.ipynb
+++ b/workspace_template/basics.ipynb
@@ -40,23 +40,7 @@
    "id": "f435536b",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
-    "%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n",
-    "\n",
-    "# Import helper functions\n",
-    "from motorsports_data_notebook.channels import get_best_lap_channels\n",
-    "from motorsports_data_notebook.visualization import (\n",
-    "    format_lap_time,\n",
-    "    plot_gps_channels,\n",
-    "    show_fig,\n",
-    ")\n",
-    "from motorsports_data_notebook.widgets import FileUpload, load_session\n",
-    "\n",
-    "# File picker - upload your own .xrk/.xrz file or use the sample data\n",
-    "file_upload = FileUpload(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\n",
-    "file_upload.display()"
-   ]
+   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import helper functions\nfrom motorsports_data_notebook.channels import get_lap_channels\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_gps_channels,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\n\n# Session picker - upload your own file and select a lap to analyze\nsession = SessionPicker(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\nsession.display()"
   },
   {
    "cell_type": "code",
@@ -64,13 +48,7 @@
    "id": "c6ee9ce9",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Load the data file with derived columns (speed_kmh, distance_m, lap_time)\n",
-    "log = load_session(file_upload.get_file_data())\n",
-    "\n",
-    "# Get laps as pandas DataFrame for display\n",
-    "laps = log.laps.to_pandas()"
-   ]
+   "source": "# Get laps as pandas DataFrame for display\nlaps = session.get_laps()"
   },
   {
    "cell_type": "code",
@@ -78,24 +56,15 @@
    "id": "d98a5c1a",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Display lap times table\n",
-    "laps.style.format({\"lap_time\": format_lap_time})"
-   ]
+   "source": "# Display lap times table\nlaps.style.format({\"lap_time\": format_lap_time})  # type: ignore[dict-item]"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "27e7fe9a",
+   "id": "40knep5enqh",
+   "source": "# Extract channel data for the selected lap\nselected_lap = session.get_selected_lap()\nlog = session.get_log()\nchannels = get_lap_channels(\n    log,\n    [\"GPS Latitude\", \"GPS Longitude\", \"speed_kmh\", \"BrakePress\", \"PPS\"],\n    int(selected_lap[\"start_time\"]),\n    int(selected_lap[\"end_time\"]),\n)",
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Extract best lap channel data\n",
-    "# Each channel keeps its native sample rate - no expensive merge/interpolation\n",
-    "best_lap, channels = get_best_lap_channels(\n",
-    "    log, laps, [\"GPS Latitude\", \"GPS Longitude\", \"speed_kmh\", \"BrakePress\", \"PPS\"]\n",
-    ")"
-   ]
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -110,7 +79,7 @@
     "    lat_channel=\"GPS Latitude\",\n",
     "    lon_channel=\"GPS Longitude\",\n",
     "    color_channels=[(\"speed_kmh\", \"Speed (km/h)\", \"Viridis\")],\n",
-    "    title=\"Speed\",\n",
+    "    title=f\"Speed - Lap {int(selected_lap['num'])}\",\n",
     ")\n",
     "show_fig(fig)"
    ]
@@ -131,7 +100,7 @@
     "        (\"BrakePress\", \"BrakePres\", \"Reds\"),\n",
     "        (\"PPS\", \"Throttle\", \"Greens\"),\n",
     "    ],\n",
-    "    title=\"Accelerator and Brake Pressure on Best Lap\",\n",
+    "    title=f\"Accelerator and Brake Pressure - Lap {int(selected_lap['num'])}\",\n",
     ")\n",
     "show_fig(fig)"
    ]

--- a/workspace_template/suspension_analysis.ipynb
+++ b/workspace_template/suspension_analysis.ipynb
@@ -12,32 +12,7 @@
    "id": "e5f6g7h8",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
-    "%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n",
-    "\n",
-    "# Import helper functions\n",
-    "from motorsports_data_notebook.channels import get_best_lap\n",
-    "from motorsports_data_notebook.suspension import (\n",
-    "    MotionRatios,\n",
-    "    VelocityRanges,\n",
-    "    SUSPENSION_CHANNEL_NAMES,\n",
-    "    analyze_suspension_velocity,\n",
-    "    format_suspension_stats_table,\n",
-    "    format_symmetry_table,\n",
-    "    format_comparison_table,\n",
-    ")\n",
-    "from motorsports_data_notebook.visualization import (\n",
-    "    format_lap_time,\n",
-    "    plot_suspension_velocity_histogram,\n",
-    "    show_fig,\n",
-    ")\n",
-    "from motorsports_data_notebook.widgets import FileUpload, load_session\n",
-    "\n",
-    "# File picker - upload your own .xrk/.xrz file or use the sample data\n",
-    "file_upload = FileUpload(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\n",
-    "file_upload.display()"
-   ]
+   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import helper functions\nfrom motorsports_data_notebook.suspension import (\n    MotionRatios,\n    VelocityRanges,\n    SUSPENSION_CHANNEL_NAMES,\n    analyze_suspension_velocity,\n    format_suspension_stats_table,\n    format_symmetry_table,\n    format_comparison_table,\n)\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_suspension_velocity_histogram,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\n\n# Session picker - upload your own file and select a lap to analyze\nsession = SessionPicker(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\nsession.display()"
   },
   {
    "cell_type": "code",
@@ -45,13 +20,7 @@
    "id": "i9j0k1l2",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Load the data file with derived columns (speed_kmh, distance_m, lap_time)\n",
-    "log = load_session(file_upload.get_file_data())\n",
-    "\n",
-    "# Get laps as pandas DataFrame for display\n",
-    "laps = log.laps.to_pandas()"
-   ]
+   "source": "# Get laps as pandas DataFrame for display\nlaps = session.get_laps()"
   },
   {
    "cell_type": "code",
@@ -59,10 +28,7 @@
    "id": "m3n4o5p6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Display lap times table\n",
-    "laps.style.format({\"lap_time\": format_lap_time})"
-   ]
+   "source": "# Display lap times table\nlaps.style.format({\"lap_time\": format_lap_time})  # type: ignore[dict-item]"
   },
   {
    "cell_type": "markdown",
@@ -117,36 +83,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "k7l8m9n0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get the best lap\n",
-    "best_lap = get_best_lap(laps)\n",
-    "print(f\"Analyzing lap {int(best_lap['num'])} - {format_lap_time(best_lap['lap_time'])}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "o1p2q3r4",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Analyze suspension velocity\n",
-    "result = analyze_suspension_velocity(\n",
-    "    log,\n",
-    "    lap_start=int(best_lap[\"start_time\"]),\n",
-    "    lap_end=int(best_lap[\"end_time\"]),\n",
-    "    channel_names=channel_names,\n",
-    "    motion_ratios=motion_ratios,\n",
-    "    velocity_ranges=velocity_ranges,\n",
-    "    smoothing_window=5,  # Rolling average to reduce noise\n",
-    "    bin_size=10.0,  # Histogram bin size in mm/s\n",
-    ")\n",
-    "\n",
-    "print(\"Analysis complete!\")"
-   ]
+   "source": "# Get the selected lap\nselected_lap = session.get_selected_lap()\nlog = session.get_log()\nprint(f\"Analyzing lap {int(selected_lap['num'])} - {format_lap_time(selected_lap['lap_time'])}\")\n\n# Analyze suspension velocity\nresult = analyze_suspension_velocity(\n    log,\n    lap_start=int(selected_lap[\"start_time\"]),\n    lap_end=int(selected_lap[\"end_time\"]),\n    channel_names=channel_names,\n    motion_ratios=motion_ratios,\n    velocity_ranges=velocity_ranges,\n    smoothing_window=5,  # Rolling average to reduce noise\n    bin_size=10.0,  # Histogram bin size in mm/s\n)\n\nprint(\"Analysis complete!\")"
   },
   {
    "cell_type": "markdown",
@@ -171,7 +111,7 @@
     "# Plot velocity histograms\n",
     "fig = plot_suspension_velocity_histogram(\n",
     "    result,\n",
-    "    title=f\"Suspension Velocity Distribution - Lap {int(best_lap['num'])} ({format_lap_time(best_lap['lap_time'])})\",\n",
+    "    title=f\"Suspension Velocity Distribution - Lap {int(selected_lap['num'])} ({format_lap_time(selected_lap['lap_time'])})\",\n",
     ")\n",
     "show_fig(fig)"
    ]

--- a/workspace_template/tire_analysis.ipynb
+++ b/workspace_template/tire_analysis.ipynb
@@ -55,27 +55,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "6fbac743",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
-    "%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n",
-    "\n",
-    "# Import helper functions\n",
-    "from motorsports_data_notebook.channels import get_best_lap_channels\n",
-    "from motorsports_data_notebook.visualization import (\n",
-    "    format_lap_time,\n",
-    "    plot_tire_thermography,\n",
-    "    show_fig,\n",
-    ")\n",
-    "from motorsports_data_notebook.widgets import FileUpload, load_session\n",
-    "\n",
-    "# File picker - upload your own .xrk/.xrz file or use the sample data\n",
-    "file_upload = FileUpload(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\n",
-    "file_upload.display()"
-   ]
+   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import helper functions\nfrom motorsports_data_notebook.channels import get_lap_channels\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_tire_thermography,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\n\n# Session picker - upload your own file and select a lap to analyze\nsession = SessionPicker(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\nsession.display()"
   },
   {
    "cell_type": "code",
@@ -83,57 +67,33 @@
    "id": "6771e836",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Load the data file with derived columns (speed_kmh, distance_m, lap_time)\n",
-    "log = load_session(file_upload.get_file_data())\n",
-    "\n",
-    "# Get laps as pandas DataFrame for display\n",
-    "laps = log.laps.to_pandas()"
-   ]
+   "source": "# Get laps as pandas DataFrame for display\nlaps = session.get_laps()"
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "62200456",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Display lap times table\n",
-    "laps.style.format({\"lap_time\": format_lap_time})"
-   ]
+   "source": "# Display lap times table\nlaps.style.format({\"lap_time\": format_lap_time})  # type: ignore[dict-item]"
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "2396f2bb",
+   "id": "xskcw5ghbj",
+   "source": "# Define channels needed for tire thermography (only interpolate what we need)\ntire_channels = [f\"{pos}_Ch{i}\" for pos in [\"FL\", \"FR\", \"RL\", \"RR\"] for i in range(1, 9)]\nother_channels = [\n    \"distance_m\",\n    \"speed_kmh\",\n    \"LateralAcc\",\n    \"InlineAcc\",\n    \"BrakePress\",\n    \"PPS\",\n    \"SteerAngle\",\n]\n\n# Extract data for the selected lap at native sample rates\nselected_lap = session.get_selected_lap()\nlog = session.get_log()\nchannels = get_lap_channels(\n    log,\n    tire_channels + other_channels,\n    int(selected_lap[\"start_time\"]),\n    int(selected_lap[\"end_time\"]),\n)",
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Define channels needed for tire thermography (only interpolate what we need)\n",
-    "tire_channels = [f\"{pos}_Ch{i}\" for pos in [\"FL\", \"FR\", \"RL\", \"RR\"] for i in range(1, 9)]\n",
-    "other_channels = [\n",
-    "    \"distance_m\",\n",
-    "    \"speed_kmh\",\n",
-    "    \"LateralAcc\",\n",
-    "    \"InlineAcc\",\n",
-    "    \"BrakePress\",\n",
-    "    \"PPS\",\n",
-    "    \"SteerAngle\",\n",
-    "]\n",
-    "\n",
-    "# Extract best lap data at native sample rates\n",
-    "best_lap, channels = get_best_lap_channels(log, laps, tire_channels + other_channels)"
-   ]
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "b59f2d9f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Tire Thermography - Best Lap (uses on-demand interpolation)\n",
-    "fig = plot_tire_thermography(channels, title=\"Tire Temperatures - Best Lap\")\n",
+    "# Tire Thermography - Selected Lap (uses on-demand interpolation)\n",
+    "fig = plot_tire_thermography(channels, title=f\"Tire Temperatures - Lap {int(selected_lap['num'])}\")\n",
     "show_fig(fig)"
    ]
   }


### PR DESCRIPTION
## Summary
- Add `LapPicker` widget: dropdown for selecting a lap from a laps DataFrame
- Add `SessionPicker` widget: combined file upload + lap picker that automatically refreshes when a new file is uploaded
- Pre-selects fastest lap (excluding out/in pit laps)
- Labels mark "(out lap)", "(in lap)", "(fastest)"
- Updated all single-lap template notebooks to use `SessionPicker` for streamlined UX
- Bumps version to 0.7.0

## Test plan
- [x] All 181 tests pass
- [x] `poetry run poe check` passes (lint, typecheck, tests)
- [ ] Manual testing: run notebooks in JupyterLab to verify widgets work
- [ ] Manual testing: upload a different file and verify lap picker updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)