### PR TITLE
Add session metadata and weather to telemetry reports

### DIFF
--- a/.claude/skills/session-analysis/SKILL.md
+++ b/.claude/skills/session-analysis/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: session-analysis
+description: Analyze a motorsports telemetry session (.xrz/.xrk), identify improvement areas, and set KPIs.
+---
+
 # Session Analysis Skill
 
 Analyze motorsports telemetry sessions, identify improvement areas, set KPIs, and track progress.
@@ -10,23 +15,25 @@ Analyze motorsports telemetry sessions, identify improvement areas, set KPIs, an
 
 ## Workflow
 
-### 1. Generate Report
+### 1. Generate Report Data
 
 For each provided file path, run:
 
 ```bash
-uv run python scripts/analyze_session.py "<file_path>" --output /tmp/session_report.json --track-map /tmp/track_map.png --comparison-dir /tmp/comparisons/
+uv run python scripts/analyze_session.py "<file_path>" --output .session-analysis/report.json --track-map .session-analysis/track_map.png --comparison-dir .session-analysis/comparisons/
 ```
 
 Read the JSON output with the Read tool. The `--track-map` flag generates a track map image with labeled corners. The `--comparison-dir` flag generates per-corner input comparison plots and zoomed GPS maps for the top 5 opportunity corners.
 
-### 2. Check Previous State
+### 2. Check for Previous Reports
 
-Look for `.session-analysis/latest.json` in the project root. If it exists, this is a **cross-session comparison**. If not, this is a **first analysis**.
+If previous session report(s) are provided (e.g., as file paths in the prompt), read them for **cross-session comparison**. For standalone use, check if `.session-analysis/report.md` exists from a prior run.
+
+Previous reports contain KPI tables and improvement areas in markdown — use these directly for comparison rather than parsing JSON state.
 
 ### 3. Identify Improvement Areas
 
-Rank the top 3–5 improvement areas by impact using corner consistency data from the report:
+Rank corners by impact and select the **top 3** for the main report. All remaining corners go to a separate appendix file (see step 7).
 
 **Priority ranking:**
 
@@ -91,19 +98,7 @@ Only mention G utilization for corners where it's below 70%. Don't add a standal
 
 ### 5. Set KPIs
 
-For each improvement area, define a measurable KPI:
-
-```json
-{
-  "name": "Turn 3 exit speed consistency",
-  "area": "corner_exit",
-  "corner_id": 3,
-  "metric_key": "exit_speed_std",
-  "current_value": 4.2,
-  "target_value": 2.0,
-  "unit": "km/h"
-}
-```
+Define **at most 3 KPIs**, all tied to the highlighted corners. Pick the metrics that would most directly address the root causes identified in step 4. Not every corner needs a KPI — if two corners share the same underlying issue, one KPI may cover both.
 
 Realistic targets:
 - `exit_speed_std`: reduce by 40–50%
@@ -118,7 +113,9 @@ Realistic targets:
 
 ### 6. Generate Report
 
-Output a structured markdown report with:
+Output the **main report** (focused, actionable) and an **appendix** (full data for reference).
+
+#### Main report
 
 1. **Track Map** — embed the track map image: `![Track Map](track_map.png)` (using the image generated in step 1)
 2. **Quick Reference** — extremely brief, memorizable list of the top 3 technique focuses. Format:
@@ -129,8 +126,13 @@ Output a structured markdown report with:
    3. **T4**: Full throttle sooner — you proved it on Lap 9
    ```
    Each item should be one line with the corner ID and the specific action. Reference a lap number where the driver proved they can do it. This must be concise enough to remember while driving.
-3. **Session Overview** — metadata, lap times, track info
-4. **Top Improvement Areas** — ranked list. For each corner, use this format:
+3. **Session Overview** — Include the session date/time (`metadata.log_date`, `metadata.log_time`), driver (`metadata.driver`), vehicle (`metadata.vehicle`), venue (`metadata.venue`), weather conditions (`weather`), lap times, and track info. Format example:
+   ```
+   **Date:** 2026-01-12 13:00 | **Driver:** CMD | **Vehicle:** Inferno 86
+   **Venue:** Sodegaura | **Weather:** Clear sky, 8.7°C, 37% humidity, wind 4.2 km/h WNW
+   ```
+   Weather comes from the Open-Meteo historical API (fetched automatically using circuit GPS center). Include `weather_description`, `temperature_c`, `relative_humidity_pct`, `wind_speed_kmh`, and `wind_direction_deg` (convert degrees to compass direction). Omit the weather line if `weather` is null.
+4. **Top 3 Improvement Areas** — the 3 highest-impact corners only. For each corner, use this format:
    ```
    ### N. Turn X — Short Description (Opportunity: NNNN)
 
@@ -155,50 +157,44 @@ Output a structured markdown report with:
    ![Turn X Map](comparisons/comparison_t{id}_map.png)
    ```
    Include: metrics table, root cause analysis for exit speed gains, G utilization technique notes where applicable (< 70%), comparison images
-5. **Corner-by-Corner Summary** — table of all corners with key consistency metrics
-6. **Brake Balance** — filtered summary (low-brake corners are excluded automatically by the report generator)
-7. **Setup Notes** — suspension and tire grip findings (if available)
-8. **KPIs** — table of targets for next session
-9. **Skipped Analyses** — any analyses that couldn't run and why
+5. **Tire Conditions** — if `tire_conditions` is available in the report, show per-lap max pressure and temperature for the best lap (and optionally a few other top laps for comparison):
+   ```
+   ## Tire Conditions
 
-When saving the report, copy the track map image and comparison images to `.session-analysis/` alongside the markdown report so the relative image references work.
+   Best lap (L9):
+   | Wheel | Max Pressure | Max Temperature |
+   |-------|-------------|-----------------|
+   | FL | 2.29 bar | 55 C |
+   | FR | 2.20 bar | 50 C |
+   | RL | 2.20 bar | 48 C |
+   | RR | 2.16 bar | 44 C |
+   ```
+   Include units from `tire_conditions.pressure_unit` and `tire_conditions.temperature_unit`. Show whichever metrics are available (both pressure and temperature when present). Omit this section if `tire_conditions` is null.
+6. **KPIs** — at most 3 targets for next session, all tied to the highlighted corners
+7. **Skipped Analyses** — any analyses that couldn't run and why (omit if none)
 
-### 7. Save State
+The track map and comparison images are already in `.session-analysis/` from step 1, so the relative image references in the markdown report work without copying.
 
-Save the full state for future comparison:
+#### Appendix
 
-```bash
-mkdir -p .session-analysis/history
-```
+Write a separate appendix file alongside the main report (e.g., `report_appendix.md` or `step<NN>_appendix.md` when called from day-review). This contains:
 
-Write `.session-analysis/latest.json`:
+1. **Corner-by-Corner Summary** — table of all corners with key consistency metrics
+2. **Remaining Corner Analyses** — same format as the top 3 but for corners ranked 4+
+3. **Brake Balance** — filtered summary (low-brake corners are excluded automatically by the report generator)
+4. **Setup Notes** — suspension and tire grip findings (if available)
 
-```json
-{
-  "analysis_date": "YYYY-MM-DDTHH:MM:SS",
-  "session_file": "<file_path>",
-  "track_info": {
-    "track_length_m": 4523.0,
-    "corner_count": 12
-  },
-  "report": { "/* SessionReport.to_dict() */" : "..." },
-  "kpis": [ "/* KPI objects */" ]
-}
-```
-
-Archive to `.session-analysis/history/YYYY-MM-DD_<session_name>.json` (same content).
+Link to the appendix from the main report: `See [full corner analysis](report_appendix.md) for all corners, brake balance, and setup notes.`
 
 ### Cross-Session Comparison
 
-When `.session-analysis/latest.json` exists:
+When previous session report(s) are available:
 
-1. **Verify track match**: corner count must match, `track_length_m` within 5%
-2. **Calculate KPI progress** for each previous KPI:
-   - `% change` = (current - previous) / previous × 100
+1. **Verify track match**: corner count and track layout should match (same turn IDs)
+2. **Compare KPIs**: read the KPI table from the previous report and calculate progress:
    - Status: **MET** (reached target), **IMPROVED** (moved toward target), **REGRESSED** (moved away), **UNCHANGED** (< 5% change)
-3. **Generate comparison table** showing previous → current → target for each KPI
+3. **Generate comparison section** in the report showing previous → current → target for each KPI
 4. **Update KPIs** — keep unmet KPIs, adjust targets for met ones, add new areas
-5. **Save updated state** to `latest.json` and archive
 
 ### Important Notes
 

--- a/.claude/skills/session-day-review/SKILL.md
+++ b/.claude/skills/session-day-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: session-day-review
+description: Analyze all sessions from a track day, track progress across sessions, and generate a day summary.
+---
+
 # Session Day Review Skill
 
 Analyze all sessions from a track day, track progress across sessions, and generate a day summary.
@@ -20,62 +25,108 @@ ls -1 "<directory_path>"/*.xrz "<directory_path>"/*.xrk 2>/dev/null | sort
 
 Print the list of files found and confirm with the user before proceeding.
 
-### 2. Analyze Each Session
+### 2. Set Up Team and Analyze Sessions
 
-Process sessions **sequentially** — each one builds on the previous session's KPIs via `.session-analysis/latest.json`.
+Process sessions **sequentially** — each one builds on the previous session's KPIs.
 
-Create the steps directory first:
+#### Create output directory
+
 ```bash
-rm -rf .session-analysis && mkdir -p .session-analysis/steps .session-analysis/history
+rm -rf .session-analysis && mkdir -p .session-analysis
 ```
 
-For each session file, spawn a **background** sub-agent:
+#### Create a team for background agents
+
+Standalone background agents (`run_in_background: true`) **cannot** prompt the user for tool permissions and will fail on Write/Bash calls. Agent teams solve this — team members inherit permissions from the controller's session.
+
+```
+TeamCreate with:
+  - team_name: "session-analysis"
+  - description: "Analyze telemetry sessions from a track day"
+  - agent_type: "controller"
+```
+
+#### Spawn session analyzers sequentially
+
+For each session file, spawn a **team member** agent. Sessions must be sequential (each reads the previous session's markdown report for cross-session comparison), so wait for each teammate's completion message before spawning the next.
+
+For **session 1** (no previous report):
 
 ```
 Agent tool with:
   - subagent_type: general-purpose
   - mode: bypassPermissions
   - run_in_background: true
+  - name: "session-01"
+  - team_name: "session-analysis"
   - prompt: |
       Follow the session-analysis skill at .claude/skills/session-analysis/SKILL.md.
 
       Session file: <file_path>
