### PR TITLE
Add split session detection and merging for multi-file telemetry sessions

### DIFF
--- a/.claude/skills/session-analysis/SKILL.md
+++ b/.claude/skills/session-analysis/SKILL.md
@@ -20,10 +20,16 @@ Analyze motorsports telemetry sessions, identify improvement areas, set KPIs, an
 For each provided file path, run:
 
 ```bash
-uv run python scripts/analyze_session.py "<file_path>" --output .session-analysis/report.json --track-map .session-analysis/track_map.png --comparison-dir .session-analysis/comparisons/
+uv run python scripts/analyze_session.py "<file_path>" --output .session-analysis/report.json --track-map .session-analysis/track_map.png --comparison-dir .session-analysis/comparisons/ --session-num <N>
 ```
 
-Read the JSON output with the Read tool. The `--track-map` flag generates a track map image with labeled corners. The `--comparison-dir` flag generates per-corner input comparison plots and zoomed GPS maps for the top 5 opportunity corners.
+Where `<N>` is the 1-based session number for the day (default: 1). This populates `metadata.session_id` in the JSON.
+
+Read the JSON output with the Read tool. After reading the JSON, use `metadata.session_id` for naming output files when called from the day-review skill (e.g., `session_2026-01-12_1300_s01_report.md`). For standalone use, the default names are fine.
+
+**No ad-hoc code:** The `analyze_session.py` script is the ONLY command you run via Bash. Do NOT run inline Python scripts, `python -c` one-liners, or any other data processing commands. All telemetry processing, metric computation, and image generation is handled by `analyze_session.py`. After it produces JSON + images, use only the Read tool to read the data and the Write tool to produce markdown reports. Everything you need is in the JSON output.
+
+The `--track-map` flag generates a track map image with labeled corners. The `--comparison-dir` flag generates per-corner input comparison plots and zoomed GPS maps for the top 5 opportunity corners.
 
 ### 2. Check for Previous Reports
 
@@ -60,15 +66,15 @@ Rank corners by impact and select the **top 3** for the main report. All remaini
 
 For each improvement area, use the `best_lap` data in the corner's consistency entry:
 
-> **Turn N — Corner Exit Speed**
-> Your best execution was on **Lap X**: you braked Ym later than average, carried Z km/h more through the apex, and exited W km/h faster.
-> **Target**: Replicate this on 80%+ of laps.
+**Turn N — Corner Exit Speed**
+Your best execution was on **Lap X**: you braked Ym later than average, carried Z km/h more through the apex, and exited W km/h faster.
+**Target**: Replicate this on 80%+ of laps.
 
 When braking metrics are available, include them in the best-lap description:
 
-> **Turn N — Braking Zone**
-> Your best execution was on **Lap X**: you braked W bar harder, released Y m earlier, and carried Z km/h more entry speed than average.
-> **Target**: Replicate this on 80%+ of laps.
+**Turn N — Braking Zone**
+Your best execution was on **Lap X**: you braked W bar harder, released Y m earlier, and carried Z km/h more entry speed than average.
+**Target**: Replicate this on 80%+ of laps.
 
 Reference `best_lap.vs_mean` for the specific deltas and `best_lap.selection_reason` for context.
 
@@ -79,9 +85,9 @@ Reference `best_lap.vs_mean` for the specific deltas and `best_lap.selection_rea
 
 Format the explanation as a ranked list of contributing factors:
 
-> **Why was Lap X faster at Turn N?**
-> 1. **Got on throttle 8m earlier** — the biggest factor
-> 2. **Carried 2.4 km/h more through the apex**
+**Why was Lap X faster at Turn N?**
+1. **Got on throttle 8m earlier** — the biggest factor
+2. **Carried 2.4 km/h more through the apex**
 
 Only include factors with meaningful deltas (speed > 1 km/h, distance > 2m, TA > 5%). Rank by impact magnitude. If no clear cause can be determined from the data, state that rather than guessing.
 
@@ -92,7 +98,9 @@ Only include factors with meaningful deltas (speed > 1 km/h, distance > 2m, TA >
 | entry | "Trail brake deeper — releasing brake before turn-in wastes lateral G" |
 | exit | "Get on throttle earlier — pause between turning and accelerating costs grip" |
 | mid | "Commit through the apex — lifting mid-corner breaks momentum" |
-| braking | "Apply brakes more progressively — abrupt application creates a grip gap" |
+| braking | "Brake later — you finished braking before the corner and coasted into the turn" |
+
+When `total_g_min_phase = "braking"`, always check `early_braking_coast_m` (on the best lap or the corner-level mean `early_braking_coast_mean`). This measures the distance from where braking G faded to the corner start — the "dead zone" where the driver is neither braking nor turning. Include the distance in the note: "You coasted Xm before the corner — brake that much later to flow directly into turn-in."
 
 Only mention G utilization for corners where it's below 70%. Don't add a standalone G utilization table — fold it into the improvement area notes.
 
@@ -126,32 +134,34 @@ Output the **main report** (focused, actionable) and an **appendix** (full data 
    3. **T4**: Full throttle sooner — you proved it on Lap 9
    ```
    Each item should be one line with the corner ID and the specific action. Reference a lap number where the driver proved they can do it. This must be concise enough to remember while driving.
