### PR TITLE
Add per-session A/B config for cross-vehicle comparison

### DIFF
--- a/desktop_app/src/inferno_analyzer/app.py
+++ b/desktop_app/src/inferno_analyzer/app.py
@@ -221,21 +221,42 @@ class InfernoAnalyzerApp(ctk.CTk, TkinterDnD.DnDWrapper):
         self._channels_b = channels
         self._update_available_channels()
 
-        # Mark both tabs stale
+        # Show A/B session controls on both config panels
+        self.suspension_config_panel.show_session_b_controls()
+        self.driver_config_panel.show_session_b_controls()
+
+        # Check if Session B has a different vehicle profile
+        logger_id_b = self.session_b_panel.logger_id
+        logger_id_a = self.session_a_panel.logger_id
+        profile_b = None
+        if logger_id_b:
+            profile_b = get_profile_for_logger(logger_id_b)
+            if profile_b and logger_id_b != logger_id_a:
+                # Different vehicle — unsync and populate B from its profile
+                self.suspension_config_panel.set_sync(False)
+                self.suspension_config_panel.set_from_profile_b(profile_b)
+                self.driver_config_panel.set_sync(False)
+                self.driver_config_panel.set_from_profile_b(profile_b)
+
+        # Mark both tabs stale; driver tab also auto-sets B's throttle threshold
         self.suspension_tab.on_session_loaded()
-        self.driver_tab.on_session_loaded()
+        self.driver_tab.on_session_b_loaded()
 
         active_tab = self._get_active_tab()
         if active_tab is not None:
-            active_tab._update_status(f"Loaded comparison: {file_path.name}")
+            status = f"Loaded comparison: {file_path.name}"
+            if profile_b and logger_id_b != logger_id_a:
+                status += f" (profile: {profile_b.name})"
+            active_tab._update_status(status)
 
     def _update_available_channels(self) -> None:
-        """Update both config panels with channels from all loaded sessions."""
+        """Update both config panels with per-session channel suggestions."""
         channels_a = getattr(self, "_channels_a", [])
         channels_b = getattr(self, "_channels_b", [])
-        merged = sorted(set(channels_a) | set(channels_b))
-        self.suspension_config_panel.update_available_channels(merged)
-        self.driver_config_panel.update_available_channels(merged)
+        self.suspension_config_panel.update_available_channels_a(channels_a)
+        self.suspension_config_panel.update_available_channels_b(channels_b)
+        self.driver_config_panel.update_available_channels_a(channels_a)
+        self.driver_config_panel.update_available_channels_b(channels_b)
 
     def _on_selection_changed(self) -> None:
         """Handle lap selection or config change — route to active tab."""
@@ -250,25 +271,41 @@ class InfernoAnalyzerApp(ctk.CTk, TkinterDnD.DnDWrapper):
             active_tab.toggle_stats_window()
 
     def _on_save_profile(self) -> None:
-        """Save a merged vehicle profile from both config panels."""
-        logger_id = self.session_a_panel.logger_id
+        """Save a merged vehicle profile from both config panels.
+
+        Saves for whichever session (A or B) is active in the current
+        config panel's segmented button.
+        """
+        active_tab = self._get_active_tab()
+        active_config = self.get_config_panel_for_tab(active_tab) if active_tab else None
+
+        # Determine which session to save for
+        saving_b = active_config is not None and active_config.active_session == "B"
+
+        if saving_b:
+            logger_id = self.session_b_panel.logger_id
+            session_panel = self.session_b_panel
+        else:
+            logger_id = self.session_a_panel.logger_id
+            session_panel = self.session_a_panel
+
         if not logger_id:
-            active_tab = self._get_active_tab()
             if active_tab is not None:
                 active_tab._update_status("No logger ID — load a session first")
             return
 
-        # Build profile from suspension config panel (has motion ratios + shock channels)
-        session_label = self.session_a_panel.get_session_label()
-        profile = self.suspension_config_panel.get_vehicle_profile(name=session_label)
+        session_label = session_panel.get_session_label()
 
-        # Merge in driver config panel channels (throttle, brake, GPS, etc.)
-        driver_profile = self.driver_config_panel.get_vehicle_profile(name=session_label)
+        if saving_b:
+            profile = self.suspension_config_panel.get_vehicle_profile_b(name=session_label)
+            driver_profile = self.driver_config_panel.get_vehicle_profile_b(name=session_label)
+        else:
+            profile = self.suspension_config_panel.get_vehicle_profile(name=session_label)
+            driver_profile = self.driver_config_panel.get_vehicle_profile(name=session_label)
+
         profile.channel_names.update(driver_profile.channel_names)
-
         save_profile_for_logger(logger_id, profile)
 
-        active_tab = self._get_active_tab()
         if active_tab is not None:
             active_tab._update_status(f"Profile saved for logger {logger_id}")
 

--- a/desktop_app/src/inferno_analyzer/driver/widgets/config_panel.py
+++ b/desktop_app/src/inferno_analyzer/driver/widgets/config_panel.py
@@ -9,6 +9,7 @@ import customtkinter as ctk
 from motorsports_data_notebook.desktop.config_panel import BaseConfigPanel
 
 if TYPE_CHECKING:
+    from motorsports_data_notebook.desktop.autocomplete_entry import AutocompleteEntry
     from motorsports_data_notebook.profiles import VehicleProfile
 
 # Default channel name mappings
@@ -79,8 +80,14 @@ class ConfigPanel(BaseConfigPanel):
         self._create_save_profile_btn()
         self._layout_widgets()
 
+    _THRESHOLD_CONFIG = {
+        "corner_threshold": ("Corner Det.:", str(DEFAULT_CORNER_THRESHOLD)),
+        "throttle_threshold": ("Throttle %:", str(DEFAULT_THROTTLE_THRESHOLD)),
+        "sustain_time": ("Sustain ms:", str(DEFAULT_SUSTAIN_TIME_MS)),
+    }
+
     def _create_threshold_widgets(self) -> None:
-        """Create threshold input widgets."""
+        """Create threshold input widgets (Session A)."""
         self.thresholds_frame = ctk.CTkFrame(self)
         self.thresholds_label = ctk.CTkLabel(
             self.thresholds_frame,
@@ -88,28 +95,38 @@ class ConfigPanel(BaseConfigPanel):
             font=ctk.CTkFont(size=12, weight="bold"),
         )
 
-        self.threshold_entries: dict[str, ctk.CTkEntry] = {}
-        self.threshold_labels: dict[str, ctk.CTkLabel] = {}
+        self._threshold_entries_a: dict[str, ctk.CTkEntry] = {}
+        self._threshold_labels_a: dict[str, ctk.CTkLabel] = {}
+        self._threshold_entries_b: dict[str, ctk.CTkEntry] | None = None
+        self._threshold_labels_b: dict[str, ctk.CTkLabel] | None = None
 