-      Step number: <NN> (zero-padded, e.g., 01, 02)
+      Step number: 01
 
-      1. Run: uv run python scripts/analyze_session.py "<file_path>" --output /tmp/session_report.json --track-map /tmp/track_map.png --comparison-dir /tmp/comparisons/
+      1. Run: uv run python scripts/analyze_session.py "<file_path>" --output .session-analysis/step01_data.json --track-map .session-analysis/step01_track_map.png --comparison-dir .session-analysis/step01_comparisons/
       2. Read the JSON output with the Read tool
-      3. Check if .session-analysis/latest.json exists for cross-session comparison
+      3. No previous reports — this is the first session
       4. Follow the SKILL.md: identify improvements, set KPIs, generate markdown report
-      5. Save state to .session-analysis/latest.json and .session-analysis/history/
-      6. Copy .session-analysis/latest.json to .session-analysis/steps/step<NN>_<session_basename>.json
-      7. Copy /tmp/track_map.png to .session-analysis/step<NN>_track_map.png
-      8. Copy /tmp/comparisons/ to .session-analysis/step<NN>_comparisons/ (if it exists)
-      9. Write the markdown report to .session-analysis/step<NN>_report.md (reference the track map as ![Track Map](step<NN>_track_map.png) and comparison images as ![Turn N Inputs](step<NN>_comparisons/comparison_t{id}_inputs.png))
+      5. Write the markdown report to .session-analysis/step01_report.md
+         - Reference track map as ![Track Map](step01_track_map.png)
+         - Reference comparisons as ![Turn N Inputs](step01_comparisons/comparison_t{id}_inputs.png)
+      6. Send a message to the team lead with a brief status
 ```
 
-**CRITICAL — context isolation:**
-- Each sub-agent MUST run with `run_in_background: true` so its results stay out of the main conversation context
-- Wait for each sub-agent to complete (via the automatic completion notification) before spawning the next one
-- Do NOT read the sub-agent's output back into the main context — the results are on disk
-- Give the user a brief status update after each session completes (e.g., "Session 2/4 done") but do NOT summarize the sub-agent's findings
-
-### 3. Generate Day Summary
-
-After all sessions are processed, spawn one final **background** sub-agent to read the step files from disk and generate the day summary:
+For **session N** (N > 1, with previous reports):
 
 ```
 Agent tool with:
   - subagent_type: general-purpose
   - mode: bypassPermissions
   - run_in_background: true
+  - name: "session-<NN>"
+  - team_name: "session-analysis"
   - prompt: |
