### PR TITLE
Add ChannelPicker widget for interactive channel mapping

### DIFF
--- a/src/motorsports_data_notebook/widgets.py
+++ b/src/motorsports_data_notebook/widgets.py
@@ -340,34 +340,47 @@ class LapPicker:
 
 
 class SessionPicker:
-    """Combined file upload and lap picker widget.
+    """Combined file upload, lap picker, and optional channel picker widget.
 
-    Provides a unified interface for uploading telemetry files and selecting
-    laps to analyze. The lap picker automatically updates when a new file
-    is uploaded, without requiring additional cell execution.
+    Provides a unified interface for uploading telemetry files, selecting
+    laps to analyze, and optionally configuring channel name mappings.
+    All components automatically update when a new file is uploaded.
 
     Parameters
     ----------
     default_file : str
         Path to the default file to use if no file is uploaded.
+    channel_mapping : dict[str, str], optional
+        Default channel name mapping. If provided, a channel picker section
+        is displayed allowing users to configure channel names with typeahead
+        autocomplete and validation. Keys are logical names (e.g., "throttle"),
+        values are default channel names (e.g., "PPS").
 
     Examples
     --------
     >>> from motorsports_data_notebook.widgets import SessionPicker
-    >>> session = SessionPicker("sample.xrz")
-    >>> session.display()  # Shows file upload and lap picker in one widget
-    >>> # After selecting a lap:
+    >>> session = SessionPicker(
+    ...     "sample.xrz",
+    ...     channel_mapping={
+    ...         "gps_latitude": "GPS Latitude",
+    ...         "throttle": "PPS",
+    ...         "brake": "BrakePress",
+    ...     }
+    ... )
+    >>> session.display()  # Shows file upload, lap picker, and channel picker
     >>> log = session.get_log()
     >>> selected_lap = session.get_selected_lap()
