### PR TITLE
Preserve .github dir and add CNAME in release deployment

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -69,11 +69,14 @@ jobs:
           git clone --depth 1 git@github.com:m3rlin45/motorsports-data-notebook-releases.git releases
           cd releases
 
-          # Remove old content (except git files)
-          find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.gitattributes' -exec rm -rf {} +
+          # Remove old content (except git files and .github)
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.gitattributes' ! -name '.github' -exec rm -rf {} +
 
           # Copy new content
           cp -r ../dist/* .
+
+          # Add CNAME for custom domain
+          echo "analysis.inferno.racing" > CNAME
 
           # Commit and push with LFS
           git config user.name "GitHub Actions"


### PR DESCRIPTION
## Summary
- Fixes release deployment that deleted the `.github/workflows/pages.yml` file needed for GitHub Pages deployment
- Preserves `.github` directory when cleaning old content
- Adds `CNAME` file for custom domain (`analysis.inferno.racing`)

## Also done
- Restored `.github/workflows/pages.yml` and `CNAME` to the releases repo (with LFS support for checkout)

## Test plan
- [ ] Create a new release to verify the workflow preserves `.github` and adds `CNAME`

🤖 Generated with [Claude Code](https://claude.com/claude-code)