-      Read the step JSON files and session reports from .session-analysis/steps/ and
-      .session-analysis/step*_report.md. Follow the day summary format in
-      .claude/skills/session-day-review/SKILL.md section "Day Summary Format".
-      Write the result to .session-analysis/day_summary_YYYY-MM-DD.md.
+      Follow the session-analysis skill at .claude/skills/session-analysis/SKILL.md.
+
+      Session file: <file_path>
+      Step number: <NN>
+
+      1. Run: uv run python scripts/analyze_session.py "<file_path>" --output .session-analysis/step<NN>_data.json --track-map .session-analysis/step<NN>_track_map.png --comparison-dir .session-analysis/step<NN>_comparisons/
+      2. Read the JSON output with the Read tool
+      3. Read the previous session report for cross-session comparison:
+         .session-analysis/step<NN-1>_report.md
+      4. Follow the SKILL.md: identify improvements, set KPIs, compare against previous KPIs
+      5. Write the markdown report to .session-analysis/step<NN>_report.md
+         - Reference track map as ![Track Map](step<NN>_track_map.png)
+         - Reference comparisons as ![Turn N Inputs](step<NN>_comparisons/comparison_t{id}_inputs.png)
+         - Include a KPI progress section comparing current values to previous report's targets
+      6. Send a message to the team lead with a brief status
 ```
 
-When the day summary agent completes, tell the user the file path and offer to show it.
+**Context isolation:**
+- Each teammate runs in the background — only their short status message enters the main context
+- Wait for each teammate's message before spawning the next one
+- Give the user a brief status update after each session completes (e.g., "Session 2/4 done")
+- Send a `shutdown_request` to each teammate after receiving their status message
+
+### 3. Generate Day Summary
+
+After all sessions are processed, spawn one final team member to read all the markdown reports and generate the day summary:
+
+```
+Agent tool with:
+  - subagent_type: general-purpose
+  - mode: bypassPermissions
+  - run_in_background: true
+  - name: "day-summary"
+  - team_name: "session-analysis"
+  - prompt: |
+      Read all session reports from .session-analysis/step*_report.md.
+      Follow the day summary format in .claude/skills/session-day-review/SKILL.md section "Day Summary Format".
+      Write the result to .session-analysis/day_summary_YYYY-MM-DD.md.
+      When done, send a message to the team lead with "Day summary written to .session-analysis/day_summary_YYYY-MM-DD.md".
+```
+
+When the day summary agent completes, shut it down, delete the team, tell the user the file path and offer to show it.
 
 ### Day Summary Format
 
@@ -125,10 +176,10 @@ Where `YYYY-MM-DD` is today's date.
 
 ### Important Notes
 
-- Sessions must be from the same track (verify corner count and track length match across step files)
-- Sequential processing is required because each `/session-analysis` invocation reads `.session-analysis/latest.json` for cross-session comparison — session N must complete before session N+1 starts
+- Sessions must be from the same track (verify corner count and track layout match across reports)
+- Sequential processing is required because each session reads the previous session's markdown report for cross-session comparison
 - If a session fails to analyze, log the error and continue with remaining sessions
 - The day summary should reference specific session numbers and lap numbers for actionable feedback
 - All speeds in km/h, distances in meters, times in seconds
-- Each sub-agent's context is isolated — the orchestrating agent reads all results from disk after all sessions complete
-- All sub-agents share the same `.session-analysis/latest.json` — this is intentional, as each session builds on the previous one's KPIs
+- Each teammate's context is isolated — the controller reads only their short status messages
+- Cross-session state is carried entirely through the markdown reports — no separate JSON state files

--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,8 @@ _output/
 desktop_app/.wine_build/
 desktop_app_driver/.wine_build/
 
+# Claude Code
+.claude/settings.local.json
+
 # Session analysis state
 .session-analysis/

--- a/src/motorsports_data_notebook/report.py
+++ b/src/motorsports_data_notebook/report.py
@@ -7,6 +7,8 @@ with JSON-serializable output.
 from __future__ import annotations
 
 import json
+import urllib.request
+import urllib.parse
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING
 
@@ -48,6 +50,59 @@ class SessionMetadata:
     total_laps: int
     valid_laps: int
     top_lap_count: int
+    driver: str | None
+    vehicle: str | None
+    venue: str | None
+    log_date: str | None
+    log_time: str | None
+    session_id: str | None = None
+    session_notes: str | None = None
+
+
+# WMO weather interpretation codes
+# https://open-meteo.com/en/docs#weathervariables
+_WMO_WEATHER_CODES: dict[int, str] = {
+    0: "Clear sky",
+    1: "Mainly clear",
+    2: "Partly cloudy",
+    3: "Overcast",
+    45: "Fog",
+    48: "Depositing rime fog",
+    51: "Light drizzle",
+    53: "Moderate drizzle",
+    55: "Dense drizzle",
+    56: "Light freezing drizzle",
+    57: "Dense freezing drizzle",
+    61: "Slight rain",
+    63: "Moderate rain",
+    65: "Heavy rain",
+    66: "Light freezing rain",
+    67: "Heavy freezing rain",
+    71: "Slight snow",
+    73: "Moderate snow",
+    75: "Heavy snow",
+    77: "Snow grains",
+    80: "Slight rain showers",
+    81: "Moderate rain showers",
+    82: "Violent rain showers",
+    85: "Slight snow showers",
+    86: "Heavy snow showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm with slight hail",
+    99: "Thunderstorm with heavy hail",
+}
+
+
+@dataclass
+class WeatherConditions:
+    """Weather conditions at the circuit during the session."""
+
+    temperature_c: float | None
+    relative_humidity_pct: int | None
+    wind_speed_kmh: float | None
+    wind_direction_deg: int | None
+    weather_code: int | None
+    weather_description: str | None
 
 
 @dataclass
@@ -116,6 +171,7 @@ class CornerBestLap:
     total_g_min: float | None = None
     total_g_min_dist: float | None = None
     total_g_min_phase: str | None = None
+    early_braking_coast_m: float | None = None
 
 
 @dataclass
@@ -149,12 +205,15 @@ class CornerConsistency:
     g_utilization_std: float | None = None
     total_g_min_mean: float | None = None
     total_g_min_phase: str | None = None
+    early_braking_coast_mean: float | None = None
     braking_g_mean_val: float | None = None
     entry_g_mean_val: float | None = None
     mid_g_mean_val: float | None = None
     exit_g_mean_val: float | None = None
     # Off-track detection
     excluded_laps: list[int] = field(default_factory=list)
+    # Per-lap raw metrics
+    per_lap_metrics: list[CornerLapMetrics] = field(default_factory=list)
 
 
 @dataclass
@@ -172,6 +231,15 @@ class TireGripSummary:
     metric_mode: str
     units: dict[str, str]
     per_wheel: dict[str, dict[str, float]]
+
+
+@dataclass
+class TireConditionsSummary:
+    """Per-lap max tire pressure and temperature."""
+
+    pressure_unit: str | None
+    temperature_unit: str | None
+    per_lap: list[dict]
 
 
 @dataclass
@@ -198,6 +266,8 @@ class SessionReport:
     track_length_m: float
     suspension: SuspensionSummary | None
     tire_grip: TireGripSummary | None
+    tire_conditions: TireConditionsSummary | None
+    weather: WeatherConditions | None
     available_analyses: list[str]
     skipped_analyses: dict[str, str]
     braking_balance: BrakingBalanceSummary | None = None
@@ -212,6 +282,79 @@ class SessionReport:
 # ── Helpers ──────────────────────────────────────────────────────────────────────
 
 
+def _fetch_weather(
+    latitude: float,
+    longitude: float,
+    log_date: str,
+    log_time: str,
+    timeout: float = 5.0,
+) -> WeatherConditions:
+    """Fetch historical weather from Open-Meteo for the session's location and time.
+
+    Parameters
+    ----------
+    latitude, longitude
+        Circuit center coordinates.
+    log_date
+        Date string in MM/DD/YYYY format (from AIM metadata).
+    log_time
+        Time string in HH:MM:SS format (from AIM metadata).
+    timeout
+        HTTP request timeout in seconds.
+    """
+    # Parse date to ISO format
+    parts = log_date.split("/")
+    iso_date = f"{parts[2]}-{parts[0]}-{parts[1]}"
+
+    # Parse hour from log_time
+    hour = int(log_time.split(":")[0])
+
+    params = urllib.parse.urlencode(
+        {
+            "latitude": f"{latitude:.4f}",
+            "longitude": f"{longitude:.4f}",
+            "start_date": iso_date,
+            "end_date": iso_date,
+            "hourly": "temperature_2m,relative_humidity_2m,wind_speed_10m,wind_direction_10m,weather_code",
+            "timezone": "auto",
+        }
+    )
+    url = f"https://archive-api.open-meteo.com/v1/archive?{params}"
+
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        data = json.loads(resp.read().decode())
+
+    hourly = data["hourly"]
+    # Find the index matching the session start hour
+    idx = hour  # hourly data starts at T00:00, one entry per hour
+    if idx >= len(hourly["temperature_2m"]):
+        idx = len(hourly["temperature_2m"]) - 1
+
+    weather_code = hourly["weather_code"][idx]
+    if weather_code is not None:
+        weather_code = int(weather_code)
+
+    return WeatherConditions(
+        temperature_c=hourly["temperature_2m"][idx],
+        relative_humidity_pct=(
+            int(hourly["relative_humidity_2m"][idx])
+            if hourly["relative_humidity_2m"][idx] is not None
+            else None
+        ),
+        wind_speed_kmh=hourly["wind_speed_10m"][idx],
+        wind_direction_deg=(
+            int(hourly["wind_direction_10m"][idx])
+            if hourly["wind_direction_10m"][idx] is not None
+            else None
+        ),
+        weather_code=weather_code,
+        weather_description=(
+            _WMO_WEATHER_CODES.get(weather_code) if weather_code is not None else None
+        ),
+    )
+
+
 def _check_channels_available(
     log: LogFile, channel_names: dict[str, str], required_keys: list[str]
 ) -> tuple[bool, list[str]]:
@@ -223,6 +366,35 @@ def _check_channels_available(
         elif channel_names[key] not in log.channels:
             missing.append(key)
     return (len(missing) == 0, missing)
+
+
+def _make_session_id(log_date: str | None, log_time: str | None, session_num: int) -> str | None:
+    """Build a session ID string from AIM metadata date/time and session number.
+
+    Parameters
+    ----------
+    log_date
+        Date string in ``MM/DD/YYYY`` format (from AIM metadata).
+    log_time
+        Time string in ``HH:MM:SS`` format (from AIM metadata).
+    session_num
+        1-based session number for the day.
+
+    Returns
+    -------
+    str or None
+        e.g. ``"2026-01-12_1300_s01"``, or None if date/time are missing.
+    """
+    if not log_date or not log_time:
+        return None
+    try:
+        parts = log_date.split("/")
+        iso_date = f"{parts[2]}-{parts[0].zfill(2)}-{parts[1].zfill(2)}"
+        time_parts = log_time.split(":")
+        hhmm = f"{time_parts[0].zfill(2)}{time_parts[1].zfill(2)}"
+        return f"{iso_date}_{hhmm}_s{session_num:02d}"
+    except (IndexError, ValueError):
+        return None
 
 
 def _corner_to_info(corner: Corner) -> CornerInfo:
@@ -251,6 +423,69 @@ def _format_lap_time(seconds: float) -> str:
     minutes = int(seconds // 60)
     remainder = seconds - minutes * 60
     return f"{minutes}:{remainder:06.3f}"
+
+
+def _collate_per_lap_metrics(
+    bp_vals: list[tuple[int, float]],
+    entry_speed_vals: list[tuple[int, float]],
+    min_speed_vals: list[tuple[int, float]],
+    exit_speed_vals: list[tuple[int, float]],
+    tp_vals: list[tuple[int, float]],
+    ta_entries: list[tuple[int, float]],
+    peak_brake_vals: list[tuple[int, float]],
+    brake_release_vals: list[tuple[int, float]],
+    braking_distance_vals: list[tuple[int, float]],
+    mean_decel_g_vals: list[tuple[int, float]],
+) -> list[CornerLapMetrics]:
+    """Collate per-lap metric tuples into CornerLapMetrics objects."""
+    # Collect all lap numbers that appear in any metric list
+    all_laps: set[int] = set()
+    all_lists = [
+        bp_vals,
+        entry_speed_vals,
+        min_speed_vals,
+        exit_speed_vals,
+        tp_vals,
+        ta_entries,
+        peak_brake_vals,
+        brake_release_vals,
+        braking_distance_vals,
+        mean_decel_g_vals,
+    ]
+    for vals in all_lists:
+        for lap_num, _ in vals:
+            all_laps.add(lap_num)
+
+    # Build lookup dicts
+    bp_map = dict(bp_vals)
+    entry_map = dict(entry_speed_vals)
+    ms_map = dict(min_speed_vals)
+    es_map = dict(exit_speed_vals)
+    tp_map = dict(tp_vals)
+    ta_map = dict(ta_entries)
+    pb_map = dict(peak_brake_vals)
+    br_map = dict(brake_release_vals)
+    bd_map = dict(braking_distance_vals)
+    mdg_map = dict(mean_decel_g_vals)
+
+    result = []
+    for lap_num in sorted(all_laps):
+        result.append(
+            CornerLapMetrics(
+                lap_num=lap_num,
+                braking_point=bp_map.get(lap_num),
+                entry_speed=entry_map.get(lap_num),
+                min_speed=ms_map.get(lap_num),
+                exit_speed=es_map.get(lap_num),
+                throttle_point=tp_map.get(lap_num),
+                throttle_acceptance_pct=ta_map.get(lap_num),
+                peak_brake=pb_map.get(lap_num),
+                brake_release_point=br_map.get(lap_num),
+                braking_distance=bd_map.get(lap_num),
+                mean_decel_g=mdg_map.get(lap_num),
+            )
+        )
+    return result
 
 
 def _get_per_lap_metric(
@@ -549,6 +784,72 @@ def _extract_tire_grip_summary(result: TireGripResult) -> TireGripSummary:
     )
 
 
+def _extract_tire_conditions(
+    log: LogFile,
+    lap_numbers: list[int],
+    channel_names: dict[str, str],
+    has_pressure: bool,
+    has_temperature: bool,
+) -> TireConditionsSummary:
+    """Extract per-lap max tire pressure and temperature."""
+    press_keys = ["tpms_press_fl", "tpms_press_fr", "tpms_press_rl", "tpms_press_rr"]
+    temp_keys = ["tpms_temp_fl", "tpms_temp_fr", "tpms_temp_rl", "tpms_temp_rr"]
+    wheel_names = ["FL", "FR", "RL", "RR"]
+
+    pressure_unit = None
+    temperature_unit = None
+    per_lap: list[dict] = []
+
+    for lap_num in lap_numbers:
+        try:
+            lap_log = log.filter_by_lap(lap_num)
+            entry: dict = {"lap_num": lap_num}
+
+            if has_pressure:
+                press_channels = [channel_names[k] for k in press_keys]
+                aligned = (
+                    lap_log.select_channels(press_channels)
+                    .resample_to_channel(press_channels[0])
+                    .channels
+                )
+                max_press = {}
+                for wn, ch in zip(wheel_names, press_channels):
+                    arr = aligned[ch].column(ch).to_numpy()
+                    max_press[wn] = round(float(arr.max()), 3)
+                    if pressure_unit is None:
+                        from motorsports_data_notebook._util import get_channel_unit
+
+                        pressure_unit = get_channel_unit(aligned[ch], ch)
+                entry["max_pressure"] = max_press
+
+            if has_temperature:
+                temp_channels = [channel_names[k] for k in temp_keys]
+                aligned = (
+                    lap_log.select_channels(temp_channels)
+                    .resample_to_channel(temp_channels[0])
+                    .channels
+                )
+                max_temp = {}
+                for wn, ch in zip(wheel_names, temp_channels):
+                    arr = aligned[ch].column(ch).to_numpy()
+                    max_temp[wn] = round(float(arr.max()), 1)
+                    if temperature_unit is None:
+                        from motorsports_data_notebook._util import get_channel_unit
+
+                        temperature_unit = get_channel_unit(aligned[ch], ch)
+                entry["max_temperature"] = max_temp
+
+            per_lap.append(entry)
+        except Exception:
+            continue
+
+    return TireConditionsSummary(
+        pressure_unit=pressure_unit,
+        temperature_unit=temperature_unit,
+        per_lap=per_lap,
+    )
+
+
 # ── Main Function ───────────────────────────────────────────────────────────────
 
 
@@ -558,6 +859,7 @@ def generate_session_report(
     motion_ratios: MotionRatios | None = None,
     top_lap_threshold: float = 1.03,
     file_name: str = "",
+    session_num: int = 1,
 ) -> SessionReport:
     """Generate a complete session analysis report.
 
@@ -577,6 +879,8 @@ def generate_session_report(
         Include laps within this fraction of the best lap time.
     file_name : str, default=""
         Source file name for metadata.
+    session_num : int, default=1
+        1-based session number for the day (used in session_id).
 
     Returns
     -------
@@ -633,6 +937,7 @@ def generate_session_report(
     corners_raw: list[Corner] = []
     corners_info: list[CornerInfo] = []
     track_length = 0.0
+    gps_center: tuple[float, float] | None = None
 
     gps_ok, gps_missing = _check_channels_available(
         log, channel_names, ["gps_latitude", "gps_longitude"]
@@ -651,6 +956,8 @@ def generate_session_report(
 
         # Filter to valid GPS samples
         valid_gps = (lat != 0.0) | (lon != 0.0)
+        if np.any(valid_gps):
+            gps_center = (float(np.mean(lat[valid_gps])), float(np.mean(lon[valid_gps])))
         if not np.all(valid_gps):
             dist = dist[valid_gps]
 
@@ -833,6 +1140,20 @@ def generate_session_report(
                 mean_decel_g_vals=mean_decel_g_vals,
             )
 
+            # Collate per-lap metrics keyed by lap_num
+            per_lap_metrics = _collate_per_lap_metrics(
+                bp_vals,
+                entry_speed_vals,
+                min_speed_vals,
+                exit_speed_vals,
+                tp_vals,
+                ta_entries,
+                peak_brake_vals,
+                brake_release_vals,
+                braking_distance_vals,
+                mean_decel_g_vals,
+            )
+
             corner_consistency.append(
                 CornerConsistency(
                     corner=corner_info,
@@ -858,6 +1179,7 @@ def generate_session_report(
                     mean_decel_g_mean=float(np.mean(mdg_values)) if mdg_values else None,
                     mean_decel_g_std=float(np.std(mdg_values)) if mdg_values else None,
                     excluded_laps=excluded,
+                    per_lap_metrics=per_lap_metrics,
                 )
             )
     elif not corners_raw:
@@ -1028,6 +1350,10 @@ def generate_session_report(
                         from collections import Counter
 
                         cc.total_g_min_phase = Counter(phases).most_common(1)[0][0]
+                    # Early braking coast distance (mean across laps where detected)
+                    coast_arr = np.asarray(corner_rows["early_braking_coast_m"].dropna().values)
+                    if len(coast_arr) > 0:
+                        cc.early_braking_coast_mean = round(float(np.mean(coast_arr)), 1)
                     for col, attr in [
                         ("braking_g_mean", "braking_g_mean_val"),
                         ("entry_g_mean", "entry_g_mean_val"),
@@ -1049,6 +1375,10 @@ def generate_session_report(
                             cc.best_lap.total_g_min = round(float(row["total_g_min"]), 3)
                             cc.best_lap.total_g_min_dist = round(float(row["total_g_min_dist"]), 1)
                             cc.best_lap.total_g_min_phase = str(row["total_g_min_phase"])
+                            if pd.notna(row.get("early_braking_coast_m")):
+                                cc.best_lap.early_braking_coast_m = round(
+                                    float(row["early_braking_coast_m"]), 1
+                                )
 
                 available.append("g_utilization")
         except Exception as e:
@@ -1106,9 +1436,49 @@ def generate_session_report(
             missing_parts.append("TPMS pressure/temperature")
         skipped["tire_grip"] = f"Missing channels: {', '.join(missing_parts)}"
 
+    # ── 9. Tire conditions (per-lap max pressure & temperature) ──────────────
+    tire_conditions = None
+    if press_ok or temp_ok:
+        try:
+            tire_conditions = _extract_tire_conditions(
+                log, top_lap_nums, channel_names, has_pressure=press_ok, has_temperature=temp_ok
+            )
+            available.append("tire_conditions")
+        except Exception as e:
+            skipped["tire_conditions"] = str(e)
+
+    # ── 10. Weather conditions ────────────────────────────────────────────────
+    weather = None
+    raw_meta_pre = log.metadata if log.metadata else {}
+    log_date_str = raw_meta_pre.get("Log Date")
+    log_time_str = raw_meta_pre.get("Log Time")
+    if gps_center and log_date_str and log_time_str:
+        try:
+            weather = _fetch_weather(gps_center[0], gps_center[1], log_date_str, log_time_str)
+            available.append("weather")
+        except Exception as e:
+            skipped["weather"] = str(e)
+    elif not gps_center:
+        skipped["weather"] = "No GPS data available for location"
+    else:
+        skipped["weather"] = "Missing Log Date or Log Time in session metadata"
+
     # ── Build report ─────────────────────────────────────────────────────────
     total_laps = len(laps_df)
     valid_laps_count = len(laps_df[laps_df["num"] > 0]) if "num" in laps_df.columns else total_laps
+
+    raw_meta = log.metadata if log.metadata else {}
+    log_date_val = raw_meta.get("Log Date")
+    log_time_val = raw_meta.get("Log Time")
+    session_id = _make_session_id(log_date_val, log_time_val, session_num)
+
+    # Combine Long Comment and Short Comment into session notes
+    _long_raw = raw_meta.get("Long Comment")
+    _short_raw = raw_meta.get("Short Comment")
+    long_comment = _long_raw.replace("\r\n", "\n").strip() if isinstance(_long_raw, str) else ""
+    short_comment = _short_raw.strip() if isinstance(_short_raw, str) else ""
+    notes_parts = [p for p in [short_comment, long_comment] if p]
+    session_notes = "\n".join(notes_parts) if notes_parts else None
 
     metadata = SessionMetadata(
         file_name=file_name,
@@ -1117,6 +1487,13 @@ def generate_session_report(
         total_laps=total_laps,
         valid_laps=valid_laps_count,
         top_lap_count=len(top_lap_nums),
+        driver=raw_meta.get("Driver"),
+        vehicle=raw_meta.get("Vehicle"),
+        venue=raw_meta.get("Venue"),
+        log_date=log_date_val,
+        log_time=log_time_val,
+        session_id=session_id,
+        session_notes=session_notes,
     )
 
     return SessionReport(
@@ -1127,6 +1504,8 @@ def generate_session_report(
         track_length_m=track_length,
         suspension=suspension,
         tire_grip=tire_grip,
+        tire_conditions=tire_conditions,
+        weather=weather,
         available_analyses=available,
         skipped_analyses=skipped,
         braking_balance=braking_balance,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,1291 @@
+"""Tests for the report module.
+
+Uses mocked LogFile and analysis functions to test orchestration
+and graceful degradation.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from motorsports_data_notebook.corners import Corner
+from motorsports_data_notebook.report import (
+    BrakingBalanceSummary,
+    CornerBestLap,
+    CornerConsistency,
+    CornerInfo,
+    CornerLapMetrics,
+    LapTimeSummary,
+    SessionMetadata,
+    SessionReport,
+    SuspensionSummary,
+    TireGripSummary,
+    _check_channels_available,
+    _collate_per_lap_metrics,
+    _compute_best_lap,
+    _corner_to_info,
+    _detect_off_track_laps,
+    _extract_suspension_summary,
+    _extract_tire_grip_summary,
+    _make_session_id,
+    generate_session_report,
+)
+
+
+def _make_corner(
+    id=1,
+    name="Turn 1",
+    direction="L",
+    start_dist=100.0,
+    end_dist=200.0,
+    apex_dist=150.0,
+    max_curvature=0.01,
+) -> Corner:
+    """Create a test Corner."""
+    return Corner(
+        id=id,
+        name=name,
+        direction=direction,
+        start_idx=int(start_dist),
+        end_idx=int(end_dist),
+        start_dist=start_dist,
+        end_dist=end_dist,
+        apex_idx=int(apex_dist),
+        apex_dist=apex_dist,
+        max_curvature=max_curvature,
+    )
+
+
+def _make_log_mock(channel_names_present=None, laps=None):
+    """Create a mock LogFile with specified channels available."""
+    log = MagicMock()
+    if channel_names_present is None:
+        channel_names_present = []
+    log.channels = {name: MagicMock() for name in channel_names_present}
+
+    if laps is None:
+        laps = pd.DataFrame(
+            {
+                "num": [0, 1, 2, 3],
+                "start_time": [0, 100, 200, 300],
+                "end_time": [100, 200, 300, 400],
+                "lap_time": pd.to_timedelta([100, 90, 91, 92], unit="s"),
+            }
+        )
+    log.laps.to_pandas.return_value = laps
+    return log
+
+
+class TestCheckChannelsAvailable:
+    """Tests for _check_channels_available."""
+
+    def test_all_present(self):
+        log = _make_log_mock(["PPS", "BrakePress"])
+        channel_names = {"throttle": "PPS", "brake": "BrakePress"}
+        ok, missing = _check_channels_available(log, channel_names, ["throttle", "brake"])
+        assert ok is True
+        assert missing == []
+
+    def test_missing_from_log(self):
+        log = _make_log_mock(["PPS"])
+        channel_names = {"throttle": "PPS", "brake": "BrakePress"}
+        ok, missing = _check_channels_available(log, channel_names, ["throttle", "brake"])
+        assert ok is False
+        assert missing == ["brake"]
+
+    def test_missing_from_channel_names(self):
+        log = _make_log_mock(["PPS"])
+        channel_names = {"throttle": "PPS"}
+        ok, missing = _check_channels_available(log, channel_names, ["throttle", "lateral_g"])
+        assert ok is False
+        assert missing == ["lateral_g"]
+
+    def test_empty_required(self):
+        log = _make_log_mock()
+        ok, missing = _check_channels_available(log, {}, [])
+        assert ok is True
+        assert missing == []
+
+
+class TestCornerToInfo:
+    """Tests for _corner_to_info."""
+
+    def test_correct_field_mapping(self):
+        corner = _make_corner(
+            id=3,
+            name="Turn 3",
+            direction="R",
+            start_dist=500.0,
+            end_dist=600.0,
+            apex_dist=550.0,
+            max_curvature=0.02,
+        )
+        info = _corner_to_info(corner)
+        assert isinstance(info, CornerInfo)
+        assert info.id == 3
+        assert info.name == "Turn 3"
+        assert info.direction == "R"
+        assert info.start_dist == 500.0
+        assert info.end_dist == 600.0
+        assert info.apex_dist == 550.0
+        assert info.length == pytest.approx(100.0)
+        assert info.radius == pytest.approx(50.0)
+
+    def test_numpy_float_conversion(self):
+        """Ensure numpy floats are converted to Python floats."""
+        corner = _make_corner(start_dist=np.float64(100.0), end_dist=np.float64(200.0))
+        info = _corner_to_info(corner)
+        assert type(info.start_dist) is float
+        assert type(info.end_dist) is float
+
+
+class TestComputeBestLap:
+    """Tests for _compute_best_lap."""
+
+    def test_returns_none_when_no_exit_speeds(self):
+        result = _compute_best_lap([], [], [], [], [])
+        assert result is None
+
+    def test_single_lap(self):
+        result = _compute_best_lap(
+            bp_vals=[(1, 450.0)],
+            min_speed_vals=[(1, 80.0)],
+            exit_speed_vals=[(1, 120.0)],
+            tp_vals=[(1, 510.0)],
+            ta_entries=[(1, 65.0)],
+        )
+        assert result is not None
+        assert result.lap_num == 1
+        assert result.selection_reason == "only lap with data"
+        assert result.exit_speed == 120.0
+        assert result.throttle_acceptance_pct == 65.0
+
+    def test_selects_best_composite(self):
+        # Lap 2 has the best exit speed, lap 3 has best min speed
+        result = _compute_best_lap(
+            bp_vals=[(1, 450.0), (2, 452.0), (3, 448.0)],
+            min_speed_vals=[(1, 80.0), (2, 82.0), (3, 85.0)],
+            exit_speed_vals=[(1, 120.0), (2, 128.0), (3, 118.0)],
+            tp_vals=[(1, 510.0), (2, 508.0), (3, 512.0)],
+            ta_entries=[(1, 65.0), (2, 60.0), (3, 70.0)],
+        )
+        assert result is not None
+        # Lap 2 should win (highest exit speed, weighted 50%)
+        assert result.lap_num == 2
+        assert result.exit_speed == 128.0
+        assert "exit_speed" in result.vs_mean
+
+    def test_vs_mean_deltas(self):
+        result = _compute_best_lap(
+            bp_vals=[(1, 100.0), (2, 104.0)],
+            min_speed_vals=[(1, 80.0), (2, 84.0)],
+            exit_speed_vals=[(1, 120.0), (2, 130.0)],
+            tp_vals=[],
+            ta_entries=[],
+        )
+        assert result is not None
+        # Lap 2 is better in all metrics
+        assert result.vs_mean["exit_speed"] > 0
+        assert result.vs_mean["min_speed"] > 0
+        assert result.vs_mean["braking_point"] > 0
+
+
+class TestExtractSuspensionSummary:
+    """Tests for _extract_suspension_summary."""
+
+    def _make_corner_velocity_data(self, **overrides):
+        data = MagicMock()
+        defaults = {
+            "skew": 0.1,
+            "kurtosis": 2.5,
+            "mean": 5.0,
+            "std": 15.0,
+            "pct_friction": 20.0,
+            "pct_slow_bump": 15.0,
+            "pct_slow_rebound": 18.0,
+            "pct_fast_bump": 10.0,
+            "pct_fast_rebound": 12.0,
+            "pct_curb": 2.0,
+        }
+        defaults.update(overrides)
+        for k, v in defaults.items():
+            setattr(data, k, v)
+        return data
+
+    def test_extracts_all_corners(self):
+        result = MagicMock()
+        result.front_left = self._make_corner_velocity_data(pct_friction=20.0)
+        result.front_right = self._make_corner_velocity_data(pct_friction=22.0)
+        result.rear_left = self._make_corner_velocity_data(pct_friction=18.0)
+        result.rear_right = self._make_corner_velocity_data(pct_friction=19.0)
+
+        summary = _extract_suspension_summary(result)
+        assert isinstance(summary, SuspensionSummary)
+        assert set(summary.per_wheel.keys()) == {"FL", "FR", "RL", "RR"}
+        assert summary.per_wheel["FL"]["pct_friction"] == 20.0
+
+    def test_symmetry_computation(self):
+        result = MagicMock()
+        result.front_left = self._make_corner_velocity_data(pct_friction=20.0, pct_slow_bump=15.0)
+        result.front_right = self._make_corner_velocity_data(pct_friction=25.0, pct_slow_bump=10.0)
+        result.rear_left = self._make_corner_velocity_data(pct_friction=18.0)
+        result.rear_right = self._make_corner_velocity_data(pct_friction=18.0)
+
+        summary = _extract_suspension_summary(result)
+        assert summary.symmetry["front_lr_friction_diff"] == pytest.approx(-5.0)
+        assert summary.symmetry["front_lr_bump_diff"] == pytest.approx(5.0)
+        assert summary.symmetry["rear_lr_friction_diff"] == pytest.approx(0.0)
+
+
+class TestExtractTireGripSummary:
+    """Tests for _extract_tire_grip_summary."""
+
+    def test_extracts_stats_and_units(self):
+        result = MagicMock()
+        result.metric_mode = "pressure"
+        result.metric_unit = "bar"
+        result.accel_unit = "g"
+
+        for attr in ("front_left", "front_right", "rear_left", "rear_right"):
+            corner = MagicMock()
+            corner.mean_g = 1.2
+            corner.std_g = 0.1
+            corner.mean_metric = 2.0
+            corner.std_metric = 0.05
+            setattr(result, attr, corner)
+
+        summary = _extract_tire_grip_summary(result)
+        assert isinstance(summary, TireGripSummary)
+        assert summary.metric_mode == "pressure"
+        assert summary.units["metric_unit"] == "bar"
+        assert summary.per_wheel["FL"]["mean_g"] == pytest.approx(1.2)
+
+
+class TestGenerateSessionReport:
+    """Integration tests for generate_session_report using mocked analysis functions."""
+
+    def _make_channel_names(self):
+        return {
+            "throttle": "PPS",
+            "brake": "BrakePress",
+            "gps_speed": "GPS Speed",
+            "gps_latitude": "GPS Latitude",
+            "gps_longitude": "GPS Longitude",
+            "lateral_g": "LateralAcc",
+            "inline_g": "InlineAcc",
+            "shock_fl": "LF_Shock_Pot",
+            "shock_fr": "RF_Shock_Pot",
+            "shock_rl": "LR_Shock_Pot",
+            "shock_rr": "RR_Shock_Pot",
+        }
+
+    @patch("motorsports_data_notebook.report.get_profile_for_logger", return_value=None)
+    @patch("motorsports_data_notebook.report.get_logger_id", return_value=None)
+    def test_minimal_report_no_channels(self, mock_logger, mock_profile):
+        """Report should work with just lap times when no channels are available."""
+        log = _make_log_mock(channel_names_present=[])
+        channel_names = self._make_channel_names()
+
+        report = generate_session_report(log, channel_names, file_name="test.xrz")
+
+        assert isinstance(report, SessionReport)
+        assert report.metadata.file_name == "test.xrz"
+        assert "lap_times" in report.available_analyses
+        assert "corners" in report.skipped_analyses
+        assert report.corners == []
+        assert report.corner_consistency == []
+        assert report.suspension is None
+        assert report.tire_grip is None
+
+    @patch("motorsports_data_notebook.report.get_profile_for_logger", return_value=None)
+    @patch("motorsports_data_notebook.report.get_logger_id", return_value="12345")
+    @patch("motorsports_data_notebook.report.identify_corners")
+    def test_corners_detected(self, mock_corners, mock_logger, mock_profile):
+        """Report should include corners when GPS channels are available."""
+        corners = [_make_corner(id=1), _make_corner(id=2, name="Turn 2", start_dist=400.0)]
+        mock_corners.return_value = corners
+
+        log = _make_log_mock(channel_names_present=["GPS Latitude", "GPS Longitude"])
+
+        # Mock the filter_by_lap chain
+        dist_arr = np.linspace(0, 2000, 100)
+        lat_arr = np.linspace(35.0, 35.1, 100)
+        lon_arr = np.linspace(139.0, 139.1, 100)
+
+        mock_table = MagicMock()
+
+        def mock_column(name):
+            if name == "GPS Latitude":
+                return MagicMock(to_numpy=lambda: lat_arr)
+            elif name == "GPS Longitude":
+                return MagicMock(to_numpy=lambda: lon_arr)
+            elif name == "distance_m":
+                return MagicMock(to_numpy=lambda: dist_arr)
+            elif name == "timecodes":
+                return MagicMock(to_numpy=lambda: np.linspace(0, 10000, 100))
+            return MagicMock(to_numpy=lambda: np.zeros(100))
+
+        # Set up all channel mocks to return column data
+        channels_dict = {}
+        for ch_name in ["GPS Latitude", "GPS Longitude", "distance_m"]:
+            ch_table = MagicMock()
+            ch_table.column = mock_column
+            channels_dict[ch_name] = ch_table
+
+        mock_resampled = MagicMock()
+        mock_resampled.channels = channels_dict
+        mock_selected = MagicMock()
+        mock_selected.resample_to_channel.return_value = mock_resampled
+        mock_filtered = MagicMock()
+        mock_filtered.select_channels.return_value = mock_selected
+        log.filter_by_lap.return_value = mock_filtered
+
+        channel_names = self._make_channel_names()
+        report = generate_session_report(log, channel_names)
+
+        assert "corners" in report.available_analyses
+        assert len(report.corners) == 2
+        assert report.track_length_m == pytest.approx(dist_arr[-1])
+
+    @patch("motorsports_data_notebook.report.get_profile_for_logger", return_value=None)
+    @patch("motorsports_data_notebook.report.get_logger_id", return_value=None)
+    def test_skipped_analyses_recorded(self, mock_logger, mock_profile):
+        """All skipped analyses should have explanations."""
+        log = _make_log_mock(channel_names_present=[])
+        channel_names = self._make_channel_names()
+
+        report = generate_session_report(log, channel_names)
+
+        assert "corners" in report.skipped_analyses
+        assert "suspension" in report.skipped_analyses
+        assert "tire_grip" in report.skipped_analyses
+
+    @patch("motorsports_data_notebook.report.get_profile_for_logger", return_value=None)
+    @patch("motorsports_data_notebook.report.get_logger_id", return_value=None)
+    def test_lap_time_summary(self, mock_logger, mock_profile):
+        """Lap time summary should correctly compute stats."""
+        laps = pd.DataFrame(
+            {
+                "num": [0, 1, 2, 3, 4],
+                "start_time": [0, 100, 200, 300, 400],
+                "end_time": [100, 200, 300, 400, 500],
+                "lap_time": pd.to_timedelta([120, 90, 91, 92, 95], unit="s"),
+            }
+        )
+        log = _make_log_mock(channel_names_present=[], laps=laps)
+        channel_names = self._make_channel_names()
+
+        report = generate_session_report(log, channel_names, top_lap_threshold=1.05)
+
+        assert report.lap_times.best_lap_num == 1
+        assert report.lap_times.best_lap_time_s == pytest.approx(90.0)
+        assert report.metadata.total_laps == 5
+        assert report.metadata.valid_laps == 4  # excludes lap 0
+        assert len(report.lap_times.all_lap_times) == 4  # excludes lap 0
+
+
+class TestSessionReportSerialization:
+    """Tests for to_dict() and to_json() methods."""
+
+    def _make_minimal_report(self):
+        return SessionReport(
+            metadata=SessionMetadata(
+                file_name="test.xrz",
+                logger_id="12345",
+                vehicle_profile="Test Car",
+                total_laps=5,
+                valid_laps=4,
+                top_lap_count=3,
+                driver=None,
+                vehicle=None,
+                venue=None,
+                log_date=None,
+                log_time=None,
+            ),
+            lap_times=LapTimeSummary(
+                best_lap_num=2,
+                best_lap_time_s=90.5,
+                best_lap_time_fmt="1:30.500",
+                top_laps=[{"num": 2, "lap_time_s": 90.5}],
+                mean_top_lap_time_s=91.0,
+                mean_top_lap_time_fmt="1:31.000",
+                std_top_lap_time_s=0.5,
+                all_lap_times=[{"num": 1, "lap_time_s": 95.0}, {"num": 2, "lap_time_s": 90.5}],
+            ),
+            corners=[
+                CornerInfo(
+                    id=1,
+                    name="Turn 1",
+                    direction="L",
+                    start_dist=100.0,
+                    end_dist=200.0,
+                    apex_dist=150.0,
+                    length=100.0,
+                    radius=50.0,
+                )
+            ],
+            corner_consistency=[
+                CornerConsistency(
+                    corner=CornerInfo(
+                        id=1,
+                        name="Turn 1",
+                        direction="L",
+                        start_dist=100.0,
+                        end_dist=200.0,
+                        apex_dist=150.0,
+                        length=100.0,
+                        radius=50.0,
+                    ),
+                    ta_mean=65.0,
+                    ta_std=3.0,
+                    bp_mean=450.0,
+                    bp_std=2.5,
+                    min_speed_mean=80.0,
+                    min_speed_std=1.5,
+                    exit_speed_mean=120.0,
+                    exit_speed_std=3.0,
+                    accel_zone_length=150.0,
+                    opportunity_score=450.0,
+                    best_lap=CornerBestLap(
+                        lap_num=2,
+                        selection_reason="fastest exit speed",
+                        braking_point=452.0,
+                        min_speed=81.0,
+                        exit_speed=123.0,
+                        throttle_acceptance_pct=62.0,
+                        throttle_point=510.0,
+                        vs_mean={"exit_speed": 3.0, "min_speed": 1.0},
+                    ),
+                )
+            ],
+            track_length_m=4500.0,
+            suspension=SuspensionSummary(
+                per_wheel={"FL": {"pct_friction": 20.0}, "FR": {"pct_friction": 22.0}},
+                symmetry={"front_lr_friction_diff": -2.0},
+            ),
+            tire_grip=TireGripSummary(
+                metric_mode="pressure",
+                units={"metric_unit": "bar", "accel_unit": "g"},
+                per_wheel={"FL": {"mean_g": 1.2}},
+            ),
+            tire_conditions=None,
+            weather=None,
+            available_analyses=["lap_times", "corners", "zones"],
+            skipped_analyses={"suspension": "Missing channels: shock_fl"},
+        )
+
+    def test_to_json_produces_valid_json(self):
+        report = self._make_minimal_report()
+        json_str = report.to_json()
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict)
+        assert parsed["metadata"]["file_name"] == "test.xrz"
+
+    def test_to_dict_round_trips(self):
+        report = self._make_minimal_report()
+        d = report.to_dict()
+        assert isinstance(d, dict)
+        assert d["track_length_m"] == 4500.0
+        assert d["corner_consistency"][0]["best_lap"]["lap_num"] == 2
+
+    def test_to_json_with_none_fields(self):
+        report = self._make_minimal_report()
+        report.suspension = None
+        report.tire_grip = None
+        json_str = report.to_json()
+        parsed = json.loads(json_str)
+        assert parsed["suspension"] is None
+        assert parsed["tire_grip"] is None
+
+
+class TestBrakingMetrics:
+    """Tests for new braking fields on CornerConsistency and CornerBestLap."""
+
+    def _make_corner_info(self):
+        return CornerInfo(
+            id=1,
+            name="Turn 1",
+            direction="L",
+            start_dist=100.0,
+            end_dist=200.0,
+            apex_dist=150.0,
+            length=100.0,
+            radius=50.0,
+        )
+
+    def test_corner_consistency_braking_fields_serialize(self):
+        """Test that CornerConsistency with braking fields serializes correctly."""
+        cc = CornerConsistency(
+            corner=self._make_corner_info(),
+            ta_mean=65.0,
+            ta_std=3.0,
+            bp_mean=450.0,
+            bp_std=2.5,
+            min_speed_mean=80.0,
+            min_speed_std=1.5,
+            exit_speed_mean=120.0,
+            exit_speed_std=3.0,
+            accel_zone_length=150.0,
+            opportunity_score=450.0,
+            best_lap=None,
+            peak_brake_mean=55.0,
+            peak_brake_std=2.0,
+            entry_speed_mean=195.0,
+            entry_speed_std=3.5,
+            brake_release_mean=180.0,
+            brake_release_std=5.0,
+            braking_distance_mean=80.0,
+            braking_distance_std=4.0,
+            mean_decel_g_mean=1.2,
+            mean_decel_g_std=0.1,
+        )
+
+        d = cc.__dict__
+        assert d["peak_brake_mean"] == 55.0
+        assert d["entry_speed_mean"] == 195.0
+        assert d["brake_release_mean"] == 180.0
+        assert d["braking_distance_mean"] == 80.0
+        assert d["mean_decel_g_mean"] == 1.2
+
+    def test_corner_best_lap_braking_fields(self):
+        """Test CornerBestLap with new braking fields."""
+        best = CornerBestLap(
+            lap_num=2,
+            selection_reason="fastest exit speed",
+            braking_point=452.0,
+            min_speed=81.0,
+            exit_speed=123.0,
+            throttle_acceptance_pct=62.0,
+            throttle_point=510.0,
+            vs_mean={"exit_speed": 3.0},
+            peak_brake=58.0,
+            entry_speed=198.0,
+            brake_release_point=175.0,
+            braking_distance=77.0,
+            mean_decel_g=1.15,
+        )
+
+        assert best.peak_brake == 58.0
+        assert best.entry_speed == 198.0
+        assert best.brake_release_point == 175.0
+        assert best.braking_distance == 77.0
+        assert best.mean_decel_g == 1.15
+
+    def test_compute_best_lap_includes_braking_vs_mean(self):
+        """Test _compute_best_lap includes new braking metrics in vs_mean."""
+        result = _compute_best_lap(
+            bp_vals=[(1, 450.0), (2, 452.0)],
+            min_speed_vals=[(1, 80.0), (2, 82.0)],
+            exit_speed_vals=[(1, 120.0), (2, 128.0)],
+            tp_vals=[],
+            ta_entries=[],
+            peak_brake_vals=[(1, 55.0), (2, 60.0)],
+            entry_speed_vals=[(1, 195.0), (2, 200.0)],
+            brake_release_vals=[(1, 180.0), (2, 175.0)],
+            braking_distance_vals=[(1, 80.0), (2, 75.0)],
+            mean_decel_g_vals=[(1, 1.1), (2, 1.3)],
+        )
+
+        assert result is not None
+        assert result.peak_brake is not None
+        assert result.entry_speed is not None
+        assert result.brake_release_point is not None
+        assert result.braking_distance is not None
+        assert result.mean_decel_g is not None
+        # vs_mean should include the new braking metrics
+        assert "peak_brake" in result.vs_mean
+        assert "entry_speed" in result.vs_mean
+
+
+class TestBrakingBalance:
+    """Tests for BrakingBalanceSummary dataclass and serialization."""
+
+    def test_create_braking_balance_summary(self):
+        """Test creating a BrakingBalanceSummary with test data."""
+        summary = BrakingBalanceSummary(
+            available=True,
+            front_channel="BrakePress",
+            rear_channel="BrakePressRear",
+            per_corner=[
+                {
+                    "corner_id": 1,
+                    "corner_name": "Turn 1",
+                    "balance_pct_mean": 62.5,
+                    "balance_pct_std": 1.2,
+                    "n_samples": 3,
+                }
+            ],
+            overall_balance_pct=62.5,
+            overall_balance_std=1.2,
+        )
+
+        assert summary.available is True
+        assert summary.front_channel == "BrakePress"
+        assert summary.overall_balance_pct == 62.5
+
+    def test_session_report_with_braking_balance(self):
+        """Test SessionReport serialization with braking_balance populated."""
+        report = SessionReport(
+            metadata=SessionMetadata(
+                file_name="test.xrz",
+                logger_id="12345",
+                vehicle_profile="Test Car",
+                total_laps=5,
+                valid_laps=4,
+                top_lap_count=3,
+                driver=None,
+                vehicle=None,
+                venue=None,
+                log_date=None,
+                log_time=None,
+            ),
+            lap_times=LapTimeSummary(
+                best_lap_num=2,
+                best_lap_time_s=90.5,
+                best_lap_time_fmt="1:30.500",
+                top_laps=[],
+                mean_top_lap_time_s=91.0,
+                mean_top_lap_time_fmt="1:31.000",
+                std_top_lap_time_s=0.5,
+                all_lap_times=[],
+            ),
+            corners=[],
+            corner_consistency=[],
+            track_length_m=4500.0,
+            suspension=None,
+            tire_grip=None,
+            tire_conditions=None,
+            weather=None,
+            available_analyses=["lap_times"],
+            skipped_analyses={},
+            braking_balance=BrakingBalanceSummary(
+                available=True,
+                front_channel="BrakePress",
+                rear_channel="BrakePressRear",
+                per_corner=[],
+                overall_balance_pct=60.0,
+                overall_balance_std=2.0,
+            ),
+        )
+
+        d = report.to_dict()
+        assert d["braking_balance"]["available"] is True
+        assert d["braking_balance"]["overall_balance_pct"] == 60.0
+
+        json_str = report.to_json()
+        parsed = json.loads(json_str)
+        assert parsed["braking_balance"]["front_channel"] == "BrakePress"
+
+    def test_session_report_braking_balance_none(self):
+        """Test SessionReport serialization with braking_balance=None."""
+        report = SessionReport(
+            metadata=SessionMetadata(
+                file_name="test.xrz",
+                logger_id=None,
+                vehicle_profile=None,
+                total_laps=3,
+                valid_laps=2,
+                top_lap_count=2,
+                driver=None,
+                vehicle=None,
+                venue=None,
+                log_date=None,
+                log_time=None,
+            ),
+            lap_times=LapTimeSummary(
+                best_lap_num=1,
+                best_lap_time_s=95.0,
+                best_lap_time_fmt="1:35.000",
+                top_laps=[],
+                mean_top_lap_time_s=95.0,
+                mean_top_lap_time_fmt="1:35.000",
+                std_top_lap_time_s=0.0,
+                all_lap_times=[],
+            ),
+            corners=[],
+            corner_consistency=[],
+            track_length_m=0.0,
+            suspension=None,
+            tire_grip=None,
+            tire_conditions=None,
+            weather=None,
+            available_analyses=["lap_times"],
+            skipped_analyses={},
+            braking_balance=None,
+        )
+
+        d = report.to_dict()
+        assert d["braking_balance"] is None
+
+        json_str = report.to_json()
+        parsed = json.loads(json_str)
+        assert parsed["braking_balance"] is None
+
+    def test_brake_balance_filtering_excludes_low_brake_corners(self):
+        """Low-brake corners (< 20% of session max) are excluded from balance stats."""
+        # Corner 1: high brake (100 bar total) -> 60% front bias
+        # Corner 2: high brake (90 bar total) -> 70% front bias
+        # Corner 3: low brake (15 bar total, < 20% of 100) -> 50% front bias (noise)
+        per_corner_data = [
+            (
+                {
+                    "corner_id": 1,
+                    "corner_name": "Turn 1",
+                    "balance_pct_mean": 60.0,
+                    "balance_pct_std": 1.0,
+                    "n_samples": 5,
+                    "peak_brake_mean": 100.0,
+                },
+                [59.0, 60.0, 61.0, 60.0, 60.0],
+            ),
+            (
+                {
+                    "corner_id": 2,
+                    "corner_name": "Turn 2",
+                    "balance_pct_mean": 70.0,
+                    "balance_pct_std": 1.5,
+                    "n_samples": 5,
+                    "peak_brake_mean": 90.0,
+                },
+                [69.0, 70.0, 71.0, 70.0, 70.0],
+            ),
+            (
+                {
+                    "corner_id": 3,
+                    "corner_name": "Turn 3",
+                    "balance_pct_mean": 50.0,
+                    "balance_pct_std": 5.0,
+                    "n_samples": 5,
+                    "peak_brake_mean": 15.0,
+                },
+                [45.0, 50.0, 55.0, 50.0, 50.0],
+            ),
+        ]
+
+        # Reproduce the filtering logic from report.py
+        session_max_peak = max(e["peak_brake_mean"] for e, _ in per_corner_data)
+        assert session_max_peak == 100.0
+
+        brake_threshold = session_max_peak * 0.2
+        assert brake_threshold == 20.0
+
+        filtered_pcts: list[float] = []
+        filtered_corners: list[dict] = []
+        for entry, pcts in per_corner_data:
+            if entry["peak_brake_mean"] >= brake_threshold:
+                filtered_corners.append(entry)
+                filtered_pcts.extend(pcts)
+
+        # Corner 3 (15 bar) should be excluded
+        assert len(filtered_corners) == 2
+        assert all(c["corner_id"] in (1, 2) for c in filtered_corners)
+
+        # Overall stats computed from filtered corners only (no 50% noise)
+        overall_mean = float(np.mean(filtered_pcts))
+        assert 60.0 < overall_mean < 70.0  # weighted mean of 60% and 70% groups
+
+        summary = BrakingBalanceSummary(
+            available=True,
+            front_channel="BrakePress",
+            rear_channel="BrakePressRear",
+            per_corner=filtered_corners,
+            overall_balance_pct=round(overall_mean, 1),
+            overall_balance_std=round(float(np.std(filtered_pcts)), 1),
+            min_brake_threshold=round(brake_threshold, 1),
+        )
+        assert summary.min_brake_threshold == 20.0
+        assert len(summary.per_corner) == 2
+
+    def test_brake_balance_filtering_keeps_all_when_all_high(self):
+        """All corners kept when all have significant brake pressure."""
+        per_corner_data = [
+            (
+                {
+                    "corner_id": 1,
+                    "corner_name": "Turn 1",
+                    "balance_pct_mean": 65.0,
+                    "balance_pct_std": 1.0,
+                    "n_samples": 3,
+                    "peak_brake_mean": 80.0,
+                },
+                [64.0, 65.0, 66.0],
+            ),
+            (
+                {
+                    "corner_id": 2,
+                    "corner_name": "Turn 2",
+                    "balance_pct_mean": 62.0,
+                    "balance_pct_std": 1.0,
+                    "n_samples": 3,
+                    "peak_brake_mean": 75.0,
+                },
+                [61.0, 62.0, 63.0],
+            ),
+        ]
+
+        session_max_peak = max(e["peak_brake_mean"] for e, _ in per_corner_data)
+        brake_threshold = session_max_peak * 0.2  # 16.0
+
+        filtered_corners = [
+            e for e, _ in per_corner_data if e["peak_brake_mean"] >= brake_threshold
+        ]
+        assert len(filtered_corners) == 2
+
+    def test_brake_balance_threshold_serialization(self):
+        """min_brake_threshold round-trips through JSON."""
+        summary = BrakingBalanceSummary(
+            available=True,
+            front_channel="BrakeF",
+            rear_channel="BrakeR",
+            per_corner=[
+                {
+                    "corner_id": 1,
+                    "corner_name": "Turn 1",
+                    "balance_pct_mean": 60.0,
+                    "balance_pct_std": 1.0,
+                    "n_samples": 3,
+                    "peak_brake_mean": 100.0,
+                }
+            ],
+            overall_balance_pct=60.0,
+            overall_balance_std=1.0,
+            min_brake_threshold=20.0,
+        )
+
+        report = SessionReport(
+            metadata=SessionMetadata(
+                file_name="test.xrz",
+                logger_id=None,
+                vehicle_profile=None,
+                total_laps=3,
+                valid_laps=2,
+                top_lap_count=2,
+                driver=None,
+                vehicle=None,
+                venue=None,
+                log_date=None,
+                log_time=None,
+            ),
+            lap_times=LapTimeSummary(
+                best_lap_num=1,
+                best_lap_time_s=90.0,
+                best_lap_time_fmt="1:30.000",
+                top_laps=[],
+                mean_top_lap_time_s=90.0,
+                mean_top_lap_time_fmt="1:30.000",
+                std_top_lap_time_s=0.0,
+                all_lap_times=[],
+            ),
+            corners=[],
+            corner_consistency=[],
+            track_length_m=4000.0,
+            suspension=None,
+            tire_grip=None,
+            tire_conditions=None,
+            weather=None,
+            available_analyses=["braking_balance"],
+            skipped_analyses={},
+            braking_balance=summary,
+        )
+
+        parsed = json.loads(report.to_json())
+        assert parsed["braking_balance"]["min_brake_threshold"] == 20.0
+
+
+class TestDetectOffTrackLaps:
+    """Tests for _detect_off_track_laps GPS deviation detection."""
+
+    @staticmethod
+    def _make_gps_data(
+        n_laps: int,
+        corner_start: float,
+        corner_end: float,
+        *,
+        offsets: dict[int, float] | None = None,
+    ) -> dict[int, tuple[np.ndarray, np.ndarray, np.ndarray]]:
+        """Build synthetic per-lap GPS data.
+
+        Creates a straight east-west track line. Each lap has the same path
+        unless an offset (in meters, north-south) is specified for that lap.
+        """
+        offsets = offsets or {}
+        # Track line: 0 to 500m, heading east at lat=35.0, lon=136.0
+        base_lat = 35.0
+        base_lon = 136.0
+        R = 6371000.0
+
+        per_lap: dict[int, tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
+        for lap in range(1, n_laps + 1):
+            dist = np.arange(0.0, 500.0, 1.0)
+            lat = np.full_like(dist, base_lat)
+            # Convert distance to longitude delta
+            lon = base_lon + np.degrees(dist / (R * np.cos(np.radians(base_lat))))
+
+            # Apply north-south offset for this lap (shift lat)
+            if lap in offsets:
+                offset_m = offsets[lap]
+                lat = lat + np.degrees(offset_m / R)
+
+            per_lap[lap] = (dist, lat, lon)
+
+        return per_lap
+
+    def test_no_off_track_when_all_laps_on_path(self):
+        """All laps on the same line -> no off-track detections."""
+        corner = _make_corner(id=1, start_dist=100.0, end_dist=200.0)
+        gps = self._make_gps_data(5, 100.0, 200.0)
+        result = _detect_off_track_laps(gps, [corner])
+        assert result == {}
+
+    def test_detects_large_deviation(self):
+        """One lap offset 20m from the path is flagged."""
+        corner = _make_corner(id=1, start_dist=100.0, end_dist=200.0)
+        gps = self._make_gps_data(5, 100.0, 200.0, offsets={3: 20.0})
+        result = _detect_off_track_laps(gps, [corner])
+        assert 1 in result
+        assert 3 in result[1]
+
+    def test_small_deviation_not_flagged(self):
+        """5m offset is within the default 10m threshold."""
+        corner = _make_corner(id=1, start_dist=100.0, end_dist=200.0)
+        gps = self._make_gps_data(5, 100.0, 200.0, offsets={3: 5.0})
+        result = _detect_off_track_laps(gps, [corner])
+        assert result == {}
+
+    def test_custom_threshold(self):
+        """8m offset detected with a tighter 6m threshold."""
+        corner = _make_corner(id=1, start_dist=100.0, end_dist=200.0)
+        gps = self._make_gps_data(5, 100.0, 200.0, offsets={2: 8.0})
+        result = _detect_off_track_laps(gps, [corner], deviation_threshold=6.0)
+        assert 1 in result
+        assert 2 in result[1]
+
+    def test_multiple_corners(self):
+        """Off-track detection works independently per corner."""
+        corner1 = _make_corner(id=1, start_dist=50.0, end_dist=120.0)
+        corner2 = _make_corner(id=2, start_dist=300.0, end_dist=400.0)
+
+        # Lap 2: offset only in corner 1 region, lap 4: offset everywhere
+        gps = self._make_gps_data(5, 50.0, 400.0)
+        # Manually shift lap 2 only in the corner 1 region
+        dist2, lat2, lon2 = gps[2]
+        R = 6371000.0
+        mask_c1 = (dist2 >= 0.0) & (dist2 <= 170.0)  # corner1 + margin
+        lat2_mod = lat2.copy()
+        lat2_mod[mask_c1] += np.degrees(25.0 / R)
+        gps[2] = (dist2, lat2_mod, lon2)
+
+        # Shift lap 4 everywhere (affects both corners)
+        dist4, lat4, lon4 = gps[4]
+        lat4_shifted = lat4 + np.degrees(25.0 / R)
+        gps[4] = (dist4, lat4_shifted, lon4)
+
+        result = _detect_off_track_laps(gps, [corner1, corner2])
+
+        # Corner 1: laps 2 and 4 off-track
+        assert 1 in result
+        assert {2, 4}.issubset(result[1])
+
+        # Corner 2: only lap 4 off-track
+        assert 2 in result
+        assert 4 in result[2]
+        assert 2 not in result[2]
+
+    def test_too_few_laps_skips_corner(self):
+        """Need at least 3 laps for median reference; 2 laps -> skip."""
+        corner = _make_corner(id=1, start_dist=100.0, end_dist=200.0)
+        gps = self._make_gps_data(2, 100.0, 200.0, offsets={2: 30.0})
+        result = _detect_off_track_laps(gps, [corner])
+        assert result == {}
+
+    def test_corner_outside_gps_range_skipped(self):
+        """Corner beyond GPS distance range produces no detections."""
+        corner = _make_corner(id=1, start_dist=600.0, end_dist=700.0)
+        gps = self._make_gps_data(5, 600.0, 700.0)  # GPS only covers 0-499m
+        result = _detect_off_track_laps(gps, [corner])
+        # Not enough interpolation points in-range -> skipped
+        assert result == {}
+
+    def test_empty_inputs(self):
+        """Empty GPS data or empty corners list -> empty result."""
+        corner = _make_corner(id=1, start_dist=100.0, end_dist=200.0)
+        assert _detect_off_track_laps({}, [corner]) == {}
+        gps = self._make_gps_data(5, 100.0, 200.0)
+        assert _detect_off_track_laps(gps, []) == {}
+
+    def test_negative_offset_detected(self):
+        """Negative (south) offset is also detected."""
+        corner = _make_corner(id=1, start_dist=100.0, end_dist=200.0)
+        gps = self._make_gps_data(5, 100.0, 200.0, offsets={1: -15.0})
+        result = _detect_off_track_laps(gps, [corner])
+        assert 1 in result
+        assert 1 in result[1]
+
+    def test_majority_off_track_flags_minority(self):
+        """When 3 of 5 laps are offset, the 2 normal laps get flagged instead.
+
+        The median path follows the majority, so the outlier detection
+        is relative — this tests that the function correctly identifies
+        laps deviating from the median regardless of which group is larger.
+        """
+        corner = _make_corner(id=1, start_dist=100.0, end_dist=200.0)
+        # Offset 3 laps by 20m; the 2 "normal" laps become the outliers
+        gps = self._make_gps_data(5, 100.0, 200.0, offsets={1: 20.0, 2: 20.0, 3: 20.0})
+        result = _detect_off_track_laps(gps, [corner])
+        assert 1 in result
+        # Laps 4,5 are now deviating from the median (which follows 1,2,3)
+        assert {4, 5}.issubset(result[1])
+
+
+class TestMakeSessionId:
+    """Tests for _make_session_id."""
+
+    def test_standard_date_time(self):
+        assert _make_session_id("01/12/2026", "13:00:05", 1) == "2026-01-12_1300_s01"
+
+    def test_session_num_padding(self):
+        assert _make_session_id("12/05/2025", "09:30:00", 3) == "2025-12-05_0930_s03"
+
+    def test_single_digit_month_day(self):
+        assert _make_session_id("1/5/2026", "8:05:00", 2) == "2026-01-05_0805_s02"
+
+    def test_none_date(self):
+        assert _make_session_id(None, "13:00:00", 1) is None
+
+    def test_none_time(self):
+        assert _make_session_id("01/12/2026", None, 1) is None
+
+    def test_both_none(self):
+        assert _make_session_id(None, None, 1) is None
+
+    def test_empty_strings(self):
+        assert _make_session_id("", "13:00:00", 1) is None
+        assert _make_session_id("01/12/2026", "", 1) is None
+
+    def test_malformed_date(self):
+        assert _make_session_id("2026-01-12", "13:00:00", 1) is None
+
+
+class TestCornerLapMetrics:
+    """Tests for CornerLapMetrics dataclass."""
+
+    def test_serialization_round_trip(self):
+        """CornerLapMetrics should round-trip through dict/JSON."""
+        from dataclasses import asdict
+
+        m = CornerLapMetrics(
+            lap_num=5,
+            braking_point=450.0,
+            entry_speed=195.0,
+            min_speed=80.0,
+            exit_speed=120.0,
+            throttle_point=510.0,
+            throttle_acceptance_pct=65.0,
+            peak_brake=55.0,
+            brake_release_point=180.0,
+            braking_distance=80.0,
+            mean_decel_g=1.2,
+        )
+        d = asdict(m)
+        assert d["lap_num"] == 5
+        assert d["exit_speed"] == 120.0
+        assert d["peak_brake"] == 55.0
+
+        json_str = json.dumps(d)
+        parsed = json.loads(json_str)
+        assert parsed["lap_num"] == 5
+        assert parsed["braking_point"] == 450.0
+
+    def test_none_fields(self):
+        """CornerLapMetrics with None fields serializes correctly."""
+        from dataclasses import asdict
+
+        m = CornerLapMetrics(
+            lap_num=3,
+            braking_point=None,
+            entry_speed=None,
+            min_speed=80.0,
+            exit_speed=120.0,
+            throttle_point=None,
+            throttle_acceptance_pct=None,
+            peak_brake=None,
+            brake_release_point=None,
+            braking_distance=None,
+            mean_decel_g=None,
+        )
+        d = asdict(m)
+        assert d["braking_point"] is None
+        assert d["min_speed"] == 80.0
+
+        json_str = json.dumps(d)
+        parsed = json.loads(json_str)
+        assert parsed["braking_point"] is None
+
+
+class TestCollatePerLapMetrics:
+    """Tests for _collate_per_lap_metrics."""
+
+    def test_basic_collation(self):
+        result = _collate_per_lap_metrics(
+            bp_vals=[(1, 450.0), (2, 452.0)],
+            entry_speed_vals=[(1, 195.0), (2, 200.0)],
+            min_speed_vals=[(1, 80.0), (2, 82.0)],
+            exit_speed_vals=[(1, 120.0), (2, 128.0)],
+            tp_vals=[(1, 510.0)],
+            ta_entries=[(1, 65.0)],
+            peak_brake_vals=[(1, 55.0), (2, 60.0)],
+            brake_release_vals=[(2, 175.0)],
+            braking_distance_vals=[(1, 80.0), (2, 75.0)],
+            mean_decel_g_vals=[(1, 1.1)],
+        )
+        assert len(result) == 2
+        assert result[0].lap_num == 1
+        assert result[0].braking_point == 450.0
+        assert result[0].throttle_point == 510.0
+        assert result[0].throttle_acceptance_pct == 65.0
+        assert result[0].brake_release_point is None  # not in lap 1
+
+        assert result[1].lap_num == 2
+        assert result[1].exit_speed == 128.0
+        assert result[1].throttle_point is None  # not in lap 2
+        assert result[1].brake_release_point == 175.0
+        assert result[1].mean_decel_g is None  # not in lap 2
+
+    def test_empty_inputs(self):
+        result = _collate_per_lap_metrics(
+            bp_vals=[],
+            entry_speed_vals=[],
+            min_speed_vals=[],
+            exit_speed_vals=[],
+            tp_vals=[],
+            ta_entries=[],
+            peak_brake_vals=[],
+            brake_release_vals=[],
+            braking_distance_vals=[],
+            mean_decel_g_vals=[],
+        )
+        assert result == []
+
+    def test_sorted_by_lap_num(self):
+        result = _collate_per_lap_metrics(
+            bp_vals=[(5, 1.0), (2, 2.0), (8, 3.0)],
+            entry_speed_vals=[],
+            min_speed_vals=[],
+            exit_speed_vals=[],
+            tp_vals=[],
+            ta_entries=[],
+            peak_brake_vals=[],
+            brake_release_vals=[],
+            braking_distance_vals=[],
+            mean_decel_g_vals=[],
+        )
+        assert [m.lap_num for m in result] == [2, 5, 8]
+
+
+class TestPerLapMetricsInCornerConsistency:
+    """Tests that per_lap_metrics appears in CornerConsistency serialized output."""
+
+    def test_per_lap_metrics_serializes(self):
+        from dataclasses import asdict
+
+        cc = CornerConsistency(
+            corner=CornerInfo(
+                id=1,
+                name="Turn 1",
+                direction="L",
+                start_dist=100.0,
+                end_dist=200.0,
+                apex_dist=150.0,
+                length=100.0,
+                radius=50.0,
+            ),
+            ta_mean=65.0,
+            ta_std=3.0,
+            bp_mean=450.0,
+            bp_std=2.5,
+            min_speed_mean=80.0,
+            min_speed_std=1.5,
+            exit_speed_mean=120.0,
+            exit_speed_std=3.0,
+            accel_zone_length=150.0,
+            opportunity_score=450.0,
+            best_lap=None,
+            per_lap_metrics=[
+                CornerLapMetrics(
+                    lap_num=1,
+                    braking_point=450.0,
+                    entry_speed=195.0,
+                    min_speed=80.0,
+                    exit_speed=120.0,
+                    throttle_point=510.0,
+                    throttle_acceptance_pct=65.0,
+                    peak_brake=55.0,
+                    brake_release_point=180.0,
+                    braking_distance=80.0,
+                    mean_decel_g=1.2,
+                ),
+            ],
+        )
+        d = asdict(cc)
+        assert "per_lap_metrics" in d
+        assert len(d["per_lap_metrics"]) == 1
+        assert d["per_lap_metrics"][0]["lap_num"] == 1
+        assert d["per_lap_metrics"][0]["exit_speed"] == 120.0
+
+        # JSON round-trip
+        json_str = json.dumps(d)
+        parsed = json.loads(json_str)
+        assert parsed["per_lap_metrics"][0]["braking_point"] == 450.0
+
+
+class TestSessionIdInMetadata:
+    """Tests that session_id appears in SessionMetadata."""
+
+    def test_session_id_in_serialized_output(self):
+        from dataclasses import asdict
+
+        meta = SessionMetadata(
+            file_name="test.xrz",
+            logger_id="12345",
+            vehicle_profile="Test Car",
+            total_laps=5,
+            valid_laps=4,
+            top_lap_count=3,
+            driver="CMD",
+            vehicle="Inferno 86",
+            venue="Sodegaura",
+            log_date="01/12/2026",
+            log_time="13:00:00",
+            session_id="2026-01-12_1300_s01",
+        )
+        d = asdict(meta)
+        assert d["session_id"] == "2026-01-12_1300_s01"
+
+        json_str = json.dumps(d)
+        parsed = json.loads(json_str)
+        assert parsed["session_id"] == "2026-01-12_1300_s01"
+
+    def test_session_id_none_by_default(self):
+        from dataclasses import asdict
+
+        meta = SessionMetadata(
+            file_name="test.xrz",
+            logger_id=None,
+            vehicle_profile=None,
+            total_laps=3,
+            valid_laps=2,
+            top_lap_count=2,
+            driver=None,
+            vehicle=None,
+            venue=None,
+            log_date=None,
+            log_time=None,
+        )
+        d = asdict(meta)
+        assert d["session_id"] is None


### PR DESCRIPTION

Enrich SessionMetadata with driver, vehicle, venue, date, and time from
AIM logger metadata. Fetch historical weather conditions (temperature,
humidity, wind, sky) from Open-Meteo's free archive API using the circuit's
GPS center coordinates and session start time.

Update session-analysis skill to display date/time and weather in the
Session Overview section.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