-3. **Session Overview** — Include the session date/time (`metadata.log_date`, `metadata.log_time`), driver (`metadata.driver`), vehicle (`metadata.vehicle`), venue (`metadata.venue`), weather conditions (`weather`), lap times, and track info. Format example:
+3. **Session Overview** — Include the session date/time (`metadata.log_date`, `metadata.log_time`), driver (`metadata.driver`), vehicle (`metadata.vehicle`), venue (`metadata.venue`), weather conditions (`weather`), lap times, and track info. If `metadata.session_notes` is present, include it as a blockquote — these are engineer/driver notes recorded at the track (setup changes, driver feedback, tire compound, etc.). Use these notes to add context to the analysis (e.g., if notes say "lots of oversteer," correlate that with rear grip data). If the notes contain abbreviations or references you don't understand, ask the user for clarification rather than guessing. Format example:
    ```
    **Date:** 2026-01-12 13:00 | **Driver:** CMD | **Vehicle:** Inferno 86
    **Venue:** Sodegaura | **Weather:** Clear sky, 8.7°C, 37% humidity, wind 4.2 km/h WNW
+
+   > **Session Notes:** Rear 23, still lots of oversteer, lots of pickup
    ```
    Weather comes from the Open-Meteo historical API (fetched automatically using circuit GPS center). Include `weather_description`, `temperature_c`, `relative_humidity_pct`, `wind_speed_kmh`, and `wind_direction_deg` (convert degrees to compass direction). Omit the weather line if `weather` is null.
 4. **Top 3 Improvement Areas** — the 3 highest-impact corners only. For each corner, use this format:
    ```
    ### N. Turn X — Short Description (Opportunity: NNNN)
 
-   | Metric | Value | Std | Best Lap |
-   |--------|-------|-----|----------|
-   | Min Speed | 93.5 km/h | 4.2 km/h | 95.3 km/h (L11) |
-   | Exit Speed | 120.8 km/h | 2.7 km/h | 124.9 km/h (L11) |
-   | Throttle Acceptance | 78.4% | 17.8% | 98.8% (L11) |
-   | Braking Point | 450m | 4.1m | 452.6m (L11) |
+   | Metric | Value | Consistency | Best Lap |
+   |--------|-------|-------------|----------|
+   | Min Speed | 93.5 km/h | 4.2 km/h | 95.3 km/h (Lap 11) |
+   | Exit Speed | 120.8 km/h | 2.7 km/h | 124.9 km/h (Lap 11) |
+   | Throttle Acceptance | 78.4% | 17.8% | 98.8% (Lap 11) |
+   | Braking Point | 450m | 4.1m | 452.6m (Lap 11) |
    | G Utilization | 40.3% | — | — |
 
    (Only include rows for metrics that are relevant/available for this corner.)
 
-   > **Best Execution: Lap 11**
-   > ...root cause analysis...
-   >
-   > **Technique:** ...G utilization note if < 70%...
-   >
-   > **Target:** ...
+   **Best Execution: Lap 11**
+   ...root cause analysis...
+
+   **Technique:** ...G utilization note if < 70%...
+
+   **Target:** ...
 
    ![Turn X Inputs](comparisons/comparison_t{id}_inputs.png)
    ![Turn X Map](comparisons/comparison_t{id}_map.png)
@@ -161,7 +171,7 @@ Output the **main report** (focused, actionable) and an **appendix** (full data 
    ```
    ## Tire Conditions
 
-   Best lap (L9):
+   Best lap (Lap 9):
    | Wheel | Max Pressure | Max Temperature |
    |-------|-------------|-----------------|
    | FL | 2.29 bar | 55 C |