+    >>> CHANNEL_NAMES = session.get_channel_names()
     """
 
-    def __init__(self, default_file: str) -> None:
+    def __init__(self, default_file: str, channel_mapping: dict[str, str] | None = None) -> None:
         import ipywidgets as widgets
 
         self._default_file = default_file
         self._widgets = widgets
         self._log: "LogFile | None" = None
         self._laps: pd.DataFrame | None = None
+        self._channel_mapping = channel_mapping
 
         # File upload section
         self._instruction = widgets.HTML(
@@ -400,29 +413,47 @@ class SessionPicker:
 
         self._lap_status = widgets.HTML(value="")
 
+        # Channel picker section (only if channel_mapping provided)
+        self._channel_picker: ChannelPicker | None = None
+        self._channel_section: "widgets.VBox | None" = None
+
+        if channel_mapping is not None:
+            # Create channel picker with empty available channels initially
+            # Will be updated when file loads
+            self._channel_picker = ChannelPicker(channel_mapping, [])
+            self._channel_section = widgets.VBox(
+                [
+                    widgets.HTML(value="<hr style='margin: 10px 0;'>"),
+                    self._channel_picker._container,
+                ]
+            )
+
         # Set up callbacks
         self._upload_widget.observe(self._on_upload, names="value")
         self._lap_dropdown.observe(self._on_lap_change, names="value")
 
-        # Layout
-        self._container = widgets.VBox(
-            [
-                self._instruction,
-                self._upload_widget,
-                self._file_status,
-                self._loading_label,
-                widgets.HTML(value="<hr style='margin: 10px 0;'>"),
-                self._lap_label,
-                self._lap_dropdown,
-                self._lap_status,
-            ]
-        )
+        # Build layout
+        layout_items = [
+            self._instruction,
+            self._upload_widget,
+            self._file_status,
+            self._loading_label,
+            widgets.HTML(value="<hr style='margin: 10px 0;'>"),
+            self._lap_label,
+            self._lap_dropdown,
+            self._lap_status,
+        ]
+
+        if self._channel_section is not None:
+            layout_items.append(self._channel_section)
+
+        self._container = widgets.VBox(layout_items)
 
         # Load default file
         self._load_file(default_file)
 
     def _load_file(self, file_data: Union[str, bytes]) -> None:
-        """Load a file and update the lap picker."""
+        """Load a file and update the lap picker and channel picker."""
         self._loading_label.value = "<span style='color: #888;'>Loading session data...</span>"
         self._lap_dropdown.disabled = True
 
@@ -430,10 +461,17 @@ class SessionPicker:
             self._log = load_session(file_data)
             self._laps = self._log.laps.to_pandas()
             self._update_lap_dropdown()
+            self._update_channel_picker()
             self._loading_label.value = ""
         except Exception as e:
             self._loading_label.value = f"<span style='color: red;'>Error loading file: {e}</span>"
             self._lap_dropdown.disabled = True
+
+    def _update_channel_picker(self) -> None:
+        """Update the channel picker with available channels from loaded log."""
+        if self._channel_picker is not None and self._log is not None:
+            available_channels = list(self._log.channels.keys())
+            self._channel_picker.update_available_channels(available_channels)
 
     def _update_lap_dropdown(self) -> None:
         """Update the lap dropdown with current laps data."""
@@ -567,3 +605,196 @@ class SessionPicker:
         idx = self._lap_dropdown.value
         result: pd.Series[Any] = self._laps.loc[idx]
         return result
+
+    def get_channel_names(self) -> dict[str, str]:
+        """Return the configured channel name mapping.
+
+        Returns
+        -------
+        dict[str, str]
+            Dictionary mapping logical channel names to configured channel names.
+
+        Raises
+        ------
+        RuntimeError
+            If no channel_mapping was provided during initialization.
+        """
+        if self._channel_picker is None:
+            raise RuntimeError(
+                "No channel_mapping provided. "
+                "Pass channel_mapping parameter to SessionPicker to enable channel configuration."
+            )
+        return self._channel_picker.get_channel_names()
+
+
+class ChannelPicker:
+    """Interactive widget for configuring channel name mappings with validation.
+
+    Provides a form-based interface for mapping logical channel names (e.g., "throttle")
+    to actual channel names in the telemetry data (e.g., "PPS"). Features typeahead
+    autocomplete and visual validation feedback for unmatched channels.
+
+    Parameters
+    ----------
+    default_mapping : dict[str, str]
+        Dictionary mapping logical channel names to default channel names.
+        Keys are logical names (e.g., "throttle"), values are default channel
+        names (e.g., "PPS").
+    available_channels : list[str]
+        List of available channel names in the current log file. Used for
+        autocomplete suggestions and validation.
+
+    Examples
+    --------
+    >>> from motorsports_data_notebook.widgets import SessionPicker, ChannelPicker
+    >>> session = SessionPicker("sample.xrz")
+    >>> session.display()
+    >>> log = session.get_log()
+    >>> channel_picker = ChannelPicker(
+    ...     default_mapping={
+    ...         "gps_latitude": "GPS Latitude",
+    ...         "gps_longitude": "GPS Longitude",
+    ...         "throttle": "PPS",
+    ...         "brake": "BrakePress",
+    ...     },
+    ...     available_channels=list(log.channels.keys()),
+    ... )
+    >>> channel_picker.display()
+    >>> CHANNEL_NAMES = channel_picker.get_channel_names()
+    """
+
+    def __init__(self, default_mapping: dict[str, str], available_channels: list[str]) -> None:
+        import ipywidgets as widgets
+
+        self._widgets = widgets
+        self._default_mapping = default_mapping.copy()
+        self._available_channels = sorted(available_channels)
+
+        # Create header
+        self._header = widgets.HTML(value="<b>Channel Configuration</b>")
+
+        # Create a row for each channel mapping
+        self._comboboxes: dict[str, "widgets.Combobox"] = {}
+        self._status_labels: dict[str, "widgets.HTML"] = {}
+        self._rows: list["widgets.HBox"] = []
+
+        for logical_name, default_value in default_mapping.items():
+            # Label for the channel
+            label = widgets.HTML(
+                value=f"<span style='font-family: monospace; width: 150px; display: inline-block;'>{logical_name}:</span>"
+            )
+
+            # Combobox with autocomplete
+            combobox = widgets.Combobox(
+                value=default_value,
+                options=self._available_channels,
+                ensure_option=False,  # Allow custom values
+                placeholder="Type to search...",
+                layout=widgets.Layout(width="200px"),
+            )
+            self._comboboxes[logical_name] = combobox
+
+            # Status indicator
+            status = widgets.HTML(value="")
+            self._status_labels[logical_name] = status
+
+            # Observe changes
+            combobox.observe(self._on_change, names="value")
+
+            # Create row
+            row = widgets.HBox([label, combobox, status])
+            self._rows.append(row)
+
+        # Summary label
+        self._summary = widgets.HTML(value="")
+
+        # Container
+        self._container = widgets.VBox([self._header] + self._rows + [self._summary])
+
+        # Initial validation
+        self._update_validation()
+
+    def _on_change(self, change: dict) -> None:  # type: ignore[type-arg]
+        """Handle combobox value changes."""
+        self._update_validation()
+
+    def _update_validation(self) -> None:
+        """Update validation status for all channels."""
+        unmatched = self.get_unmatched_channels()
+
+        for logical_name, combobox in self._comboboxes.items():
+            value = combobox.value
+            status_label = self._status_labels[logical_name]
+
+            if value in self._available_channels:
+                status_label.value = (
+                    "<span style='color: green; margin-left: 10px;'>&#10003; Found</span>"
+                )
+            else:
+                status_label.value = (
+                    "<span style='color: red; margin-left: 10px;'>&#10007; Not found</span>"
+                )
+
+        # Update summary
+        if len(unmatched) == 0:
+            self._summary.value = (
+                "<span style='color: green; margin-top: 10px; display: block;'>"
+                "&#10003; All channels configured correctly</span>"
+            )
+        else:
+            self._summary.value = (
+                f"<span style='color: red; margin-top: 10px; display: block;'>"
+                f"&#10007; {len(unmatched)} channel(s) not found</span>"
+            )
+
+    def display(self) -> None:
+        """Display the channel picker widget."""
+        display(self._container)
+
+    def get_channel_names(self) -> dict[str, str]:
+        """Get the current channel name mapping.
+
+        Returns
+        -------
+        dict[str, str]
+            Dictionary mapping logical channel names to configured channel names.
+        """
+        return {logical_name: combobox.value for logical_name, combobox in self._comboboxes.items()}
+
+    def get_unmatched_channels(self) -> list[str]:
+        """Get list of logical channel names with unmatched values.
+
+        Returns
+        -------
+        list[str]
+            List of logical channel names whose values are not in the
+            available channels list.
+        """
+        unmatched = []
+        for logical_name, combobox in self._comboboxes.items():
+            if combobox.value not in self._available_channels:
+                unmatched.append(logical_name)
+        return unmatched
+
+    def update_available_channels(self, available_channels: list[str]) -> None:
+        """Update the list of available channels.
+
+        Parameters
+        ----------
+        available_channels : list[str]
+            New list of available channel names.
+        """
+        self._available_channels = sorted(available_channels)
+        for combobox in self._comboboxes.values():
+            combobox.options = self._available_channels
+        self._update_validation()
+
+    def is_valid(self) -> bool:
+        """Check if all channels are matched.
+
+        Returns
+        -------
+        bool
+            True if all configured channel names are found in available channels.
+        """
+        return len(self.get_unmatched_channels()) == 0

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from motorsports_data_notebook.widgets import load_session, LapPicker, SessionPicker
+from motorsports_data_notebook.widgets import load_session, LapPicker, SessionPicker, ChannelPicker
 
 
 # Path to patch aim_xrk - it's imported inside the function
@@ -415,9 +415,19 @@ def mock_ipywidgets_session():
         mock_dropdown.observe = MagicMock()
         return mock_dropdown
 
+    def create_combobox(**kwargs):
+        mock_combo = MagicMock()
+        mock_combo.value = kwargs.get("value", "")
+        mock_combo.options = kwargs.get("options", [])
+        mock_combo.observe = MagicMock()
+        return mock_combo
+
     mock_widgets.Dropdown.side_effect = create_dropdown
+    mock_widgets.Combobox.side_effect = create_combobox
     mock_widgets.HTML.return_value = MagicMock()
+    mock_widgets.HBox.return_value = MagicMock()
     mock_widgets.VBox.return_value = MagicMock()
+    mock_widgets.Layout.return_value = MagicMock()
     mock_widgets.FileUpload.return_value = MagicMock()
     mock_widgets.FileUpload.return_value.observe = MagicMock()
     mock_widgets.FileUpload.return_value.value = None
@@ -495,3 +505,264 @@ class TestSessionPicker:
 
             with pytest.raises(RuntimeError, match="No session loaded"):
                 picker.get_selected_lap()
+
+    def test_with_channel_mapping_creates_channel_picker(
+        self, mock_log_file, mock_ipywidgets_session
+    ):
+        """Test that providing channel_mapping creates a channel picker."""
+        channel_mapping = {"throttle": "PPS", "brake": "BrakePress"}
+
+        with (
+            patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_session}),
+            patch(AIM_XRK_PATCH_PATH, return_value=mock_log_file),
+        ):
+            picker = SessionPicker("test.xrz", channel_mapping=channel_mapping)
+
+            assert picker._channel_picker is not None
+            assert picker._channel_section is not None
+
+    def test_without_channel_mapping_no_channel_picker(
+        self, mock_log_file, mock_ipywidgets_session
+    ):
+        """Test that not providing channel_mapping doesn't create a channel picker."""
+        with (
+            patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_session}),
+            patch(AIM_XRK_PATCH_PATH, return_value=mock_log_file),
+        ):
+            picker = SessionPicker("test.xrz")
+
+            assert picker._channel_picker is None
+            assert picker._channel_section is None
+
+    def test_get_channel_names_returns_mapping(
+        self, mock_log_file, mock_ipywidgets_session
+    ):
+        """Test that get_channel_names returns the channel mapping."""
+        channel_mapping = {"throttle": "PPS", "brake": "BrakePress"}
+
+        with (
+            patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_session}),
+            patch(AIM_XRK_PATCH_PATH, return_value=mock_log_file),
+        ):
+            picker = SessionPicker("test.xrz", channel_mapping=channel_mapping)
+            result = picker.get_channel_names()
+
+            assert result == channel_mapping
+
+    def test_get_channel_names_raises_without_mapping(
+        self, mock_log_file, mock_ipywidgets_session
+    ):
+        """Test that get_channel_names raises error when no mapping provided."""
+        with (
+            patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_session}),
+            patch(AIM_XRK_PATCH_PATH, return_value=mock_log_file),
+        ):
+            picker = SessionPicker("test.xrz")
+
+            with pytest.raises(RuntimeError, match="No channel_mapping provided"):
+                picker.get_channel_names()
+
+    def test_channel_picker_updates_on_file_load(
+        self, mock_log_file, mock_ipywidgets_session
+    ):
+        """Test that channel picker is updated with available channels on file load."""
+        channel_mapping = {"throttle": "PPS"}
+
+        with (
+            patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_session}),
+            patch(AIM_XRK_PATCH_PATH, return_value=mock_log_file),
+        ):
+            picker = SessionPicker("test.xrz", channel_mapping=channel_mapping)
+
+            # The channel picker should have been updated with available channels
+            # from the log file (which has "GPS Speed" channel)
+            assert picker._channel_picker is not None
+            assert "GPS Speed" in picker._channel_picker._available_channels
+
+
+# ============================================================================
+# Fixtures for ChannelPicker
+# ============================================================================
+
+
+@pytest.fixture
+def sample_available_channels():
+    """Sample list of available channels."""
+    return [
+        "GPS Latitude",
+        "GPS Longitude",
+        "GPS Speed",
+        "PPS",
+        "BrakePress",
+        "LateralAcc",
+        "SteerAngle",
+        "speed_kmh",
+        "distance_m",
+    ]
+
+
+@pytest.fixture
+def sample_channel_mapping():
+    """Sample default channel mapping."""
+    return {
+        "gps_latitude": "GPS Latitude",
+        "gps_longitude": "GPS Longitude",
+        "throttle": "PPS",
+        "brake": "BrakePress",
+    }
+
+
+@pytest.fixture
+def mock_ipywidgets_channel():
+    """Create mock ipywidgets module for ChannelPicker tests."""
+    mock_widgets = MagicMock()
+
+    def create_combobox(**kwargs):
+        mock_combo = MagicMock()
+        mock_combo.value = kwargs.get("value", "")
+        mock_combo.options = kwargs.get("options", [])
+        mock_combo.observe = MagicMock()
+        return mock_combo
+
+    mock_widgets.Combobox.side_effect = create_combobox
+    mock_widgets.HTML.return_value = MagicMock()
+    mock_widgets.HBox.return_value = MagicMock()
+    mock_widgets.VBox.return_value = MagicMock()
+    mock_widgets.Layout.return_value = MagicMock()
+    return mock_widgets
+
+
+# ============================================================================
+# Tests for ChannelPicker
+# ============================================================================
+
+
+class TestChannelPicker:
+    """Tests for ChannelPicker widget."""
+
+    def test_initializes_with_default_mapping(
+        self, sample_channel_mapping, sample_available_channels, mock_ipywidgets_channel
+    ):
+        """Test that ChannelPicker initializes with the provided default mapping."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_channel}):
+            picker = ChannelPicker(sample_channel_mapping, sample_available_channels)
+
+            # Should create comboboxes for each channel
+            assert len(picker._comboboxes) == len(sample_channel_mapping)
+            assert "gps_latitude" in picker._comboboxes
+            assert "throttle" in picker._comboboxes
+
+    def test_get_channel_names_returns_current_values(
+        self, sample_channel_mapping, sample_available_channels, mock_ipywidgets_channel
+    ):
+        """Test that get_channel_names returns the current combobox values."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_channel}):
+            picker = ChannelPicker(sample_channel_mapping, sample_available_channels)
+
+            result = picker.get_channel_names()
+
+            assert result == sample_channel_mapping
+
+    def test_get_unmatched_channels_returns_empty_when_all_valid(
+        self, sample_channel_mapping, sample_available_channels, mock_ipywidgets_channel
+    ):
+        """Test that get_unmatched_channels returns empty list when all channels are valid."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_channel}):
+            picker = ChannelPicker(sample_channel_mapping, sample_available_channels)
+
+            unmatched = picker.get_unmatched_channels()
+
+            assert unmatched == []
+
+    def test_get_unmatched_channels_returns_invalid_channels(
+        self, sample_available_channels, mock_ipywidgets_channel
+    ):
+        """Test that get_unmatched_channels returns channels not in available list."""
+        mapping_with_invalid = {
+            "gps_latitude": "GPS Latitude",
+            "throttle": "InvalidChannel",  # Not in available_channels
+        }
+
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_channel}):
+            picker = ChannelPicker(mapping_with_invalid, sample_available_channels)
+
+            unmatched = picker.get_unmatched_channels()
+
+            assert "throttle" in unmatched
+            assert "gps_latitude" not in unmatched
+
+    def test_is_valid_returns_true_when_all_matched(
+        self, sample_channel_mapping, sample_available_channels, mock_ipywidgets_channel
+    ):
+        """Test that is_valid returns True when all channels are matched."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_channel}):
+            picker = ChannelPicker(sample_channel_mapping, sample_available_channels)
+
+            assert picker.is_valid() is True
+
+    def test_is_valid_returns_false_when_unmatched(
+        self, sample_available_channels, mock_ipywidgets_channel
+    ):
+        """Test that is_valid returns False when channels are unmatched."""
+        mapping_with_invalid = {
+            "gps_latitude": "GPS Latitude",
+            "throttle": "InvalidChannel",
+        }
+
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_channel}):
+            picker = ChannelPicker(mapping_with_invalid, sample_available_channels)
+
+            assert picker.is_valid() is False
+
+    def test_update_available_channels_updates_options(
+        self, sample_channel_mapping, sample_available_channels, mock_ipywidgets_channel
+    ):
+        """Test that update_available_channels updates combobox options."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_channel}):
+            picker = ChannelPicker(sample_channel_mapping, sample_available_channels)
+
+            new_channels = ["NewChannel1", "NewChannel2"]
+            picker.update_available_channels(new_channels)
+
+            assert picker._available_channels == sorted(new_channels)
+            # All comboboxes should have updated options
+            for combobox in picker._comboboxes.values():
+                assert combobox.options == sorted(new_channels)
+
+    def test_update_available_channels_updates_validation(
+        self, sample_channel_mapping, sample_available_channels, mock_ipywidgets_channel
+    ):
+        """Test that update_available_channels triggers validation update."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_channel}):
+            picker = ChannelPicker(sample_channel_mapping, sample_available_channels)
+
+            # Initially all valid
+            assert picker.is_valid() is True
+
+            # Update to channels that don't include the defaults
+            new_channels = ["NewChannel1", "NewChannel2"]
+            picker.update_available_channels(new_channels)
+
+            # Now all channels should be unmatched
+            assert picker.is_valid() is False
+            assert len(picker.get_unmatched_channels()) == len(sample_channel_mapping)
+
+    def test_combobox_values_sorted_alphabetically(
+        self, sample_channel_mapping, sample_available_channels, mock_ipywidgets_channel
+    ):
+        """Test that available channels are sorted alphabetically."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_channel}):
+            picker = ChannelPicker(sample_channel_mapping, sample_available_channels)
+
+            assert picker._available_channels == sorted(sample_available_channels)
+
+    def test_empty_available_channels(
+        self, sample_channel_mapping, mock_ipywidgets_channel
+    ):
+        """Test handling of empty available channels list."""
+        with patch.dict("sys.modules", {"ipywidgets": mock_ipywidgets_channel}):
+            picker = ChannelPicker(sample_channel_mapping, [])
+
+            assert picker._available_channels == []
+            assert picker.is_valid() is False
+            assert len(picker.get_unmatched_channels()) == len(sample_channel_mapping)

--- a/workspace_template/basics.ipynb
+++ b/workspace_template/basics.ipynb
@@ -40,7 +40,7 @@
    "id": "f435536b",
    "metadata": {},
    "outputs": [],
-   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import helper functions\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_gps_channels,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\n\n# Session picker - upload your own file and select a lap to analyze\nsession = SessionPicker(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\nsession.display()"
+   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import helper functions\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_gps_channels,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\n\n# Session picker with channel configuration\n# Upload your own file and select a lap to analyze\nsession = SessionPicker(\n    default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\",\n    channel_mapping={\n        \"gps_latitude\": \"GPS Latitude\",\n        \"gps_longitude\": \"GPS Longitude\",\n        \"throttle\": \"PPS\",\n        \"brake\": \"BrakePress\",\n    },\n)\nsession.display()"
   },
   {
    "cell_type": "code",
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "id": "40knep5enqh",
-   "source": "# Extract channel data for the selected lap using libxrk 0.5.0 methods\nselected_lap = session.get_selected_lap()\nlog = session.get_log()\nlap_num = int(selected_lap[\"num\"])\n\n# Filter to lap, select channels, and resample to GPS timebase\nchannels = (\n    log.filter_by_lap(lap_num)\n    .select_channels([\"GPS Latitude\", \"GPS Longitude\", \"speed_kmh\", \"BrakePress\", \"PPS\"])\n    .resample_to_channel(\"GPS Latitude\")\n    .channels\n)",
+   "source": "# Extract channel data for the selected lap using libxrk 0.5.0 methods\nselected_lap = session.get_selected_lap()\nlog = session.get_log()\nCHANNEL_NAMES = session.get_channel_names()\nlap_num = int(selected_lap[\"num\"])\n\n# Get channel names from configuration\ngps_lat_ch = CHANNEL_NAMES[\"gps_latitude\"]\ngps_lon_ch = CHANNEL_NAMES[\"gps_longitude\"]\nthrottle_ch = CHANNEL_NAMES[\"throttle\"]\nbrake_ch = CHANNEL_NAMES[\"brake\"]\n\n# Filter to lap, select channels, and resample to GPS timebase\nchannels = (\n    log.filter_by_lap(lap_num)\n    .select_channels([gps_lat_ch, gps_lon_ch, \"speed_kmh\", brake_ch, throttle_ch])\n    .resample_to_channel(gps_lat_ch)\n    .channels\n)",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -72,17 +72,7 @@
    "id": "37f88359",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Plot speed on GPS map using channel tables directly\n",
-    "fig = plot_gps_channels(\n",
-    "    channels,\n",
-    "    lat_channel=\"GPS Latitude\",\n",
-    "    lon_channel=\"GPS Longitude\",\n",
-    "    color_channels=[(\"speed_kmh\", \"Speed (km/h)\", \"Viridis\")],\n",
-    "    title=f\"Speed - Lap {int(selected_lap['num'])}\",\n",
-    ")\n",
-    "show_fig(fig)"
-   ]
+   "source": "# Plot speed on GPS map using channel tables directly\nfig = plot_gps_channels(\n    channels,\n    lat_channel=gps_lat_ch,\n    lon_channel=gps_lon_ch,\n    color_channels=[(\"speed_kmh\", \"Speed (km/h)\", \"Viridis\")],\n    title=f\"Speed - Lap {int(selected_lap['num'])}\",\n)\nshow_fig(fig)"
   },
   {
    "cell_type": "code",
@@ -90,20 +80,7 @@
    "id": "b38f078e",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Plot with multiple color channels (automatically interpolated to GPS timebase)\n",
-    "fig = plot_gps_channels(\n",
-    "    channels,\n",
-    "    lat_channel=\"GPS Latitude\",\n",
-    "    lon_channel=\"GPS Longitude\",\n",
-    "    color_channels=[\n",
-    "        (\"BrakePress\", \"BrakePres\", \"Reds\"),\n",
-    "        (\"PPS\", \"Throttle\", \"Greens\"),\n",
-    "    ],\n",
-    "    title=f\"Accelerator and Brake Pressure - Lap {int(selected_lap['num'])}\",\n",
-    ")\n",
-    "show_fig(fig)"
-   ]
+   "source": "# Plot with multiple color channels (automatically interpolated to GPS timebase)\nfig = plot_gps_channels(\n    channels,\n    lat_channel=gps_lat_ch,\n    lon_channel=gps_lon_ch,\n    color_channels=[\n        (brake_ch, \"BrakePres\", \"Reds\"),\n        (throttle_ch, \"Throttle\", \"Greens\"),\n    ],\n    title=f\"Accelerator and Brake Pressure - Lap {int(selected_lap['num'])}\",\n)\nshow_fig(fig)"
   }
  ],
  "metadata": {

--- a/workspace_template/consistency_analysis.ipynb
+++ b/workspace_template/consistency_analysis.ipynb
@@ -55,7 +55,7 @@
    "id": "98ae7254",
    "metadata": {},
    "outputs": [],
-   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import core libraries\nimport pandas as pd\nfrom IPython.display import display\n\n# Visualization libraries\nimport plotly.express as px\nimport plotly.graph_objects as go\n\n# Import helper functions\nfrom motorsports_data_notebook.channels import (\n    get_best_lap_channels,\n    get_top_laps,\n)\nfrom motorsports_data_notebook.corners import identify_corners\nfrom motorsports_data_notebook.driver_analysis import find_throttle_acceptance\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    visualize_throttle_acceptance,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import FileUpload, load_session\nfrom motorsports_data_notebook.zones import (\n    compute_segment_stats,\n    create_track_segments,\n    detect_zones_averaged,\n    get_corner_data,\n)\n\n# File picker - upload your own .xrk/.xrz file or use the sample data\nfile_upload = FileUpload(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\nfile_upload.display()"
+   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import core libraries\nimport pandas as pd\nfrom IPython.display import display\n\n# Visualization libraries\nimport plotly.express as px\nimport plotly.graph_objects as go\n\n# Import helper functions\nfrom motorsports_data_notebook.channels import (\n    get_best_lap_channels,\n    get_top_laps,\n)\nfrom motorsports_data_notebook.corners import identify_corners\nfrom motorsports_data_notebook.driver_analysis import find_throttle_acceptance\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    visualize_throttle_acceptance,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\nfrom motorsports_data_notebook.zones import (\n    compute_segment_stats,\n    create_track_segments,\n    detect_zones_averaged,\n    get_corner_data,\n)\n\n# Session picker with channel configuration\n# Upload your own .xrk/.xrz file or use the sample data\nsession = SessionPicker(\n    default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\",\n    channel_mapping={\n        # GPS channels (required for corner detection)\n        \"gps_latitude\": \"GPS Latitude\",\n        \"gps_longitude\": \"GPS Longitude\",\n        \"gps_speed\": \"GPS Speed\",  # Speed in m/s from GPS\n        # Pedal inputs (required for zone detection)\n        \"throttle\": \"PPS\",  # Throttle position sensor (0-100%)\n        \"brake\": \"BrakePress\",  # Brake pressure (0-100%)\n        # Dynamics (required for throttle acceptance analysis)\n        \"lateral_g\": \"LateralAcc\",  # Lateral acceleration in G\n        \"steering\": \"SteerAngle\",  # Steering angle in degrees\n    },\n)\nsession.display()"
   },
   {
    "cell_type": "code",
@@ -63,42 +63,7 @@
    "id": "d886a5c2",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Load the data file with derived columns (speed_kmh, distance_m, lap_time)\n",
-    "log = load_session(file_upload.get_file_data())\n",
-    "\n",
-    "# Get laps as pandas DataFrame\n",
-    "laps = log.laps.to_pandas()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1082ac6c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ===== Channel Name Configuration =====\n",
-    "# Different data loggers use different channel names. Configure yours here.\n",
-    "# Print available channels to help identify the correct names:\n",
-    "print(\"Available channels in this log file:\")\n",
-    "print(sorted(log.channels.keys()))\n",
-    "\n",
-    "# Required channel mappings - modify values to match YOUR data logger's channel names\n",
-    "# These are defaults for AIM loggers\n",
-    "CHANNEL_NAMES = {\n",
-    "    # GPS channels (required for corner detection)\n",
-    "    \"gps_latitude\": \"GPS Latitude\",\n",
-    "    \"gps_longitude\": \"GPS Longitude\",\n",
-    "    \"gps_speed\": \"GPS Speed\",  # Speed in m/s from GPS\n",
-    "    # Pedal inputs (required for zone detection)\n",
-    "    \"throttle\": \"PPS\",  # Throttle position sensor (0-100%)\n",
-    "    \"brake\": \"BrakePress\",  # Brake pressure (0-100%)\n",
-    "    # Dynamics (required for throttle acceptance analysis)\n",
-    "    \"lateral_g\": \"LateralAcc\",  # Lateral acceleration in G\n",
-    "    \"steering\": \"SteerAngle\",  # Steering angle in degrees\n",
-    "}"
-   ]
+   "source": "# Get the loaded session data\nlog = session.get_log()\nlaps = session.get_laps()\nCHANNEL_NAMES = session.get_channel_names()"
   },
   {
    "cell_type": "code",
@@ -106,10 +71,7 @@
    "id": "d4339e52",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Display lap times table\n",
-    "laps.style.format({\"lap_time\": format_lap_time})"
-   ]
+   "source": "# Display lap times table\nlaps.style.format({\"lap_time\": format_lap_time})  # type: ignore[dict-item]"
   },
   {
    "cell_type": "code",

--- a/workspace_template/suspension_analysis.ipynb
+++ b/workspace_template/suspension_analysis.ipynb
@@ -12,7 +12,7 @@
    "id": "e5f6g7h8",
    "metadata": {},
    "outputs": [],
-   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import helper functions\nfrom motorsports_data_notebook.suspension import (\n    MotionRatios,\n    VelocityRanges,\n    SUSPENSION_CHANNEL_NAMES,\n    analyze_suspension_velocity,\n    format_suspension_stats_table,\n    format_symmetry_table,\n    format_comparison_table,\n)\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_suspension_velocity_histogram,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\n\n# Session picker - upload your own file and select a lap to analyze\nsession = SessionPicker(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\nsession.display()"
+   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import helper functions\nfrom motorsports_data_notebook.suspension import (\n    MotionRatios,\n    VelocityRanges,\n    SUSPENSION_CHANNEL_NAMES,\n    analyze_suspension_velocity,\n    format_suspension_stats_table,\n    format_symmetry_table,\n    format_comparison_table,\n)\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_suspension_velocity_histogram,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\n\n# Session picker with channel configuration\n# Upload your own file and select a lap to analyze\nsession = SessionPicker(\n    default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\",\n    channel_mapping={\n        \"shock_fl\": \"LF_Shock_Pot\",\n        \"shock_fr\": \"RF_Shock_Pot\",\n        \"shock_rl\": \"LR_Shock_Pot\",\n        \"shock_rr\": \"RR_Shock_Pot\",\n    },\n)\nsession.display()"
   },
   {
    "cell_type": "code",
@@ -42,35 +42,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "u1v2w3x4",
+   "id": "e2nmp3fh92e",
+   "source": "# Get the configured channel names\nchannel_names = session.get_channel_names()\n\n# Motion ratios: wheel_velocity = shock_velocity / motion_ratio\n# Default: Toyota 86 ZN6 (front MacPherson: 0.997, rear multi-link: 0.768)\nmotion_ratios = MotionRatios(\n    front_left=0.997,\n    front_right=0.997,\n    rear_left=0.768,\n    rear_right=0.768,\n)\n\n# Velocity range thresholds (mm/s) - defines the shading regions\nvelocity_ranges = VelocityRanges(\n    friction=5.0,  # Below: static friction zone\n    slow=25.0,  # Below: low speed damping\n    fast=200.0,  # Above: curb/high speed\n)",
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Shock pot channel names - modify to match your data logger setup\n",
-    "channel_names = {\n",
-    "    \"shock_fl\": \"LF_Shock_Pot\",\n",
-    "    \"shock_fr\": \"RF_Shock_Pot\",\n",
-    "    \"shock_rl\": \"LR_Shock_Pot\",\n",
-    "    \"shock_rr\": \"RR_Shock_Pot\",\n",
-    "}\n",
-    "\n",
-    "# Motion ratios: wheel_velocity = shock_velocity / motion_ratio\n",
-    "# Default: Toyota 86 ZN6 (front MacPherson: 0.997, rear multi-link: 0.768)\n",
-    "motion_ratios = MotionRatios(\n",
-    "    front_left=0.997,\n",
-    "    front_right=0.997,\n",
-    "    rear_left=0.768,\n",
-    "    rear_right=0.768,\n",
-    ")\n",
-    "\n",
-    "# Velocity range thresholds (mm/s) - defines the shading regions\n",
-    "velocity_ranges = VelocityRanges(\n",
-    "    friction=5.0,  # Below: static friction zone\n",
-    "    slow=25.0,  # Below: low speed damping\n",
-    "    fast=200.0,  # Above: curb/high speed\n",
-    ")"
-   ]
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/workspace_template/tire_analysis.ipynb
+++ b/workspace_template/tire_analysis.ipynb
@@ -59,7 +59,7 @@
    "id": "6fbac743",
    "metadata": {},
    "outputs": [],
-   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import helper functions\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_tire_thermography,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\n\n# Session picker - upload your own file and select a lap to analyze\nsession = SessionPicker(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\nsession.display()"
+   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import helper functions\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_tire_thermography,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\n\n# Session picker with channel configuration\n# Upload your own file and select a lap to analyze\n# Note: Tire temperature channels (FL_Ch1-8, etc.) follow fixed naming conventions.\nsession = SessionPicker(\n    default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\",\n    channel_mapping={\n        \"lateral_g\": \"LateralAcc\",\n        \"inline_g\": \"InlineAcc\",\n        \"throttle\": \"PPS\",\n        \"brake\": \"BrakePress\",\n        \"steering\": \"SteerAngle\",\n    },\n)\nsession.display()"
   },
   {
    "cell_type": "code",
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "id": "xskcw5ghbj",
-   "source": "# Define channels needed for tire thermography\ntire_channels = [f\"{pos}_Ch{i}\" for pos in [\"FL\", \"FR\", \"RL\", \"RR\"] for i in range(1, 9)]\nother_channels = [\n    \"distance_m\",\n    \"speed_kmh\",\n    \"LateralAcc\",\n    \"InlineAcc\",\n    \"BrakePress\",\n    \"PPS\",\n    \"SteerAngle\",\n]\n\n# Extract data for the selected lap using libxrk 0.5.0 methods\nselected_lap = session.get_selected_lap()\nlog = session.get_log()\nlap_num = int(selected_lap[\"num\"])\n\n# Filter to lap, select channels, and resample to distance_m timebase\nchannels = (\n    log.filter_by_lap(lap_num)\n    .select_channels(tire_channels + other_channels)\n    .resample_to_channel(\"distance_m\")\n    .channels\n)",
+   "source": "# Get the configured channel names and session data\nlog = session.get_log()\nCHANNEL_NAMES = session.get_channel_names()\n\n# Define channels needed for tire thermography\ntire_channels = [f\"{pos}_Ch{i}\" for pos in [\"FL\", \"FR\", \"RL\", \"RR\"] for i in range(1, 9)]\nother_channels = [\n    \"distance_m\",\n    \"speed_kmh\",\n    CHANNEL_NAMES[\"lateral_g\"],\n    CHANNEL_NAMES[\"inline_g\"],\n    CHANNEL_NAMES[\"brake\"],\n    CHANNEL_NAMES[\"throttle\"],\n    CHANNEL_NAMES[\"steering\"],\n]\n\n# Extract data for the selected lap using libxrk 0.5.0 methods\nselected_lap = session.get_selected_lap()\nlap_num = int(selected_lap[\"num\"])\n\n# Filter to lap, select channels, and resample to distance_m timebase\nchannels = (\n    log.filter_by_lap(lap_num)\n    .select_channels(tire_channels + other_channels)\n    .resample_to_channel(\"distance_m\")\n    .channels\n)",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/workspace_template/track_analysis.ipynb
+++ b/workspace_template/track_analysis.ipynb
@@ -51,7 +51,7 @@
    "id": "de1404e9",
    "metadata": {},
    "outputs": [],
-   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import core libraries\nimport numpy as np\nimport plotly.graph_objects as go\n\n# Import helper functions\nfrom motorsports_data_notebook.channels import (\n    get_best_lap_channels,\n    get_top_laps,\n)\nfrom motorsports_data_notebook.corners import identify_corners\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_track_segments,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import FileUpload, load_session\nfrom motorsports_data_notebook.zones import create_track_segments, detect_zones_averaged\n\n# File picker - upload your own .xrk/.xrz file or use the sample data\nfile_upload = FileUpload(default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\")\nfile_upload.display()"
+   "source": "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n\n# Import core libraries\nimport numpy as np\nimport plotly.graph_objects as go\n\n# Import helper functions\nfrom motorsports_data_notebook.channels import (\n    get_best_lap_channels,\n    get_top_laps,\n)\nfrom motorsports_data_notebook.corners import identify_corners\nfrom motorsports_data_notebook.visualization import (\n    format_lap_time,\n    plot_track_segments,\n    show_fig,\n)\nfrom motorsports_data_notebook.widgets import SessionPicker\nfrom motorsports_data_notebook.zones import create_track_segments, detect_zones_averaged\n\n# Session picker with channel configuration\n# Upload your own .xrk/.xrz file or use the sample data\nsession = SessionPicker(\n    default_file=\"CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz\",\n    channel_mapping={\n        # GPS channels (required for corner detection)\n        \"gps_latitude\": \"GPS Latitude\",\n        \"gps_longitude\": \"GPS Longitude\",\n        \"gps_speed\": \"GPS Speed\",  # Speed in m/s from GPS\n        # Pedal inputs (required for zone detection)\n        \"throttle\": \"PPS\",  # Throttle position sensor (0-100%)\n        \"brake\": \"BrakePress\",  # Brake pressure (0-100%)\n        # Dynamics (optional, for throttle acceptance analysis)\n        \"lateral_g\": \"LateralAcc\",  # Lateral acceleration in G\n        \"steering\": \"SteerAngle\",  # Steering angle in degrees\n    },\n)\nsession.display()"
   },
   {
    "cell_type": "code",
@@ -59,42 +59,7 @@
    "id": "0c8b22ba",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Load the data file with derived columns (speed_kmh, distance_m, lap_time)\n",
-    "log = load_session(file_upload.get_file_data())\n",
-    "\n",
-    "# Get laps as pandas DataFrame\n",
-    "laps = log.laps.to_pandas()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "36ddcb68",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ===== Channel Name Configuration =====\n",
-    "# Different data loggers use different channel names. Configure yours here.\n",
-    "# Print available channels to help identify the correct names:\n",
-    "print(\"Available channels in this log file:\")\n",
-    "print(sorted(log.channels.keys()))\n",
-    "\n",
-    "# Required channel mappings - modify values to match YOUR data logger's channel names\n",
-    "# These are defaults for AIM loggers\n",
-    "CHANNEL_NAMES = {\n",
-    "    # GPS channels (required for corner detection)\n",
-    "    \"gps_latitude\": \"GPS Latitude\",\n",
-    "    \"gps_longitude\": \"GPS Longitude\",\n",
-    "    \"gps_speed\": \"GPS Speed\",  # Speed in m/s from GPS\n",
-    "    # Pedal inputs (required for zone detection)\n",
-    "    \"throttle\": \"PPS\",  # Throttle position sensor (0-100%)\n",
-    "    \"brake\": \"BrakePress\",  # Brake pressure (0-100%)\n",
-    "    # Dynamics (optional, for throttle acceptance analysis)\n",
-    "    \"lateral_g\": \"LateralAcc\",  # Lateral acceleration in G\n",
-    "    \"steering\": \"SteerAngle\",  # Steering angle in degrees\n",
-    "}"
-   ]
+   "source": "# Get the loaded session data\nlog = session.get_log()\nlaps = session.get_laps()\nCHANNEL_NAMES = session.get_channel_names()"
   },
   {
    "cell_type": "code",
@@ -102,10 +67,7 @@
    "id": "4db2748d",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Display lap times table\n",
-    "laps.style.format({\"lap_time\": format_lap_time})"
-   ]
+   "source": "# Display lap times table\nlaps.style.format({\"lap_time\": format_lap_time})  # type: ignore[dict-item]"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

- Add `ChannelPicker` widget with typeahead autocomplete for configuring channel name mappings
- Integrate `ChannelPicker` into `SessionPicker` with optional `channel_mapping` parameter
- Update all 5 notebooks to use the integrated approach, reducing boilerplate

## Features

- **Typeahead autocomplete**: Uses ipywidgets `Combobox` for channel selection with suggestions
- **Real-time validation**: Green checkmarks for matched channels, red X for unmatched
- **Auto-update**: Channel picker updates available channels when a new file is uploaded
- **Backwards compatible**: `channel_mapping` is optional; without it, no channel picker is shown

## Notebook Usage (After)

```python
session = SessionPicker(
    "sample.xrz",
    channel_mapping={
        "gps_latitude": "GPS Latitude",
        "throttle": "PPS",
        "brake": "BrakePress",
    },
)
session.display()

log = session.get_log()
CHANNEL_NAMES = session.get_channel_names()
```

## Test plan

- [x] All 179 tests pass (`poetry run poe check`)
- [x] Manual test: Start JupyterLab and verify each notebook displays the channel picker
- [x] Manual test: Verify typeahead suggestions appear when typing in combobox
- [x] Manual test: Verify unmatched channels show red highlighting
- [x] Manual test: Upload a new file and verify channel picker updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)