-        threshold_config = {
-            "corner_threshold": ("Corner Det.:", str(DEFAULT_CORNER_THRESHOLD)),
-            "throttle_threshold": ("Throttle %:", str(DEFAULT_THROTTLE_THRESHOLD)),
-            "sustain_time": ("Sustain ms:", str(DEFAULT_SUSTAIN_TIME_MS)),
-        }
-
-        for key, (display_name, default_val) in threshold_config.items():
-            self.threshold_labels[key] = ctk.CTkLabel(
+        for key, (display_name, default_val) in self._THRESHOLD_CONFIG.items():
+            self._threshold_labels_a[key] = ctk.CTkLabel(
                 self.thresholds_frame,
                 text=display_name,
                 font=ctk.CTkFont(size=11),
             )
-            self.threshold_entries[key] = ctk.CTkEntry(
+            self._threshold_entries_a[key] = ctk.CTkEntry(
                 self.thresholds_frame,
                 width=80,
                 font=ctk.CTkFont(size=11),
             )
-            self.threshold_entries[key].insert(0, default_val)
-            self.threshold_entries[key].bind("<KeyRelease>", self._on_entry_changed)
+            self._threshold_entries_a[key].insert(0, default_val)
+            self._threshold_entries_a[key].bind("<KeyRelease>", self._on_entry_changed)
+
+    @property
+    def threshold_entries(self) -> dict[str, ctk.CTkEntry]:
+        """Return the active session's threshold entries."""
+        if self._active_session == "B" and self._threshold_entries_b is not None:
+            return self._threshold_entries_b
+        return self._threshold_entries_a
+
+    @property
+    def threshold_labels(self) -> dict[str, ctk.CTkLabel]:
+        """Return the active session's threshold labels."""
+        if self._active_session == "B" and self._threshold_labels_b is not None:
+            return self._threshold_labels_b
+        return self._threshold_labels_a
 
     def _create_save_profile_btn(self) -> None:
         """Create the Save Profile button."""
@@ -130,49 +147,105 @@ class ConfigPanel(BaseConfigPanel):
         self._pack_channels()
 
         # Add save profile button next to reset channels button
-        num_channel_rows = (len(self.channel_entries) + 1) // 2
         self.reset_channels_btn.grid_configure(columnspan=2)
-        self.save_profile_btn.grid(row=num_channel_rows + 1, column=2, columnspan=2, pady=2)
+        self.save_profile_btn.grid(row=self._channel_button_row, column=2, columnspan=2, pady=2)
 
         # Thresholds
         self.thresholds_frame.pack(fill="x", padx=5, pady=2)
-        self.thresholds_label.grid(row=0, column=0, columnspan=4, sticky="w", padx=2, pady=1)
-
-        threshold_keys = list(self.threshold_entries.keys())
-        for i, key in enumerate(threshold_keys):
-            row = i + 1
-            self.threshold_labels[key].grid(row=row, column=0, padx=(2, 1), pady=1, sticky="e")
-            self.threshold_entries[key].grid(row=row, column=1, padx=1, pady=1, sticky="w")
+        self._repack_thresholds_grid()
 
         # Status
         self._pack_status()
 
-    def get_corner_threshold(self) -> float:
-        """Get the corner detection threshold."""
+    def _repack_thresholds_grid(self) -> None:
+        """Re-grid the active session's threshold labels/entries."""
+        for widget in self.thresholds_frame.winfo_children():
+            widget.grid_forget()
+
+        self.thresholds_label.grid(row=0, column=0, columnspan=4, sticky="w", padx=2, pady=1)
+
+        labels = self.threshold_labels
+        entries = self.threshold_entries
+
+        for i, key in enumerate(entries):
+            row = i + 1
+            labels[key].grid(row=row, column=0, padx=(2, 1), pady=1, sticky="e")
+            entries[key].grid(row=row, column=1, padx=1, pady=1, sticky="w")
+
+    def _get_threshold(self, key: str, default: float, entries: dict[str, ctk.CTkEntry]) -> float:
+        """Read a float threshold from the given entry dict."""
         try:
-            return float(self.threshold_entries["corner_threshold"].get())
+            return float(entries[key].get())
         except ValueError:
-            return DEFAULT_CORNER_THRESHOLD
+            return default
+
+    def get_corner_threshold(self) -> float:
+        """Get Session A corner detection threshold (backward compat)."""
+        return self.get_corner_threshold_a()
+
+    def get_corner_threshold_a(self) -> float:
+        """Get Session A corner detection threshold."""
+        return self._get_threshold(
+            "corner_threshold", DEFAULT_CORNER_THRESHOLD, self._threshold_entries_a
+        )
+
+    def get_corner_threshold_b(self) -> float:
+        """Get Session B corner detection threshold."""
+        if self._sync_with_a or self._threshold_entries_b is None:
+            return self.get_corner_threshold_a()
+        return self._get_threshold(
+            "corner_threshold", DEFAULT_CORNER_THRESHOLD, self._threshold_entries_b
+        )
 
     def get_throttle_threshold(self) -> float:
-        """Get the throttle acceptance threshold."""
-        try:
-            return float(self.threshold_entries["throttle_threshold"].get())
-        except ValueError:
-            return DEFAULT_THROTTLE_THRESHOLD
+        """Get Session A throttle acceptance threshold (backward compat)."""
+        return self.get_throttle_threshold_a()
+
+    def get_throttle_threshold_a(self) -> float:
+        """Get Session A throttle acceptance threshold."""
+        return self._get_threshold(
+            "throttle_threshold", DEFAULT_THROTTLE_THRESHOLD, self._threshold_entries_a
+        )
+
+    def get_throttle_threshold_b(self) -> float:
+        """Get Session B throttle acceptance threshold."""
+        if self._sync_with_a or self._threshold_entries_b is None:
+            return self.get_throttle_threshold_a()
+        return self._get_threshold(
+            "throttle_threshold", DEFAULT_THROTTLE_THRESHOLD, self._threshold_entries_b
+        )
 
     def set_throttle_threshold(self, value: float) -> None:
-        """Programmatically update the throttle threshold entry field."""
-        entry = self.threshold_entries["throttle_threshold"]
+        """Programmatically update the Session A throttle threshold entry field."""
+        entry = self._threshold_entries_a["throttle_threshold"]
+        entry.delete(0, "end")
+        entry.insert(0, f"{value:.1f}")
+
+    def set_throttle_threshold_b(self, value: float) -> None:
+        """Programmatically update the Session B throttle threshold entry field."""
+        if self._threshold_entries_b is None:
+            return
+        entry = self._threshold_entries_b["throttle_threshold"]
         entry.delete(0, "end")
         entry.insert(0, f"{value:.1f}")
 
     def get_sustain_time_ms(self) -> float:
-        """Get the sustain time in milliseconds."""
-        try:
-            return float(self.threshold_entries["sustain_time"].get())
-        except ValueError:
-            return DEFAULT_SUSTAIN_TIME_MS
+        """Get Session A sustain time in milliseconds (backward compat)."""
+        return self.get_sustain_time_ms_a()
+
+    def get_sustain_time_ms_a(self) -> float:
+        """Get Session A sustain time in milliseconds."""
+        return self._get_threshold(
+            "sustain_time", DEFAULT_SUSTAIN_TIME_MS, self._threshold_entries_a
+        )
+
+    def get_sustain_time_ms_b(self) -> float:
+        """Get Session B sustain time in milliseconds."""
+        if self._sync_with_a or self._threshold_entries_b is None:
+            return self.get_sustain_time_ms_a()
+        return self._get_threshold(
+            "sustain_time", DEFAULT_SUSTAIN_TIME_MS, self._threshold_entries_b
+        )
 
     def _on_save_profile_click(self) -> None:
         """Handle Save Profile button click."""
@@ -180,7 +253,7 @@ class ConfigPanel(BaseConfigPanel):
             self._on_save_profile()
 
     def set_from_profile(self, profile: VehicleProfile) -> None:
-        """Populate channel entries from a VehicleProfile.
+        """Populate Session A channel entries from a VehicleProfile.
 
         Maps from the shared profile's canonical keys (gps_latitude,
         gps_longitude) to this app's local keys (gps_lat, gps_lon).
@@ -193,12 +266,28 @@ class ConfigPanel(BaseConfigPanel):
         for profile_key, channel_value in profile.channel_names.items():
             # Map profile key to local key (e.g. gps_latitude -> gps_lat)
             local_key = _PROFILE_KEY_TO_LOCAL.get(profile_key, profile_key)
-            if local_key in self.channel_entries:
-                self.channel_entries[local_key].delete(0, "end")
-                self.channel_entries[local_key].insert(0, channel_value)
+            if local_key in self._channel_entries_a:
+                self._channel_entries_a[local_key].delete(0, "end")
+                self._channel_entries_a[local_key].insert(0, channel_value)
+
+    def set_from_profile_b(self, profile: VehicleProfile) -> None:
+        """Populate Session B channel entries from a VehicleProfile.
+
+        Parameters
+        ----------
+        profile : VehicleProfile
+            The profile to populate B entries from.
+        """
+        self._ensure_b_entries()
+        assert self._channel_entries_b is not None
+        for profile_key, channel_value in profile.channel_names.items():
+            local_key = _PROFILE_KEY_TO_LOCAL.get(profile_key, profile_key)
+            if local_key in self._channel_entries_b:
+                self._channel_entries_b[local_key].delete(0, "end")
+                self._channel_entries_b[local_key].insert(0, channel_value)
 
     def get_vehicle_profile(self, name: str) -> VehicleProfile:
-        """Build a VehicleProfile from current field values.
+        """Build a VehicleProfile from Session A's current field values.
 
         Maps local keys back to the shared profile's canonical keys.
 
@@ -212,13 +301,36 @@ class ConfigPanel(BaseConfigPanel):
         VehicleProfile
             Profile with current field values.
         """
+        return self._build_profile_from_entries(name, self._channel_entries_a)
+
+    def get_vehicle_profile_b(self, name: str) -> VehicleProfile:
+        """Build a VehicleProfile from Session B's current field values.
+
+        Parameters
+        ----------
+        name : str
+            Name for the profile.
+
+        Returns
+        -------
+        VehicleProfile
+            Profile with B's channel names.
+        """
+        if self._sync_with_a or self._channel_entries_b is None:
+            return self._build_profile_from_entries(name, self._channel_entries_a)
+        return self._build_profile_from_entries(name, self._channel_entries_b)
+
+    def _build_profile_from_entries(
+        self, name: str, entries: dict[str, AutocompleteEntry]
+    ) -> VehicleProfile:
+        """Build a VehicleProfile from a set of channel entries."""
         from motorsports_data_notebook.profiles import VehicleProfile
         from motorsports_data_notebook.suspension import MotionRatios
 
         # Map local keys back to profile keys
         local_to_profile = {v: k for k, v in _PROFILE_KEY_TO_LOCAL.items()}
         channel_names: dict[str, str] = {}
-        for local_key, entry in self.channel_entries.items():
+        for local_key, entry in entries.items():
             profile_key = local_to_profile.get(local_key, local_key)
             channel_names[profile_key] = entry.get() or self._default_channels[local_key]
 
@@ -227,3 +339,46 @@ class ConfigPanel(BaseConfigPanel):
             channel_names=channel_names,
             motion_ratios=MotionRatios(),
         )
+
+    # ------------------------------------------------------------------
+    # BaseConfigPanel hooks for per-session thresholds
+    # ------------------------------------------------------------------
+
+    def _create_b_extra(self) -> None:
+        """Create Session B threshold entries."""
+        self._threshold_entries_b = {}
+        self._threshold_labels_b = {}
+        for key, (display_name, _) in self._THRESHOLD_CONFIG.items():
+            self._threshold_labels_b[key] = ctk.CTkLabel(
+                self.thresholds_frame,
+                text=display_name,
+                font=ctk.CTkFont(size=11),
+            )
+            self._threshold_entries_b[key] = ctk.CTkEntry(
+                self.thresholds_frame,
+                width=80,
+                font=ctk.CTkFont(size=11),
+            )
+            # Initialize from A
+            self._threshold_entries_b[key].insert(0, self._threshold_entries_a[key].get())
+            self._threshold_entries_b[key].bind("<KeyRelease>", self._on_entry_changed)
+
+    def _repack_extra_widgets(self) -> None:
+        """Swap threshold entries when session changes."""
+        self._repack_thresholds_grid()
+
+    def _copy_extra_a_to_b(self) -> None:
+        """Copy A thresholds to B."""
+        if self._threshold_entries_b is None:
+            return
+        for key in self._threshold_entries_a:
+            val = self._threshold_entries_a[key].get()
+            self._threshold_entries_b[key].delete(0, "end")
+            self._threshold_entries_b[key].insert(0, val)
+
+    def _apply_extra_sync_state(self, state: str) -> None:
+        """Enable/disable B threshold entries."""
+        if self._threshold_entries_b is None:
+            return
+        for entry in self._threshold_entries_b.values():
+            entry.configure(state=state)

--- a/desktop_app/src/inferno_analyzer/suspension/widgets/config_panel.py
+++ b/desktop_app/src/inferno_analyzer/suspension/widgets/config_panel.py
@@ -58,8 +58,15 @@ class ConfigPanel(BaseConfigPanel):
         self._create_save_profile_btn()
         self._layout_widgets()
 
+    _RATIO_CORNERS = [
+        ("FL", "front_left"),
+        ("FR", "front_right"),
+        ("RL", "rear_left"),
+        ("RR", "rear_right"),
+    ]
+
     def _create_ratio_widgets(self) -> None:
-        """Create motion ratio input widgets."""
+        """Create motion ratio input widgets (Session A)."""
         self.ratios_frame = ctk.CTkFrame(self)
         self.ratios_label = ctk.CTkLabel(
             self.ratios_frame,
@@ -67,27 +74,25 @@ class ConfigPanel(BaseConfigPanel):
             font=ctk.CTkFont(size=12, weight="bold"),
         )
 
-        self.ratio_entries: dict[str, ctk.CTkEntry] = {}
-        self.ratio_labels: dict[str, ctk.CTkLabel] = {}
+        self._ratio_entries_a: dict[str, ctk.CTkEntry] = {}
+        self._ratio_labels_a: dict[str, ctk.CTkLabel] = {}
+        self._ratio_entries_b: dict[str, ctk.CTkEntry] | None = None
+        self._ratio_labels_b: dict[str, ctk.CTkLabel] | None = None
 
-        for corner, default_val in [
-            ("FL", self._default_ratios.front_left),
-            ("FR", self._default_ratios.front_right),
-            ("RL", self._default_ratios.rear_left),
-            ("RR", self._default_ratios.rear_right),
-        ]:
-            self.ratio_labels[corner] = ctk.CTkLabel(
+        for corner, attr in self._RATIO_CORNERS:
+            default_val = getattr(self._default_ratios, attr)
+            self._ratio_labels_a[corner] = ctk.CTkLabel(
                 self.ratios_frame,
                 text=f"{corner}:",
                 font=ctk.CTkFont(size=11),
             )
-            self.ratio_entries[corner] = ctk.CTkEntry(
+            self._ratio_entries_a[corner] = ctk.CTkEntry(
                 self.ratios_frame,
                 width=80,
                 font=ctk.CTkFont(size=11),
             )
-            self.ratio_entries[corner].insert(0, f"{default_val:.3f}")
-            self.ratio_entries[corner].bind("<KeyRelease>", self._on_entry_changed)
+            self._ratio_entries_a[corner].insert(0, f"{default_val:.3f}")
+            self._ratio_entries_a[corner].bind("<KeyRelease>", self._on_entry_changed)
 
         self.reset_ratios_btn = ctk.CTkButton(
             self.ratios_frame,
@@ -97,6 +102,20 @@ class ConfigPanel(BaseConfigPanel):
             font=ctk.CTkFont(size=10),
             command=self._reset_ratios,
         )
+
+    @property
+    def ratio_entries(self) -> dict[str, ctk.CTkEntry]:
+        """Return the active session's ratio entries."""
+        if self._active_session == "B" and self._ratio_entries_b is not None:
+            return self._ratio_entries_b
+        return self._ratio_entries_a
+
+    @property
+    def ratio_labels(self) -> dict[str, ctk.CTkLabel]:
+        """Return the active session's ratio labels."""
+        if self._active_session == "B" and self._ratio_labels_b is not None:
+            return self._ratio_labels_b
+        return self._ratio_labels_a
 
     def _create_save_profile_btn(self) -> None:
         """Create the Save Profile button (placed in channels frame)."""
@@ -115,29 +134,38 @@ class ConfigPanel(BaseConfigPanel):
 
         # Motion ratios frame
         self.ratios_frame.pack(fill="x", padx=5, pady=2)
-        self.ratios_label.grid(row=0, column=0, columnspan=4, sticky="w", padx=2, pady=1)
-
-        self.ratio_labels["FL"].grid(row=1, column=0, padx=(2, 1), pady=1, sticky="e")
-        self.ratio_entries["FL"].grid(row=1, column=1, padx=1, pady=1)
-        self.ratio_labels["FR"].grid(row=1, column=2, padx=(5, 1), pady=1, sticky="e")
-        self.ratio_entries["FR"].grid(row=1, column=3, padx=1, pady=1)
-
-        self.ratio_labels["RL"].grid(row=2, column=0, padx=(2, 1), pady=1, sticky="e")
-        self.ratio_entries["RL"].grid(row=2, column=1, padx=1, pady=1)
-        self.ratio_labels["RR"].grid(row=2, column=2, padx=(5, 1), pady=1, sticky="e")
-        self.ratio_entries["RR"].grid(row=2, column=3, padx=1, pady=1)
-
-        self.reset_ratios_btn.grid(row=3, column=0, columnspan=4, pady=2)
+        self._repack_ratios_grid()
 
         # Channels + status (from base class)
         self._pack_channels()
 
         # Add save profile button next to reset channels button
-        num_channel_rows = (len(self.channel_entries) + 1) // 2
         self.reset_channels_btn.grid_configure(columnspan=2)
-        self.save_profile_btn.grid(row=num_channel_rows + 1, column=2, columnspan=2, pady=2)
+        self.save_profile_btn.grid(row=self._channel_button_row, column=2, columnspan=2, pady=2)
 
         self._pack_status()
+
+    def _repack_ratios_grid(self) -> None:
+        """Re-grid the active session's ratio labels/entries."""
+        for widget in self.ratios_frame.winfo_children():
+            widget.grid_forget()
+
+        self.ratios_label.grid(row=0, column=0, columnspan=4, sticky="w", padx=2, pady=1)
+
+        labels = self.ratio_labels
+        entries = self.ratio_entries
+
+        labels["FL"].grid(row=1, column=0, padx=(2, 1), pady=1, sticky="e")
+        entries["FL"].grid(row=1, column=1, padx=1, pady=1)
+        labels["FR"].grid(row=1, column=2, padx=(5, 1), pady=1, sticky="e")
+        entries["FR"].grid(row=1, column=3, padx=1, pady=1)
+
+        labels["RL"].grid(row=2, column=0, padx=(2, 1), pady=1, sticky="e")
+        entries["RL"].grid(row=2, column=1, padx=1, pady=1)
+        labels["RR"].grid(row=2, column=2, padx=(5, 1), pady=1, sticky="e")
+        entries["RR"].grid(row=2, column=3, padx=1, pady=1)
+
+        self.reset_ratios_btn.grid(row=3, column=0, columnspan=4, pady=2)
 
     def _on_save_profile_click(self) -> None:
         """Handle Save Profile button click."""
@@ -145,32 +173,49 @@ class ConfigPanel(BaseConfigPanel):
             self._on_save_profile()
 
     def set_from_profile(self, profile: VehicleProfile) -> None:
-        """Populate all fields from a VehicleProfile.
+        """Populate all fields from a VehicleProfile (Session A).
 
         Parameters
         ----------
         profile : VehicleProfile
             The profile to populate from.
         """
-        # Set motion ratios
-        ratios = {
-            "FL": profile.motion_ratios.front_left,
-            "FR": profile.motion_ratios.front_right,
-            "RL": profile.motion_ratios.rear_left,
-            "RR": profile.motion_ratios.rear_right,
-        }
-        for corner, val in ratios.items():
-            self.ratio_entries[corner].delete(0, "end")
-            self.ratio_entries[corner].insert(0, f"{val:.3f}")
+        # Set motion ratios (A)
+        for corner, attr in self._RATIO_CORNERS:
+            val = getattr(profile.motion_ratios, attr)
+            self._ratio_entries_a[corner].delete(0, "end")
+            self._ratio_entries_a[corner].insert(0, f"{val:.3f}")
 
-        # Set channel names
-        for key, entry in self.channel_entries.items():
+        # Set channel names (explicitly target A entries)
+        for key, entry in self._channel_entries_a.items():
             if key in profile.channel_names:
                 entry.delete(0, "end")
                 entry.insert(0, profile.channel_names[key])
 
+    def set_from_profile_b(self, profile: VehicleProfile) -> None:
+        """Populate Session B entries from a VehicleProfile.
+
+        Parameters
+        ----------
+        profile : VehicleProfile
+            The profile to populate B entries from.
+        """
+        self._ensure_b_entries()
+        assert self._channel_entries_b is not None
+        assert self._ratio_entries_b is not None
+
+        for key, entry in self._channel_entries_b.items():
+            if key in profile.channel_names:
+                entry.delete(0, "end")
+                entry.insert(0, profile.channel_names[key])
+
+        for corner, attr in self._RATIO_CORNERS:
+            val = getattr(profile.motion_ratios, attr)
+            self._ratio_entries_b[corner].delete(0, "end")
+            self._ratio_entries_b[corner].insert(0, f"{val:.3f}")
+
     def get_vehicle_profile(self, name: str) -> VehicleProfile:
-        """Build a VehicleProfile from current field values.
+        """Build a VehicleProfile from Session A's current field values.
 
         Parameters
         ----------
@@ -186,38 +231,111 @@ class ConfigPanel(BaseConfigPanel):
 
         return VehicleProfile(
             name=name,
-            channel_names=self.get_channel_names(),
-            motion_ratios=self.get_motion_ratios(),
+            channel_names=self.get_channel_names_a(),
+            motion_ratios=self.get_motion_ratios_a(),
         )
 
-    def _reset_ratios(self) -> None:
-        """Reset motion ratios to Toyota 86 defaults."""
-        defaults = MotionRatios.toyota_86_zn6()
-        values = {
-            "FL": defaults.front_left,
-            "FR": defaults.front_right,
-            "RL": defaults.rear_left,
-            "RR": defaults.rear_right,
-        }
-        for corner, val in values.items():
-            self.ratio_entries[corner].delete(0, "end")
-            self.ratio_entries[corner].insert(0, f"{val:.3f}")
-        self._on_entry_changed()
+    def get_vehicle_profile_b(self, name: str) -> VehicleProfile:
+        """Build a VehicleProfile from Session B's current field values.
 
-    def get_motion_ratios(self) -> MotionRatios:
-        """Get current motion ratio values.
+        Parameters
+        ----------
+        name : str
+            Name for the profile.
 
         Returns
         -------
-        MotionRatios
-            Motion ratios from the input fields.
+        VehicleProfile
+            Profile with B's channel names and motion ratios.
         """
+        from motorsports_data_notebook.profiles import VehicleProfile
+
+        return VehicleProfile(
+            name=name,
+            channel_names=self.get_channel_names_b(),
+            motion_ratios=self.get_motion_ratios_b(),
+        )
+
+    def _reset_ratios(self) -> None:
+        """Reset motion ratios to Toyota 86 defaults for the active session."""
+        defaults = MotionRatios.toyota_86_zn6()
+        entries = self.ratio_entries
+        for corner, attr in self._RATIO_CORNERS:
+            val = getattr(defaults, attr)
+            entries[corner].delete(0, "end")
+            entries[corner].insert(0, f"{val:.3f}")
+        if self._active_session == "A" and self._sync_with_a:
+            self._copy_extra_a_to_b()
+        self._on_entry_changed()
+
+    def _ratios_from_entries(self, entries: dict[str, ctk.CTkEntry]) -> MotionRatios:
+        """Parse MotionRatios from a set of entry widgets."""
         try:
             return MotionRatios(
-                front_left=float(self.ratio_entries["FL"].get()),
-                front_right=float(self.ratio_entries["FR"].get()),
-                rear_left=float(self.ratio_entries["RL"].get()),
-                rear_right=float(self.ratio_entries["RR"].get()),
+                front_left=float(entries["FL"].get()),
+                front_right=float(entries["FR"].get()),
+                rear_left=float(entries["RL"].get()),
+                rear_right=float(entries["RR"].get()),
             )
         except ValueError:
             return MotionRatios.toyota_86_zn6()
+
+    def get_motion_ratios(self) -> MotionRatios:
+        """Get motion ratios for Session A (backward compat)."""
+        return self.get_motion_ratios_a()
+
+    def get_motion_ratios_a(self) -> MotionRatios:
+        """Get Session A motion ratio values."""
+        return self._ratios_from_entries(self._ratio_entries_a)
+
+    def get_motion_ratios_b(self) -> MotionRatios:
+        """Get Session B motion ratio values.
+
+        Returns A's values if synced or B entries don't exist.
+        """
+        if self._sync_with_a or self._ratio_entries_b is None:
+            return self.get_motion_ratios_a()
+        return self._ratios_from_entries(self._ratio_entries_b)
+
+    # ------------------------------------------------------------------
+    # BaseConfigPanel hooks for per-session motion ratios
+    # ------------------------------------------------------------------
+
+    def _create_b_extra(self) -> None:
+        """Create Session B motion ratio entries."""
+        self._ratio_entries_b = {}
+        self._ratio_labels_b = {}
+        for corner, _ in self._RATIO_CORNERS:
+            self._ratio_labels_b[corner] = ctk.CTkLabel(
+                self.ratios_frame,
+                text=f"{corner}:",
+                font=ctk.CTkFont(size=11),
+            )
+            self._ratio_entries_b[corner] = ctk.CTkEntry(
+                self.ratios_frame,
+                width=80,
+                font=ctk.CTkFont(size=11),
+            )
+            # Initialize from A
+            self._ratio_entries_b[corner].insert(0, self._ratio_entries_a[corner].get())
+            self._ratio_entries_b[corner].bind("<KeyRelease>", self._on_entry_changed)
+
+    def _repack_extra_widgets(self) -> None:
+        """Swap ratio entries when session changes."""
+        self._repack_ratios_grid()
+
+    def _copy_extra_a_to_b(self) -> None:
+        """Copy A motion ratios to B."""
+        if self._ratio_entries_b is None:
+            return
+        for corner in self._ratio_entries_a:
+            val = self._ratio_entries_a[corner].get()
+            self._ratio_entries_b[corner].delete(0, "end")
+            self._ratio_entries_b[corner].insert(0, val)
+
+    def _apply_extra_sync_state(self, state: str) -> None:
+        """Enable/disable B motion ratio entries."""
+        if self._ratio_entries_b is None:
+            return
+        for entry in self._ratio_entries_b.values():
+            entry.configure(state=state)

--- a/desktop_app/src/inferno_analyzer/tabs/base_tab.py
+++ b/desktop_app/src/inferno_analyzer/tabs/base_tab.py
@@ -57,15 +57,16 @@ class BaseAnalysisTab(ABC):
         """Arrange tab-specific widgets."""
 
     @abstractmethod
-    def _get_analysis_params(self) -> dict | None:
+    def _get_analysis_params(self) -> Any:
         """Read config from the tab's config panel.
 
         Returns None if analysis cannot proceed (e.g., no session loaded,
-        no laps selected).
+        no laps selected). Subclasses return a TypedDict specific to their
+        analysis type.
         """
 
     @abstractmethod
-    def _analysis_worker(self, params: dict) -> None:
+    def _analysis_worker(self, params: Any) -> None:
         """Run the analysis in a background thread.
 
         Must store results in self._result_a / self._result_b and call

--- a/desktop_app/src/inferno_analyzer/tabs/driver_tab.py
+++ b/desktop_app/src/inferno_analyzer/tabs/driver_tab.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import customtkinter as ctk
@@ -21,6 +22,23 @@ from inferno_analyzer.tabs.base_tab import BaseAnalysisTab
 
 if TYPE_CHECKING:
     from inferno_analyzer.app import InfernoAnalyzerApp
+    from libxrk.base import LogFile
+
+
+@dataclass
+class DriverParams:
+    session_a: LogFile
+    laps_a: list[int]
+    session_b: LogFile | None
+    laps_b: list[int]
+    channel_names_a: dict[str, str]
+    channel_names_b: dict[str, str]
+    corner_threshold_a: float
+    corner_threshold_b: float
+    throttle_threshold_a: float
+    throttle_threshold_b: float
+    sustain_time_ms_a: float
+    sustain_time_ms_b: float
 
 
 class DriverTab(BaseAnalysisTab):
@@ -53,7 +71,7 @@ class DriverTab(BaseAnalysisTab):
         self.corner_selector.pack(side="left", fill="y", padx=(0, 5))
         self.chart_view.pack(side="left", fill="both", expand=True)
 
-    def _get_analysis_params(self) -> dict | None:
+    def _get_analysis_params(self) -> DriverParams | None:
         session_a = self.app.session_a_panel.log
         if session_a is None:
             return None
@@ -72,40 +90,39 @@ class DriverTab(BaseAnalysisTab):
                 return None
 
         config_panel = self.app.driver_config_panel
-        channel_names = config_panel.get_channel_names()
-        corner_threshold = config_panel.get_corner_threshold()
-        throttle_threshold = config_panel.get_throttle_threshold()
-        sustain_time_ms = config_panel.get_sustain_time_ms()
-
-        return {
-            "session_a": session_a,
-            "laps_a": laps_a,
-            "session_b": session_b,
-            "laps_b": laps_b,
-            "channel_names": channel_names,
-            "corner_threshold": corner_threshold,
-            "throttle_threshold": throttle_threshold,
-            "sustain_time_ms": sustain_time_ms,
-        }
-
-    def _analysis_worker(self, params: dict) -> None:
-        self._result_a = analyze_driver_consistency(
-            params["session_a"],
-            params["laps_a"],
-            params["channel_names"],
-            corner_threshold=params["corner_threshold"],
-            throttle_threshold=params["throttle_threshold"],
-            sustain_time_ms=params["sustain_time_ms"],
+        return DriverParams(
+            session_a=session_a,
+            laps_a=laps_a,
+            session_b=session_b,
+            laps_b=laps_b,
+            channel_names_a=config_panel.get_channel_names_a(),
+            channel_names_b=config_panel.get_channel_names_b(),
+            corner_threshold_a=config_panel.get_corner_threshold_a(),
+            corner_threshold_b=config_panel.get_corner_threshold_b(),
+            throttle_threshold_a=config_panel.get_throttle_threshold_a(),
+            throttle_threshold_b=config_panel.get_throttle_threshold_b(),
+            sustain_time_ms_a=config_panel.get_sustain_time_ms_a(),
+            sustain_time_ms_b=config_panel.get_sustain_time_ms_b(),
         )
 
-        if params["laps_b"] and params["session_b"] is not None:
+    def _analysis_worker(self, params: DriverParams) -> None:
+        self._result_a = analyze_driver_consistency(
+            params.session_a,
+            params.laps_a,
+            params.channel_names_a,
+            corner_threshold=params.corner_threshold_a,
+            throttle_threshold=params.throttle_threshold_a,
+            sustain_time_ms=params.sustain_time_ms_a,
+        )
+
+        if params.laps_b and params.session_b is not None:
             self._result_b = analyze_driver_consistency(
-                params["session_b"],
-                params["laps_b"],
-                params["channel_names"],
-                corner_threshold=params["corner_threshold"],
-                throttle_threshold=params["throttle_threshold"],
-                sustain_time_ms=params["sustain_time_ms"],
+                params.session_b,
+                params.laps_b,
+                params.channel_names_b,
+                corner_threshold=params.corner_threshold_b,
+                throttle_threshold=params.throttle_threshold_b,
+                sustain_time_ms=params.sustain_time_ms_b,
             )
         else:
             self._result_b = None
@@ -158,11 +175,18 @@ class DriverTab(BaseAnalysisTab):
         self._result_b = None
         self._stale = True
         self._auto_set_throttle_threshold()
-        self._last_throttle_channel = self.app.driver_config_panel.get_channel_names()["throttle"]
+        self._last_throttle_channel = self.app.driver_config_panel.get_channel_names_a()["throttle"]
+
+    def on_session_b_loaded(self) -> None:
+        """Called when Session B file is loaded — auto-set B's throttle threshold."""
+        self._result_a = None
+        self._result_b = None
+        self._stale = True
+        self._auto_set_throttle_threshold_b()
 
     def on_selection_changed(self) -> None:
         """Override to handle throttle channel change → auto-threshold."""
-        current_throttle = self.app.driver_config_panel.get_channel_names()["throttle"]
+        current_throttle = self.app.driver_config_panel.get_channel_names_a()["throttle"]
         if (
             self._last_throttle_channel is not None
             and current_throttle != self._last_throttle_channel
@@ -177,12 +201,12 @@ class DriverTab(BaseAnalysisTab):
     # ------------------------------------------------------------------
 
     def _auto_set_throttle_threshold(self) -> bool:
-        """Set throttle threshold to 95% of peak throttle channel value."""
+        """Set Session A throttle threshold to 95% of peak throttle channel value."""
         log = self.app.session_a_panel.log
         if log is None:
             return False
 
-        throttle_name = self.app.driver_config_panel.get_channel_names()["throttle"]
+        throttle_name = self.app.driver_config_panel.get_channel_names_a()["throttle"]
         if throttle_name not in log.channels:
             return False
 
@@ -197,13 +221,34 @@ class DriverTab(BaseAnalysisTab):
         except Exception:
             return False
 
+    def _auto_set_throttle_threshold_b(self) -> bool:
+        """Set Session B throttle threshold to 95% of peak throttle channel value."""
+        log = self.app.session_b_panel.log
+        if log is None:
+            return False
+
+        throttle_name = self.app.driver_config_panel.get_channel_names_b()["throttle"]
+        if throttle_name not in log.channels:
+            return False
+
+        try:
+            data = log.channels[throttle_name].column(throttle_name).to_numpy()
+            peak = float(np.nanpercentile(data, 95))
+            if peak <= 0:
+                return False
+            threshold = round(peak * 0.95, 1)
+            self.app.driver_config_panel.set_throttle_threshold_b(threshold)
+            return True
+        except Exception:
+            return False
+
     def _diagnose_empty_ta(self) -> str:
         """Suggest why TA values are empty."""
         log = self.app.session_a_panel.log
         if log is None:
             return "try lower threshold"
 
-        lateral_g_name = self.app.driver_config_panel.get_channel_names()["lateral_g"]
+        lateral_g_name = self.app.driver_config_panel.get_channel_names_a()["lateral_g"]
         if lateral_g_name not in log.channels:
             return f"Lat G channel '{lateral_g_name}' not found"
 

--- a/desktop_app/src/inferno_analyzer/tabs/suspension_tab.py
+++ b/desktop_app/src/inferno_analyzer/tabs/suspension_tab.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import customtkinter as ctk
@@ -13,7 +14,20 @@ from inferno_analyzer.tabs.base_tab import BaseAnalysisTab
 
 if TYPE_CHECKING:
     from inferno_analyzer.app import InfernoAnalyzerApp
-    from motorsports_data_notebook.suspension import VelocityHistogramResult
+    from libxrk.base import LogFile
+    from motorsports_data_notebook.suspension import MotionRatios, VelocityHistogramResult
+
+
+@dataclass
+class SuspensionParams:
+    session_a: LogFile
+    laps_a: list[int]
+    session_b: LogFile | None
+    laps_b: list[int]
+    channel_names_a: dict[str, str]
+    channel_names_b: dict[str, str]
+    motion_ratios_a: MotionRatios
+    motion_ratios_b: MotionRatios
 
 
 class SuspensionTab(BaseAnalysisTab):
@@ -35,7 +49,7 @@ class SuspensionTab(BaseAnalysisTab):
     def _layout_tab_widgets(self) -> None:
         self.chart_view.pack(fill="both", expand=True)
 
-    def _get_analysis_params(self) -> dict | None:
+    def _get_analysis_params(self) -> SuspensionParams | None:
         session_a = self.app.session_a_panel.log
         if session_a is None:
             return None
@@ -54,32 +68,31 @@ class SuspensionTab(BaseAnalysisTab):
                 return None
 
         config_panel = self.app.suspension_config_panel
-        motion_ratios = config_panel.get_motion_ratios()
-        channel_names = config_panel.get_channel_names()
-
-        return {
-            "session_a": session_a,
-            "laps_a": laps_a,
-            "session_b": session_b,
-            "laps_b": laps_b,
-            "motion_ratios": motion_ratios,
-            "channel_names": channel_names,
-        }
-
-    def _analysis_worker(self, params: dict) -> None:
-        self._result_a = analyze_suspension_velocity_multi_lap(
-            params["session_a"],
-            params["laps_a"],
-            channel_names=params["channel_names"],
-            motion_ratios=params["motion_ratios"],
+        return SuspensionParams(
+            session_a=session_a,
+            laps_a=laps_a,
+            session_b=session_b,
+            laps_b=laps_b,
+            channel_names_a=config_panel.get_channel_names_a(),
+            channel_names_b=config_panel.get_channel_names_b(),
+            motion_ratios_a=config_panel.get_motion_ratios_a(),
+            motion_ratios_b=config_panel.get_motion_ratios_b(),
         )
 
-        if params["laps_b"] and params["session_b"] is not None:
+    def _analysis_worker(self, params: SuspensionParams) -> None:
+        self._result_a = analyze_suspension_velocity_multi_lap(
+            params.session_a,
+            params.laps_a,
+            channel_names=params.channel_names_a,
+            motion_ratios=params.motion_ratios_a,
+        )
+
+        if params.laps_b and params.session_b is not None:
             self._result_b = analyze_suspension_velocity_multi_lap(
-                params["session_b"],
-                params["laps_b"],
-                channel_names=params["channel_names"],
-                motion_ratios=params["motion_ratios"],
+                params.session_b,
+                params.laps_b,
+                channel_names=params.channel_names_b,
+                motion_ratios=params.motion_ratios_b,
             )
         else:
             self._result_b = None

--- a/src/motorsports_data_notebook/desktop/config_panel.py
+++ b/src/motorsports_data_notebook/desktop/config_panel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tkinter as tk
 from typing import Callable
 
 import customtkinter as ctk
@@ -15,6 +16,10 @@ class BaseConfigPanel(ctk.CTkFrame):
     Provides title label, channel name entries with autocomplete,
     reset button, and status/statistics controls. Subclasses add
     domain-specific sections and call layout methods.
+
+    Supports per-session (A/B) channel entries for cross-vehicle comparison.
+    Session B entries are created lazily when needed. A sync checkbox lets
+    users keep B in sync with A (default) or edit independently.
     """
 
     def __init__(
@@ -25,25 +30,25 @@ class BaseConfigPanel(ctk.CTkFrame):
         on_stats_click: Callable[[], None] | None = None,
         on_config_changed: Callable[[], None] | None = None,
     ) -> None:
-        """Initialize the config panel.
-
-        Parameters
-        ----------
-        parent : ctk.CTkFrame
-            Parent widget.
-        channel_defaults : dict[str, str]
-            Default channel name mappings (key -> default value).
-        channel_display_names : dict[str, str]
-            Display labels for channel entries (key -> label text).
-        on_stats_click : callable, optional
-            Callback when statistics button is clicked.
-        on_config_changed : callable, optional
-            Callback when any configuration value changes.
-        """
         super().__init__(parent)
         self._default_channels = channel_defaults
+        self._channel_display_names = channel_display_names
         self._on_stats_click = on_stats_click
         self._on_config_changed = on_config_changed
+
+        # Session state
+        self._active_session: str = "A"
+        self._sync_with_a: bool = True
+        self._sync_var = tk.BooleanVar(value=True)
+
+        # Suggestion lists per session
+        self._suggestions_a: list[str] = []
+        self._suggestions_b: list[str] = []
+
+        # B entries (lazily created)
+        self._channel_entries_b: dict[str, AutocompleteEntry] | None = None
+        self._channel_labels_b: dict[str, ctk.CTkLabel] | None = None
+
         self._create_base_widgets(channel_display_names)
 
     def _create_base_widgets(self, channel_display_names: dict[str, str]) -> None:
@@ -63,23 +68,23 @@ class BaseConfigPanel(ctk.CTkFrame):
             font=ctk.CTkFont(size=12, weight="bold"),
         )
 
-        # Channel name entries
-        self.channel_entries: dict[str, AutocompleteEntry] = {}
-        self.channel_labels: dict[str, ctk.CTkLabel] = {}
+        # Session A channel name entries
+        self._channel_entries_a: dict[str, AutocompleteEntry] = {}
+        self._channel_labels_a: dict[str, ctk.CTkLabel] = {}
 
         for key, display_name in channel_display_names.items():
-            self.channel_labels[key] = ctk.CTkLabel(
+            self._channel_labels_a[key] = ctk.CTkLabel(
                 self.channels_frame,
                 text=display_name,
                 font=ctk.CTkFont(size=11),
             )
-            self.channel_entries[key] = AutocompleteEntry(
+            self._channel_entries_a[key] = AutocompleteEntry(
                 self.channels_frame,
                 width=120,
                 font=ctk.CTkFont(size=11),
                 on_change=self._on_entry_changed,
             )
-            self.channel_entries[key].insert(0, self._default_channels[key])
+            self._channel_entries_a[key].insert(0, self._default_channels[key])
 
         # Reset channels button
         self.reset_channels_btn = ctk.CTkButton(
@@ -89,6 +94,28 @@ class BaseConfigPanel(ctk.CTkFrame):
             height=24,
             font=ctk.CTkFont(size=10),
             command=self._reset_channels,
+        )
+
+        # Session selector (hidden initially)
+        self._session_selector = ctk.CTkSegmentedButton(
+            self.channels_frame,
+            values=["Session A", "Session B"],
+            command=self._on_session_selector_changed,
+            font=ctk.CTkFont(size=10),
+            height=24,
+        )
+        self._session_selector.set("Session A")
+
+        # Sync checkbox (hidden initially)
+        self._sync_checkbox = ctk.CTkCheckBox(
+            self.channels_frame,
+            text="Sync with A",
+            variable=self._sync_var,
+            command=self._on_sync_toggled,
+            font=ctk.CTkFont(size=10),
+            height=20,
+            checkbox_width=16,
+            checkbox_height=16,
         )
 
         # Status and actions frame
@@ -108,36 +135,304 @@ class BaseConfigPanel(ctk.CTkFrame):
             command=self._on_stats_btn_click,
         )
 
-    def _pack_channels(self) -> None:
-        """Pack the channels frame with dynamic 2-column grid layout."""
-        self.channels_frame.pack(fill="x", padx=5, pady=2)
-        self.channels_label.grid(row=0, column=0, columnspan=4, sticky="w", padx=2, pady=1)
+    # ------------------------------------------------------------------
+    # Backward-compatible properties: channel_entries / channel_labels
+    # return the active session's entries so subclass layout code works.
+    # ------------------------------------------------------------------
 
-        keys = list(self.channel_entries.keys())
+    @property
+    def channel_entries(self) -> dict[str, AutocompleteEntry]:
+        """Return the active session's channel entries."""
+        if self._active_session == "B" and self._channel_entries_b is not None:
+            return self._channel_entries_b
+        return self._channel_entries_a
+
+    @property
+    def channel_labels(self) -> dict[str, ctk.CTkLabel]:
+        """Return the active session's channel labels."""
+        if self._active_session == "B" and self._channel_labels_b is not None:
+            return self._channel_labels_b
+        return self._channel_labels_a
+
+    # ------------------------------------------------------------------
+    # Channel grid layout
+    # ------------------------------------------------------------------
+
+    def _pack_channels(self) -> None:
+        """Pack the channels frame and lay out the channel grid."""
+        self.channels_frame.pack(fill="x", padx=5, pady=2)
+        self._repack_channel_grid()
+
+    def _repack_channel_grid(self) -> None:
+        """Re-grid channel labels/entries for the active session.
+
+        Layout:
+          Row 0: "Channel Names:" label
+          Row 1: session selector + sync checkbox (only when B entries exist)
+          Row 2+: channel label/entry pairs in 2-column layout
+          Last row: reset button
+
+        Sets ``self._channel_button_row`` for subclass save-button placement.
+        """
+        # Ungrid everything in channels_frame
+        for widget in self.channels_frame.winfo_children():
+            widget.grid_forget()
+
+        row = 0
+        # Row 0: section header
+        self.channels_label.grid(row=row, column=0, columnspan=4, sticky="w", padx=2, pady=1)
+        row += 1
+
+        # Row 1: session selector + sync (only when B entries exist)
+        if self._channel_entries_b is not None:
+            self._session_selector.grid(row=row, column=0, columnspan=3, padx=2, pady=2, sticky="w")
+            if self._active_session == "B":
+                self._sync_checkbox.grid(row=row, column=3, padx=2, pady=2, sticky="e")
+            row += 1
+
+        # Active entries
+        entries = self.channel_entries
+        labels = self.channel_labels
+
+        keys = list(entries.keys())
         for i, key in enumerate(keys):
-            row = (i // 2) + 1
+            grid_row = (i // 2) + row
             col_offset = (i % 2) * 2
             padx_label = (2, 1) if col_offset == 0 else (5, 1)
-            self.channel_labels[key].grid(
-                row=row, column=col_offset, padx=padx_label, pady=1, sticky="e"
-            )
-            self.channel_entries[key].grid(
-                row=row, column=col_offset + 1, padx=1, pady=1, sticky="w"
-            )
+            labels[key].grid(row=grid_row, column=col_offset, padx=padx_label, pady=1, sticky="e")
+            entries[key].grid(row=grid_row, column=col_offset + 1, padx=1, pady=1, sticky="w")
 
-        num_rows = (len(keys) + 1) // 2
-        self.reset_channels_btn.grid(row=num_rows + 1, column=0, columnspan=4, pady=2)
+        num_entry_rows = (len(keys) + 1) // 2
+        button_row = row + num_entry_rows
+        self.reset_channels_btn.grid(row=button_row, column=0, columnspan=4, pady=2)
+
+        # Expose for subclass save-button placement
+        self._channel_button_row = button_row
+
+    # ------------------------------------------------------------------
+    # Lazy B entry creation
+    # ------------------------------------------------------------------
+
+    def _ensure_b_entries(self) -> None:
+        """Create Session B channel entries if they don't exist yet."""
+        if self._channel_entries_b is not None:
+            return
+
+        self._channel_entries_b = {}
+        self._channel_labels_b = {}
+
+        for key, display_name in self._channel_display_names.items():
+            self._channel_labels_b[key] = ctk.CTkLabel(
+                self.channels_frame,
+                text=display_name,
+                font=ctk.CTkFont(size=11),
+            )
+            self._channel_entries_b[key] = AutocompleteEntry(
+                self.channels_frame,
+                width=120,
+                font=ctk.CTkFont(size=11),
+                on_change=self._on_entry_changed,
+            )
+            # Initialize from A's current values
+            self._channel_entries_b[key].insert(0, self._channel_entries_a[key].get())
+
+        # Apply current suggestions for B
+        if self._suggestions_b:
+            for entry in self._channel_entries_b.values():
+                entry.set_suggestions(self._suggestions_b)
+
+        # Let subclasses create their B widgets
+        self._create_b_extra()
+
+        # Apply sync state (disable B entries if synced)
+        self._apply_sync_state()
+
+    # ------------------------------------------------------------------
+    # Session switching
+    # ------------------------------------------------------------------
+
+    def show_session_b_controls(self) -> None:
+        """Show the session A/B selector and create B entries if needed."""
+        self._ensure_b_entries()
+        self._repack_channel_grid()
+
+    def _on_session_selector_changed(self, value: str) -> None:
+        """Handle session selector toggle."""
+        new_session = "A" if value == "Session A" else "B"
+        if new_session == self._active_session:
+            return
+        self._active_session = new_session
+        self._repack_channel_grid()
+        self._repack_extra_widgets()
+
+    # ------------------------------------------------------------------
+    # Sync logic
+    # ------------------------------------------------------------------
+
+    def _on_sync_toggled(self) -> None:
+        """Handle sync checkbox toggle."""
+        self._sync_with_a = self._sync_var.get()
+        if self._sync_with_a:
+            self._copy_a_to_b()
+        self._apply_sync_state()
+
+    def _copy_a_to_b(self) -> None:
+        """Copy all A entry values to B entries."""
+        if self._channel_entries_b is None:
+            return
+        for key in self._channel_entries_a:
+            val = self._channel_entries_a[key].get()
+            self._channel_entries_b[key].delete(0, "end")
+            self._channel_entries_b[key].insert(0, val)
+        self._copy_extra_a_to_b()
+
+    def _apply_sync_state(self) -> None:
+        """Enable or disable B entries based on sync state."""
+        if self._channel_entries_b is None:
+            return
+        state = "disabled" if self._sync_with_a else "normal"
+        for entry in self._channel_entries_b.values():
+            entry.configure(state=state)
+        self._apply_extra_sync_state(state)
+
+    def set_sync(self, synced: bool) -> None:
+        """Programmatically set the sync state."""
+        self._sync_with_a = synced
+        self._sync_var.set(synced)
+        if synced:
+            self._copy_a_to_b()
+        self._apply_sync_state()
+
+    # ------------------------------------------------------------------
+    # Entry change handler
+    # ------------------------------------------------------------------
+
+    def _on_entry_changed(self, event=None) -> None:
+        """Handle any config entry value change."""
+        # If editing A while synced, propagate to B
+        if self._active_session == "A" and self._sync_with_a:
+            self._copy_a_to_b()
+        if self._on_config_changed:
+            self._on_config_changed()
+
+    # ------------------------------------------------------------------
+    # Channel reset
+    # ------------------------------------------------------------------
+
+    def _reset_channels(self) -> None:
+        """Reset channel names to defaults for the active session."""
+        entries = self.channel_entries
+        for key, val in self._default_channels.items():
+            entries[key].delete(0, "end")
+            entries[key].insert(0, val)
+        # If we reset A and sync is on, copy to B
+        if self._active_session == "A" and self._sync_with_a:
+            self._copy_a_to_b()
+        self._on_entry_changed()
+
+    # ------------------------------------------------------------------
+    # Channel name getters
+    # ------------------------------------------------------------------
+
+    def get_channel_names(self) -> dict[str, str]:
+        """Get channel names for Session A (backward compat)."""
+        return self.get_channel_names_a()
+
+    def get_channel_names_a(self) -> dict[str, str]:
+        """Get current channel name mappings for Session A."""
+        return {
+            key: self._channel_entries_a[key].get() or self._default_channels[key]
+            for key in self._default_channels
+        }
+
+    def get_channel_names_b(self) -> dict[str, str]:
+        """Get current channel name mappings for Session B.
+
+        Returns A's values if synced or if B entries don't exist.
+        """
+        if self._sync_with_a or self._channel_entries_b is None:
+            return self.get_channel_names_a()
+        return {
+            key: self._channel_entries_b[key].get() or self._default_channels[key]
+            for key in self._default_channels
+        }
+
+    # ------------------------------------------------------------------
+    # Autocomplete suggestions
+    # ------------------------------------------------------------------
+
+    def update_available_channels(self, channel_names: list[str]) -> None:
+        """Update autocomplete suggestions for Session A (backward compat)."""
+        self.update_available_channels_a(channel_names)
+
+    def update_available_channels_a(self, channels: list[str]) -> None:
+        """Update autocomplete suggestions for Session A entries."""
+        self._suggestions_a = channels
+        for entry in self._channel_entries_a.values():
+            entry.set_suggestions(channels)
+
+    def update_available_channels_b(self, channels: list[str]) -> None:
+        """Update autocomplete suggestions for Session B entries."""
+        self._suggestions_b = channels
+        if self._channel_entries_b is not None:
+            for entry in self._channel_entries_b.values():
+                entry.set_suggestions(channels)
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def active_session(self) -> str:
+        """Return the currently selected session ('A' or 'B')."""
+        return self._active_session
+
+    @property
+    def is_synced(self) -> bool:
+        """Return whether B entries are synced with A."""
+        return self._sync_with_a
+
+    # ------------------------------------------------------------------
+    # Subclass hooks for extra A/B widgets (motion ratios, thresholds)
+    # ------------------------------------------------------------------
+
+    def _create_b_extra(self) -> None:
+        """Create Session B versions of subclass-specific widgets.
+
+        Called once from ``_ensure_b_entries()``. Override in subclasses
+        that have additional per-session parameters.
+        """
+
+    def _repack_extra_widgets(self) -> None:
+        """Re-grid subclass-specific widgets for the active session.
+
+        Called after session selector changes. Override in subclasses.
+        """
+
+    def _copy_extra_a_to_b(self) -> None:
+        """Copy subclass-specific A values to B entries.
+
+        Called when sync copies A→B. Override in subclasses.
+        """
+
+    def _apply_extra_sync_state(self, state: str) -> None:
+        """Enable or disable subclass-specific B entries.
+
+        Parameters
+        ----------
+        state : str
+            "disabled" when synced, "normal" when independent.
+        """
+
+    # ------------------------------------------------------------------
+    # Status / stats
+    # ------------------------------------------------------------------
 
     def _pack_status(self) -> None:
         """Pack the status frame with label and stats button."""
         self.status_frame.pack(fill="x", padx=5, pady=(5, 2))
         self.status_label.pack(side="left", fill="x", expand=True, padx=2)
         self.stats_btn.pack(side="right", padx=2)
-
-    def _on_entry_changed(self, event=None) -> None:
-        """Handle any config entry value change."""
-        if self._on_config_changed:
-            self._on_config_changed()
 
     def _on_stats_btn_click(self) -> None:
         """Handle statistics button click."""
@@ -151,22 +446,3 @@ class BaseConfigPanel(ctk.CTkFrame):
     def set_stats_button_text(self, text: str) -> None:
         """Update the statistics button text."""
         self.stats_btn.configure(text=text)
-
-    def update_available_channels(self, channel_names: list[str]) -> None:
-        """Update autocomplete suggestions for all channel entries."""
-        for entry in self.channel_entries.values():
-            entry.set_suggestions(channel_names)
-
-    def _reset_channels(self) -> None:
-        """Reset channel names to defaults."""
-        for key, val in self._default_channels.items():
-            self.channel_entries[key].delete(0, "end")
-            self.channel_entries[key].insert(0, val)
-        self._on_entry_changed()
-
-    def get_channel_names(self) -> dict[str, str]:
-        """Get current channel name mappings."""
-        return {
-            key: self.channel_entries[key].get() or self._default_channels[key]
-            for key in self._default_channels
-        }


### PR DESCRIPTION
## Summary

- Add A/B segmented button to config panels for per-session channel mappings, motion ratios, and analysis thresholds
- When comparing different vehicles (e.g., Toyota 86 vs Honda EK9), each session can now have independent config
- Sync checkbox (default: on) keeps B in sync with A; auto-unchecks when a different vehicle profile is detected
- Session B throttle threshold auto-detected from B's telemetry data on load
- Typed analysis params via dataclasses (`SuspensionParams`, `DriverParams`) replace untyped dicts

## Test plan

- [x] `just check` passes (lint + typecheck + 210 tests)
- [x] Desktop app mypy passes (29 files, 0 errors)
- [ ] Load Session A only → no segmented button visible, identical to previous behavior
- [ ] Load Session B (same vehicle) → segmented button appears, sync checked, A/B show same values
- [ ] Load Session B (different vehicle) → auto-unchecks sync, B populated from profile, throttle threshold auto-set
- [ ] Run analysis → correct channels/thresholds/ratios used per session
- [ ] Toggle sync on/off → values copy correctly, entries enable/disable

🤖 Generated with [Claude Code](https://claude.com/claude-code)