@@ -170,6 +180,8 @@ Output the **main report** (focused, actionable) and an **appendix** (full data 
    | RR | 2.16 bar | 44 C |
    ```
    Include units from `tire_conditions.pressure_unit` and `tire_conditions.temperature_unit`. Show whichever metrics are available (both pressure and temperature when present). Omit this section if `tire_conditions` is null.
+
+   **Important:** Present tire data as-is without making qualitative judgments (e.g., "low" or "high"). Normal pressure and temperature ranges vary by car, tire compound, and target setup — the analysis tool has no reference values to judge against. Only note objective cross-wheel differences (e.g., "RR pressure 0.10 bar lower than other corners") and trends across laps or sessions. Leave interpretation to the driver/engineer.
 6. **KPIs** — at most 3 targets for next session, all tied to the highlighted corners
 7. **Skipped Analyses** — any analyses that couldn't run and why (omit if none)
 
@@ -186,18 +198,67 @@ Write a separate appendix file alongside the main report (e.g., `report_appendix
 
 Link to the appendix from the main report: `See [full corner analysis](report_appendix.md) for all corners, brake balance, and setup notes.`
 
+### File Naming
+
+When `metadata.session_id` is available, use it for output file naming to make files self-describing:
+
+- Report: `session_<session_id>_report.md` (e.g., `session_2026-01-12_1300_s01_report.md`)
+- Appendix: `session_<session_id>_appendix.md`
+- JSON: `session_<session_id>_data.json`
+
+Include the driver name and vehicle in the report's H1 heading:
+```
+# Session Report — CMD / Inferno 86 — Sodegaura S1
+```
+Where "CMD" is `metadata.driver`, "Inferno 86" is `metadata.vehicle`, "Sodegaura" is `metadata.venue`, and "S1" is the session number. Omit any field that is null.
+
+When called from the day-review skill with step-based naming, the step prefix takes precedence but the session_id should still appear in the report heading.
+
+### Driver & Vehicle Awareness
+
+Always display driver and vehicle prominently:
+- **Report H1 heading**: Include driver, vehicle, venue, and session number (see File Naming above)
+- **Session Overview**: Always show `metadata.driver` and `metadata.vehicle` even if null (display "Unknown" as placeholder)
+
+When comparing across sessions, check `metadata.driver` and `metadata.vehicle`:
+
+- **Same driver + same car**: Full comparison is valid — compare all metrics
+- **Different driver + same car**: Compare **best-lap values** across drivers as proof of car capability. Any metric where the other driver achieved a better best-lap value is valid evidence that the car can do it:
+  - Speeds: `best_lap.exit_speed`, `best_lap.min_speed`, `best_lap.entry_speed`
+  - Technique: `best_lap.throttle_acceptance_pct`, `best_lap.braking_point`, `best_lap.brake_release_point`, `best_lap.g_utilization_pct`, `best_lap.early_braking_coast_m`
+  - Use phrasing like: "Sobu San achieved 95% throttle acceptance at T5 in S2 — this proves the car allows aggressive throttle application here. Your best was 84% — room to improve."
+  - Do **NOT** compare consistency/progression metrics across drivers: all `_std` metrics, `_mean` metrics, `opportunity_score`. These reflect driver skill level, not car capability.
+  - Do **NOT** compare driver progression (e.g., "Driver A improved more than Driver B"). Each driver's progression is tracked independently.
+- **Different car**: Skip cross-session corner comparison entirely (different car = different physics)
+
 ### Cross-Session Comparison
 
 When previous session report(s) are available:
 
 1. **Verify track match**: corner count and track layout should match (same turn IDs)
-2. **Compare KPIs**: read the KPI table from the previous report and calculate progress:
+2. **Check weather stability** before comparing per-corner data:
+
+   | Condition | Threshold |
+   |-----------|-----------|
+   | Temperature | Within 5°C |
+   | Rain transition | No dry↔wet (WMO codes 0–3 = dry, 51+ = precipitation) |
+   | Wind speed | Within 15 km/h |
+
+   If weather changed significantly, note it in the report and skip per-corner lap-level comparisons for that session pair. KPI trend comparison (mean/std) is still valid.
+
+3. **Compare KPIs**: read the KPI table from the previous report and calculate progress:
    - Status: **MET** (reached target), **IMPROVED** (moved toward target), **REGRESSED** (moved away), **UNCHANGED** (< 5% change)
-3. **Generate comparison section** in the report showing previous → current → target for each KPI
-4. **Update KPIs** — keep unmet KPIs, adjust targets for met ones, add new areas
+4. **Per-corner lap-level comparison** (new): When previous session JSON is available and weather is stable:
+   - Read `corner_consistency[*].per_lap_metrics` from the previous JSON
+   - Compare current session's per-corner best values against previous session's per-lap data at matching corners (same corner ID)
+   - Report improvements: "Your best exit at T3 was 124.9 km/h (Lap 11), up from 122.1 km/h best in Session 1 (Lap 7)"
+   - **Causality**: only reference older sessions, never newer ones
+5. **Generate comparison section** in the report showing previous → current → target for each KPI
+6. **Update KPIs** — keep unmet KPIs, adjust targets for met ones, add new areas
 
 ### Important Notes
 
+- **Prefer `.xrk` over `.xrz`:** When both formats exist, use `.xrk`. XRK files have correct metadata (driver, vehicle, etc.) while XRZ compressed archives can have stale/incorrect metadata fields.
 - The report JSON uses canonical channel key names, not raw AIM channel names
 - `opportunity_score = exit_speed_std × accel_zone_length` — higher means more lap time to gain
 - All speeds are in km/h, distances in meters, times in seconds
@@ -222,7 +283,7 @@ G utilization measures how continuously the driver uses available tire grip thro
 - `total_g_min_phase = "entry"` → trail braking gap — brakes released before turn-in builds lateral G. Fix: maintain brake pressure deeper into the turn, release gradually as steering input increases
 - `total_g_min_phase = "exit"` → exit hesitation — gap between turning and accelerating. Fix: begin throttle application earlier while still unwinding steering
 - `total_g_min_phase = "mid"` → mid-corner lift — driver pauses or lifts at apex. Fix: carry more commitment through the apex
-- `total_g_min_phase = "braking"` → late/abrupt brake application creating a gap before peak braking force
+- `total_g_min_phase = "braking"` → braking too early — driver finished braking and coasted before the corner started. Check `early_braking_coast_m` for the distance. Fix: brake later so braking flows directly into turn-in via trail braking
 
 **Severity thresholds:**
 - `g_utilization_mean` < 30% → HIGH — large G holes, major coaching priority
@@ -231,6 +292,14 @@ G utilization measures how continuously the driver uses available tire grip thro
 - `g_utilization_mean` >= 70% → OK — smooth transitions
 
 Compare per-phase G means (`braking_g_mean_val`, `entry_g_mean_val`, `mid_g_mean_val`, `exit_g_mean_val`): the lowest phase is where the driver is leaving grip on the table.
+
+### Report Formatting Conventions
+
+- **Lap references**: Always write "Lap 1", "Lap 2", etc. — never abbreviate to "L1", "L2"
+- **Throttle acceptance**: Always write "throttle acceptance" in full — never abbreviate to "TA"
+- **Consistency, not std**: When describing variation to the driver, say "consistency" not "std" or "standard deviation". E.g., "exit speed consistency: 2.7 km/h" not "exit speed std: 2.7 km/h". The underlying metric names in code/tables can still use `_std` but narrative text should say consistency.
+- **No blockquotes for analysis details**: Use normal formatting (bold headers, paragraphs, lists) for best execution descriptions, technique notes, and targets. Do not wrap them in blockquotes (`>`). Blockquotes are only for session notes from the logger metadata.
+- **Table headers**: Use "Consistency" instead of "Std" as the column header in metrics tables
 
 ### Brake Balance Interpretation
 

--- a/.claude/skills/session-day-review/SKILL.md
+++ b/.claude/skills/session-day-review/SKILL.md
@@ -23,7 +23,44 @@ List all `.xrz` and `.xrk` files in the specified directory, sorted by filename 
 ls -1 "<directory_path>"/*.xrz "<directory_path>"/*.xrk 2>/dev/null | sort
 ```
 
+**Prefer `.xrk` over `.xrz`:** When both formats exist for the same session (same base name), use the `.xrk` file. XRK files contain the raw data with correct metadata (driver name, etc.), while XRZ compressed archives can have stale/incorrect metadata fields. Deduplicate by base name and pick `.xrk` when both are present.
+
 Print the list of files found and confirm with the user before proceeding.
+
+#### Detect split sessions
+
+AIM loggers create a new file when the car is restarted (e.g., after a spin). These split files are really one session and should be merged for analysis. After deduplicating to `.xrk` files, run:
+
+```bash
+uv run python scripts/group_sessions.py <file1> <file2> ... [--max-gap 30]
+```
+
+This outputs a JSON array of groups. Each group is one logical session (one or more files). Example output:
+
+```json
+[
+  ["file_0095.xrk", "file_0096.xrk"],
+  ["file_0098.xrk"],
+  ["file_0100.xrk", "file_0101.xrk"]
+]
+```
+
+Files are grouped when they have the same driver, same venue, and a time gap < 30 minutes.
+
+Parse the JSON and present the grouping to the user, showing start times, lap counts, and gaps for merged files:
+
+```
+Detected 3 logical sessions from 5 files:
+  Session 1: file_0095.xrk (08:51, 9 laps) + file_0096.xrk (09:11, 4 laps) — merged, 20 min gap
+  Session 2: file_0098.xrk (10:10, 14 laps)
+  Session 3: file_0100.xrk (11:32, 3 laps) + file_0101.xrk (11:49, 7 laps) — merged, 17 min gap
+```
+
+Confirm with the user before proceeding. When spawning session analyzer agents, pass all files in a group as arguments to `analyze_session.py`. The script handles merging internally (renumbers laps, excludes partial boundary laps). For example:
+
+```
+uv run python scripts/analyze_session.py "file_0095.xrk" "file_0096.xrk" --output ... --session-num 1
+```
 
 ### 2. Set Up Team and Analyze Sessions
 
@@ -65,14 +102,16 @@ Agent tool with:
       Session file: <file_path>
       Step number: 01
 
-      1. Run: uv run python scripts/analyze_session.py "<file_path>" --output .session-analysis/step01_data.json --track-map .session-analysis/step01_track_map.png --comparison-dir .session-analysis/step01_comparisons/
+      1. Run: uv run python scripts/analyze_session.py "<file_path>" --output .session-analysis/step01_data.json --track-map .session-analysis/step01_track_map.png --comparison-dir .session-analysis/step01_comparisons/ --session-num 1
       2. Read the JSON output with the Read tool
       3. No previous reports — this is the first session
-      4. Follow the SKILL.md: identify improvements, set KPIs, generate markdown report
-      5. Write the markdown report to .session-analysis/step01_report.md
+      4. Note the driver name (metadata.driver) and vehicle (metadata.vehicle) — include both in the report heading and Session Overview
+      5. Follow the SKILL.md: identify improvements, set KPIs, generate markdown report
+      6. Write the markdown report to .session-analysis/step01_report.md
          - Reference track map as ![Track Map](step01_track_map.png)
          - Reference comparisons as ![Turn N Inputs](step01_comparisons/comparison_t{id}_inputs.png)
-      6. Send a message to the team lead with a brief status
+      7. Write the appendix to .session-analysis/step01_appendix.md
+      8. Send a message to the team lead with a brief status including the driver name
 ```
 
 For **session N** (N > 1, with previous reports):
@@ -90,16 +129,24 @@ Agent tool with:
       Session file: <file_path>
       Step number: <NN>
 
-      1. Run: uv run python scripts/analyze_session.py "<file_path>" --output .session-analysis/step<NN>_data.json --track-map .session-analysis/step<NN>_track_map.png --comparison-dir .session-analysis/step<NN>_comparisons/
+      1. Run: uv run python scripts/analyze_session.py "<file_path>" --output .session-analysis/step<NN>_data.json --track-map .session-analysis/step<NN>_track_map.png --comparison-dir .session-analysis/step<NN>_comparisons/ --session-num <N>
       2. Read the JSON output with the Read tool
-      3. Read the previous session report for cross-session comparison:
-         .session-analysis/step<NN-1>_report.md
-      4. Follow the SKILL.md: identify improvements, set KPIs, compare against previous KPIs
-      5. Write the markdown report to .session-analysis/step<NN>_report.md
+      3. Read the previous session's markdown report AND JSON for cross-session comparison:
+         - Markdown: .session-analysis/step<NN-1>_report.md (for KPI comparison)
+         - JSON: .session-analysis/step<NN-1>_data.json (for per-lap corner data in corner_consistency[*].per_lap_metrics)
+      4. Check driver/vehicle: compare metadata.driver and metadata.vehicle between current and previous JSON.
+         - Same driver + same car: full comparison valid
+         - Different driver + same car: only compare car capability metrics (see SKILL.md "Driver & Vehicle Awareness")
+         - Different car: skip cross-session corner comparison
+      5. Check weather stability between sessions (see SKILL.md "Cross-Session Comparison" thresholds). If weather changed significantly, note it and skip per-corner lap-level comparisons.
+      6. Follow the SKILL.md: identify improvements, set KPIs, compare against previous KPIs
+      7. Write the markdown report to .session-analysis/step<NN>_report.md
          - Reference track map as ![Track Map](step<NN>_track_map.png)
          - Reference comparisons as ![Turn N Inputs](step<NN>_comparisons/comparison_t{id}_inputs.png)
          - Include a KPI progress section comparing current values to previous report's targets
-      6. Send a message to the team lead with a brief status
+         - Include driver/vehicle in heading and Session Overview
+      8. Write the appendix to .session-analysis/step<NN>_appendix.md
+      9. Send a message to the team lead with a brief status including the driver name
 ```
 
 **Context isolation:**
@@ -110,7 +157,7 @@ Agent tool with:
 
 ### 3. Generate Day Summary
 
-After all sessions are processed, spawn one final team member to read all the markdown reports and generate the day summary:
+After all sessions are processed, spawn one final team member to read all the markdown reports and JSON data files, then generate the day summary:
 
 ```
 Agent tool with:
@@ -121,7 +168,10 @@ Agent tool with:
   - team_name: "session-analysis"
   - prompt: |
       Read all session reports from .session-analysis/step*_report.md.
+      Also read all session JSON files from .session-analysis/step*_data.json to get metadata (driver, vehicle, session_id).
       Follow the day summary format in .claude/skills/session-day-review/SKILL.md section "Day Summary Format".
+      Include driver name(s) and vehicle in the day summary heading.
+      If drivers changed between sessions, note it in the summary and flag which comparisons used car-capability-only mode.
       Write the result to .session-analysis/day_summary_YYYY-MM-DD.md.
       When done, send a message to the team lead with "Day summary written to .session-analysis/day_summary_YYYY-MM-DD.md".
 ```
@@ -130,10 +180,20 @@ When the day summary agent completes, shut it down, delete the team, tell the us
 
 ### Day Summary Format
 
+The day summary heading should include driver, vehicle, venue, and date:
+```
+# Day Summary — CMD / Inferno 86 — Sodegaura — 2026-01-12
+```
+
 The day summary markdown should cover:
 
+#### Driver & Vehicle
+- List the driver(s) and vehicle for each session
+- If the driver changed between sessions, clearly note which sessions had which driver
+- Flag that cross-session comparisons between different drivers used car-capability-only mode
+
 #### Lap Time Progression
-- Table: Session # | Best Lap | Mean Top Lap | Lap Count | Improvement vs Previous
+- Table: Session # | Driver | Best Lap | Mean Top Lap | Lap Count | Improvement vs Previous
 - Trend: improving, plateauing, or regressing across the day
 - Note any session where times got significantly worse (potential setup change, tire degradation, or fatigue)
 
@@ -177,9 +237,11 @@ Where `YYYY-MM-DD` is today's date.
 ### Important Notes
 
 - Sessions must be from the same track (verify corner count and track layout match across reports)
-- Sequential processing is required because each session reads the previous session's markdown report for cross-session comparison
+- Sequential processing is required because each session reads the previous session's markdown report and JSON for cross-session comparison
 - If a session fails to analyze, log the error and continue with remaining sessions
 - The day summary should reference specific session numbers and lap numbers for actionable feedback
 - All speeds in km/h, distances in meters, times in seconds
 - Each teammate's context is isolated — the controller reads only their short status messages
-- Cross-session state is carried entirely through the markdown reports — no separate JSON state files
+- Cross-session state is carried through both markdown reports (KPIs, narrative) and JSON files (per-lap corner data, metadata)
+- **Driver changes**: Check `metadata.driver` from each session JSON. If drivers differ between consecutive sessions, the session agent switches to car-capability-only comparison mode. The day summary should clearly note driver changes.
+- **Weather stability**: Agents compare `weather` objects between consecutive sessions. If temperature differs by >5°C, wind by >15 km/h, or a dry↔wet transition occurred, per-corner lap-level comparisons are skipped for that pair.

--- a/scripts/analyze_session.py
+++ b/scripts/analyze_session.py
@@ -3,6 +3,11 @@
 
 Usage:
     uv run python scripts/analyze_session.py path/to/session.xrz [options]
+    uv run python scripts/analyze_session.py file1.xrk file2.xrk [options]
+
+When multiple files are provided, they are merged into a single session
+(e.g., when a session is split across files due to a car restart). Laps
+are renumbered sequentially across all files.
 
 Options:
     --output FILE            Write JSON to file instead of stdout
@@ -21,7 +26,7 @@ from pathlib import Path
 
 import numpy as np
 
-from motorsports_data_notebook._util import load_session
+from motorsports_data_notebook._util import MergedLogFile, load_session
 from motorsports_data_notebook.profiles import (
     DEFAULT_CHANNEL_NAMES,
     get_logger_id,
@@ -36,7 +41,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Generate a structured session analysis report from AIM telemetry data."
     )
-    parser.add_argument("session_file", help="Path to XRK/XRZ/IBT telemetry file")
+    parser.add_argument(
+        "session_file",
+        nargs="+",
+        help="Path(s) to XRK/XRZ/IBT telemetry file(s). Multiple files are merged into one session.",
+    )
     parser.add_argument("--output", "-o", help="Output file path (default: stdout)")
     parser.add_argument("--profile", "-p", help="Vehicle profile name (overrides auto-detect)")
     parser.add_argument(
@@ -54,19 +63,36 @@ def main() -> int:
         "--comparison-dir",
         help="Save corner comparison images (inputs + map) to this directory",
     )
+    parser.add_argument(
+        "--session-num",
+        type=int,
+        default=1,
+        help="Session number for the day (1-based, used in session_id)",
+    )
     args = parser.parse_args()
 
-    session_path = Path(args.session_file)
-    if not session_path.exists():
-        print(f"Error: file not found: {session_path}", file=sys.stderr)
-        return 1
+    session_paths = [Path(f) for f in args.session_file]
+    for p in session_paths:
+        if not p.exists():
+            print(f"Error: file not found: {p}", file=sys.stderr)
+            return 1
 
-    # Load session
+    # Load session(s)
     try:
-        log = load_session(str(session_path))
+        logs = [load_session(str(p)) for p in session_paths]
+        if len(logs) == 1:
+            log = logs[0]
+        else:
+            log = MergedLogFile(logs)
+            print(
+                f"Merged {len(logs)} files into one session "
+                f"({len(log.laps)} total laps)",
+                file=sys.stderr,
+            )
     except Exception as e:
         print(f"Error loading session: {e}", file=sys.stderr)
         return 2
+    session_path = session_paths[0]
 
     # Resolve profile and channel names
     if args.profile:
@@ -100,6 +126,7 @@ def main() -> int:
             motion_ratios=motion_ratios,
             top_lap_threshold=args.threshold,
             file_name=session_path.name,
+            session_num=args.session_num,
         )
     except Exception as e:
         print(f"Error generating report: {e}", file=sys.stderr)
@@ -398,7 +425,9 @@ def _generate_comparison_images(
         count += 1
 
     if count > 0:
-        print(f"Corner comparison images saved to {comparison_dir} ({count} corners)", file=sys.stderr)
+        print(
+            f"Corner comparison images saved to {comparison_dir} ({count} corners)", file=sys.stderr
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/group_sessions.py
+++ b/scripts/group_sessions.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Detect and group split session files into logical sessions.
+
+AIM loggers create a new file when the car is restarted (e.g., after a spin).
+This script detects split sessions by comparing metadata timestamps and groups
+files that belong to the same on-track session.
+
+Usage:
+    uv run python scripts/group_sessions.py file1.xrk file2.xrk file3.xrk ...
+
+Output:
+    JSON array of session groups with metadata for display:
+
+    [
+      {
+        "files": [
+          {"path": "file_0095.xrk", "start": "08:51:22", "laps": 9},
+          {"path": "file_0096.xrk", "start": "09:11:32", "laps": 4}
+        ],
+        "gap_minutes": [20.2],
+        "driver": "CMD",
+        "venue": "Fuji GP Sh"
+      },
+      ...
+    ]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from motorsports_data_notebook._util import load_session
+
+
+def _parse_aim_datetime(date_str: str, time_str: str) -> datetime | None:
+    """Parse AIM metadata date/time strings into a datetime.
+
+    AIM uses MM/DD/YYYY for dates and HH:MM:SS for times.
+    """
+    if not date_str or not time_str:
+        return None
+    try:
+        return datetime.strptime(f"{date_str} {time_str}", "%m/%d/%Y %H:%M:%S")
+    except ValueError:
+        return None
+
+
+def group_session_files(
+    files: list[str],
+    max_gap_minutes: float = 30.0,
+) -> list[dict]:
+    """Group consecutive session files into logical sessions.
+
+    Files are grouped when they have the same driver, same venue,
+    and a time gap of less than max_gap_minutes between them.
+
+    Parameters
+    ----------
+    files : list[str]
+        Sorted list of file paths.
+    max_gap_minutes : float
+        Maximum time gap (in minutes) to consider files part of the
+        same session. Default: 30.
+
+    Returns
+    -------
+    list[dict]
+        Groups with metadata. Each group has:
+        - files: list of {path, start, laps} dicts
+        - gap_minutes: list of gaps between consecutive files in the group
+        - driver: driver name
+        - venue: venue name
+    """
+    if not files:
+        return []
+
+    # Extract metadata from each file
+    file_info: list[dict] = []
+    for f in files:
+        log = load_session(f)
+        meta = log.metadata or {}
+        dt = _parse_aim_datetime(meta.get("Log Date", ""), meta.get("Log Time", ""))
+        file_info.append(
+            {
+                "path": f,
+                "datetime": dt,
+                "start": meta.get("Log Time", ""),
+                "laps": len(log.laps),
+                "driver": meta.get("Driver", ""),
+                "venue": meta.get("Venue", ""),
+            }
+        )
+
+    def _make_file_entry(info: dict) -> dict:
+        return {"path": info["path"], "start": info["start"], "laps": info["laps"]}
+
+    # Group consecutive files
+    groups: list[dict] = [
+        {
+            "files": [_make_file_entry(file_info[0])],
+            "gap_minutes": [],
+            "driver": file_info[0]["driver"],
+            "venue": file_info[0]["venue"],
+        }
+    ]
+
+    for i in range(1, len(file_info)):
+        prev = file_info[i - 1]
+        curr = file_info[i]
+
+        same_driver = prev["driver"] == curr["driver"]
+        same_venue = prev["venue"] == curr["venue"]
+
+        gap_min = None
+        within_gap = False
+        if prev["datetime"] and curr["datetime"]:
+            gap_min = (curr["datetime"] - prev["datetime"]).total_seconds() / 60.0
+            within_gap = gap_min < max_gap_minutes
+
+        if same_driver and same_venue and within_gap:
+            groups[-1]["files"].append(_make_file_entry(curr))
+            groups[-1]["gap_minutes"].append(round(gap_min, 1))
+        else:
+            groups.append(
+                {
+                    "files": [_make_file_entry(curr)],
+                    "gap_minutes": [],
+                    "driver": curr["driver"],
+                    "venue": curr["venue"],
+                }
+            )
+
+    return groups
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect and group split session files into logical sessions."
+    )
+    parser.add_argument(
+        "files",
+        nargs="+",
+        help="Telemetry file paths, sorted by session order.",
+    )
+    parser.add_argument(
+        "--max-gap",
+        type=float,
+        default=30.0,
+        help="Maximum time gap in minutes to merge sessions (default: 30).",
+    )
+    args = parser.parse_args()
+
+    for f in args.files:
+        if not Path(f).exists():
+            print(f"Error: file not found: {f}", file=sys.stderr)
+            return 1
+
+    groups = group_session_files(args.files, max_gap_minutes=args.max_gap)
+    print(json.dumps(groups, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/motorsports_data_notebook/_types.py
+++ b/src/motorsports_data_notebook/_types.py
@@ -8,4 +8,6 @@ if TYPE_CHECKING:
     from libxrk.base import LogFile as AimLogFile
     from libibt.base import LogFile as IbtLogFile
 
-    LogFile = AimLogFile | IbtLogFile
+    from ._util import MergedLogFile
+
+    LogFile = AimLogFile | IbtLogFile | MergedLogFile

--- a/src/motorsports_data_notebook/_util.py
+++ b/src/motorsports_data_notebook/_util.py
@@ -260,3 +260,121 @@ def _post_process_session(log: "LogFile") -> "LogFile":
 
     log.laps = clean_laps(log.laps)
     return log
+
+
+# ---------------------------------------------------------------------------
+# Session merging
+# ---------------------------------------------------------------------------
+
+
+class MergedLogFile:
+    """Wrapper that presents multiple LogFile objects as a single session.
+
+    Used when a single on-track session is split across multiple files
+    (e.g., car restart after a spin). Renumbers laps sequentially and
+    delegates filter_by_lap() to the correct underlying file.
+
+    The wrapper is duck-type compatible with LogFile — it exposes the same
+    attributes (metadata, channels, laps, file_name) and the critical
+    filter_by_lap() method that the analysis pipeline relies on.
+    """
+
+    def __init__(self, logs: list) -> None:
+        if len(logs) < 2:
+            raise ValueError("MergedLogFile requires at least 2 LogFile objects")
+
+        self._logs = logs
+
+        # Build lap mapping: new_num -> (log_index, original_num)
+        self._lap_map: dict[int, tuple[int, int]] = {}
+
+        # Collect all lap durations to compute median for partial-lap detection
+        all_durations: list[float] = []
+        for log in logs:
+            laps = log.laps
+            if len(laps) == 0:
+                continue
+            starts = laps.column("start_time").to_numpy()
+            ends = laps.column("end_time").to_numpy()
+            all_durations.extend((ends - starts).tolist())
+        median_duration = float(np.median(all_durations)) if all_durations else 0.0
+
+        # Identify boundary laps that are likely partial (< 75% of median).
+        # These occur when a file ends mid-lap (e.g., car spins then logger restarts).
+        boundary_skip: set[tuple[int, int]] = set()  # (log_idx, original_lap_num)
+        for log_idx, log in enumerate(logs):
+            laps = log.laps
+            if len(laps) == 0:
+                continue
+            nums = laps.column("num").to_pylist()
+            starts = laps.column("start_time").to_numpy()
+            ends = laps.column("end_time").to_numpy()
+
+            # Last lap of non-last files
+            if log_idx < len(logs) - 1:
+                dur = float(ends[-1] - starts[-1])
+                if median_duration > 0 and dur < median_duration * 0.75:
+                    boundary_skip.add((log_idx, nums[-1]))
+
+            # First lap of non-first files
+            if log_idx > 0:
+                dur = float(ends[0] - starts[0])
+                if median_duration > 0 and dur < median_duration * 0.75:
+                    boundary_skip.add((log_idx, nums[0]))
+
+        # Renumber laps sequentially, skipping partial boundary laps
+        parts: list[pa.Table] = []
+        next_num = 1
+        for log_idx, log in enumerate(logs):
+            laps = log.laps
+            n = len(laps)
+            if n == 0:
+                continue
+
+            orig_nums = laps.column("num").to_pylist()
+            keep_indices: list[int] = []
+            for i, orig_num in enumerate(orig_nums):
+                if (log_idx, orig_num) in boundary_skip:
+                    continue
+                self._lap_map[next_num] = (log_idx, orig_num)
+                keep_indices.append(i)
+                next_num += 1
+
+            if not keep_indices:
+                continue
+
+            kept = laps.take(keep_indices)
+            new_nums = pa.array(
+                list(range(next_num - len(keep_indices), next_num)),
+                type=kept.column("num").type,
+            )
+            num_idx = kept.schema.get_field_index("num")
+            parts.append(kept.set_column(num_idx, "num", new_nums))
+
+        self.laps = pa.concat_tables(parts) if parts else logs[0].laps
+
+        # Use first file's metadata
+        self.metadata = logs[0].metadata
+        self.file_name = logs[0].file_name
+
+        # Union of channels (for existence checks; actual data accessed via filter_by_lap)
+        self.channels: dict = {}
+        for log in logs:
+            for ch_name in log.channels:
+                if ch_name not in self.channels:
+                    self.channels[ch_name] = log.channels[ch_name]
+
+    def filter_by_lap(self, lap_num: int):
+        """Delegate to the correct underlying LogFile."""
+        if lap_num not in self._lap_map:
+            raise ValueError(f"Lap {lap_num} not found in merged session")
+        log_idx, orig_num = self._lap_map[lap_num]
+        return self._logs[log_idx].filter_by_lap(orig_num)
+
+    def select_channels(self, channels):
+        """Delegate to the first underlying LogFile.
+
+        Only valid for whole-session operations (e.g., suspension analysis)
+        where the data doesn't need per-lap isolation.
+        """
+        return self._logs[0].select_channels(channels)


### PR DESCRIPTION

AIM loggers create a new file when the car is restarted (e.g., after a
spin). This adds support for detecting and merging these split files into
a single logical session for analysis.

- MergedLogFile wrapper in _util.py: renumbers laps sequentially across
  files, delegates filter_by_lap() to the correct underlying LogFile,
  and excludes partial boundary laps (< 75% of median lap time)
- analyze_session.py: accepts multiple file paths (nargs='+'), creates
  MergedLogFile when given multiple files
- group_sessions.py: new script that detects split sessions by comparing
  metadata timestamps (same driver, venue, < 30 min gap)
- Updated session-analysis skill: no ad-hoc code instruction
- Updated session-day-review skill: runs group_sessions.py to detect
  splits, shows timestamps/lap counts for user confirmation

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
