### PR TITLE
Improve tire pressure calculator UI and add settings persistence

### DIFF
--- a/tire_pressure_calculator/App.axaml
+++ b/tire_pressure_calculator/App.axaml
@@ -1,7 +1,7 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="TirePressureCalculator.App"
-             RequestedThemeVariant="Dark">
+             RequestedThemeVariant="Default">
   <Application.Styles>
     <FluentTheme />
   </Application.Styles>

--- a/tire_pressure_calculator/Settings.cs
+++ b/tire_pressure_calculator/Settings.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TirePressureCalculator;
+
+public class CornerSettings
+{
+    public double CurrentTemp { get; set; } = 20.0;
+    public double TargetHotTemp { get; set; } = 80.0;
+    public double TargetHotPressure { get; set; } = 1.80;
+}
+
+public class AppSettings
+{
+    public CornerSettings FrontLeft { get; set; } = new();
+    public CornerSettings FrontRight { get; set; } = new();
+    public CornerSettings RearLeft { get; set; } = new();
+    public CornerSettings RearRight { get; set; } = new();
+
+    private static string FilePath =>
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "TirePressureCalculator",
+            "settings.json");
+
+    public static AppSettings Load()
+    {
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                var json = File.ReadAllText(FilePath);
+                return JsonSerializer.Deserialize(json, SettingsContext.Default.AppSettings) ?? new();
+            }
+        }
+        catch { }
+        return new();
+    }
+
+    public void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(FilePath)!;
+            Directory.CreateDirectory(dir);
+            var json = JsonSerializer.Serialize(this, SettingsContext.Default.AppSettings);
+            File.WriteAllText(FilePath, json);
+        }
+        catch { }
+    }
+}
+
+// AOT-compatible JSON serialization
+[JsonSerializable(typeof(AppSettings))]
+[JsonSourceGenerationOptions(WriteIndented = true)]
+internal partial class SettingsContext : JsonSerializerContext { }

--- a/tire_pressure_calculator/Tests/AppSettingsTests.cs
+++ b/tire_pressure_calculator/Tests/AppSettingsTests.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+
+namespace TirePressureCalculator.Tests;
+
+public class AppSettingsTests
+{
+    [Fact]
+    public void CornerSettings_Defaults_AreSensible()
+    {
+        var s = new CornerSettings();
+
+        Assert.Equal(20.0, s.CurrentTemp);
+        Assert.Equal(80.0, s.TargetHotTemp);
+        Assert.Equal(1.80, s.TargetHotPressure);
+    }
+
+    [Fact]
+    public void AppSettings_Defaults_HasFourCorners()
+    {
+        var s = new AppSettings();
+
+        Assert.NotNull(s.FrontLeft);
+        Assert.NotNull(s.FrontRight);
+        Assert.NotNull(s.RearLeft);
+        Assert.NotNull(s.RearRight);
+    }
+
+    [Fact]
+    public void AppSettings_RoundTrip_PreservesValues()
+    {
+        var original = new AppSettings
+        {
+            FrontLeft = new CornerSettings { CurrentTemp = 15.0, TargetHotTemp = 90.0, TargetHotPressure = 2.10 },
+            FrontRight = new CornerSettings { CurrentTemp = 16.0, TargetHotTemp = 91.0, TargetHotPressure = 2.11 },
+            RearLeft = new CornerSettings { CurrentTemp = 17.0, TargetHotTemp = 92.0, TargetHotPressure = 2.12 },
+            RearRight = new CornerSettings { CurrentTemp = 18.0, TargetHotTemp = 93.0, TargetHotPressure = 2.13 },
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var deserialized = JsonSerializer.Deserialize<AppSettings>(json)!;
+
+        Assert.Equal(15.0, deserialized.FrontLeft.CurrentTemp);
+        Assert.Equal(90.0, deserialized.FrontLeft.TargetHotTemp);
+        Assert.Equal(2.10, deserialized.FrontLeft.TargetHotPressure);
+        Assert.Equal(18.0, deserialized.RearRight.CurrentTemp);
+        Assert.Equal(93.0, deserialized.RearRight.TargetHotTemp);
+        Assert.Equal(2.13, deserialized.RearRight.TargetHotPressure);
+    }
+}

--- a/tire_pressure_calculator/ViewModels/MainViewModel.cs
+++ b/tire_pressure_calculator/ViewModels/MainViewModel.cs
@@ -2,8 +2,39 @@ namespace TirePressureCalculator.ViewModels;
 
 public class MainViewModel
 {
-    public TireCornerViewModel FrontLeft { get; } = new() { Label = "FL" };
-    public TireCornerViewModel FrontRight { get; } = new() { Label = "FR" };
-    public TireCornerViewModel RearLeft { get; } = new() { Label = "RL" };
-    public TireCornerViewModel RearRight { get; } = new() { Label = "RR" };
+    public TireCornerViewModel FrontLeft { get; }
+    public TireCornerViewModel FrontRight { get; }
+    public TireCornerViewModel RearLeft { get; }
+    public TireCornerViewModel RearRight { get; }
+
+    private readonly AppSettings _settings;
+
+    public MainViewModel()
+    {
+        _settings = AppSettings.Load();
+
+        FrontLeft = CreateCorner("FL", _settings.FrontLeft);
+        FrontRight = CreateCorner("FR", _settings.FrontRight);
+        RearLeft = CreateCorner("RL", _settings.RearLeft);
+        RearRight = CreateCorner("RR", _settings.RearRight);
+    }
+
+    private TireCornerViewModel CreateCorner(string label, CornerSettings s)
+    {
+        var vm = new TireCornerViewModel
+        {
+            Label = label,
+            CurrentTemp = s.CurrentTemp,
+            TargetHotTemp = s.TargetHotTemp,
+            TargetHotPressure = s.TargetHotPressure
+        };
+        vm.PropertyChanged += (_, _) =>
+        {
+            s.CurrentTemp = vm.CurrentTemp;
+            s.TargetHotTemp = vm.TargetHotTemp;
+            s.TargetHotPressure = vm.TargetHotPressure;
+            _settings.Save();
+        };
+        return vm;
+    }
 }

--- a/tire_pressure_calculator/Views/MainWindow.axaml
+++ b/tire_pressure_calculator/Views/MainWindow.axaml
@@ -3,68 +3,91 @@
         xmlns:vm="using:TirePressureCalculator.ViewModels"
         x:Class="TirePressureCalculator.Views.MainWindow"
         x:DataType="vm:MainViewModel"
-        Title="Cold Tire Pressure Calculator"
+        Title="Tire Pressure Calculator"
         Width="700" Height="520"
         MinWidth="600" MinHeight="400">
 
   <Window.Resources>
     <DataTemplate x:Key="CornerTemplate" x:DataType="vm:TireCornerViewModel">
-      <Border Margin="6" Padding="12" CornerRadius="8"
-              Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-              BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-              BorderThickness="1">
-        <StackPanel Spacing="6">
-          <TextBlock Text="{Binding Label}"
-                     FontSize="20" FontWeight="Bold"
-                     HorizontalAlignment="Center" />
+      <StackPanel Spacing="4" Margin="16,8">
+        <TextBlock Text="{Binding Label}"
+                   FontSize="18" FontWeight="Bold"
+                   HorizontalAlignment="Center" />
 
-          <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto">
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Current Temp (°C)"
-                       VerticalAlignment="Center" Margin="0,4" />
-            <NumericUpDown Grid.Row="0" Grid.Column="1"
-                           Value="{Binding CurrentTemp}"
+        <!-- Cold temp and hot temp side by side -->
+        <Grid ColumnDefinitions="*,8,*" RowDefinitions="Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Current °C"
+                     FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+          <Border Grid.Row="1" Grid.Column="0"
+                  BorderBrush="#406090FF" BorderThickness="1.5" CornerRadius="4">
+            <NumericUpDown Value="{Binding CurrentTemp}"
                            Minimum="-40" Maximum="60"
                            FormatString="F1" Increment="0.5"
-                           Margin="8,4,0,4" HorizontalAlignment="Stretch" />
+                           ShowButtonSpinner="False"
+                           HorizontalContentAlignment="Center" />
+          </Border>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Target Hot Temp (°C)"
-                       VerticalAlignment="Center" Margin="0,4" />
-            <NumericUpDown Grid.Row="1" Grid.Column="1"
-                           Value="{Binding TargetHotTemp}"
+          <TextBlock Grid.Row="0" Grid.Column="2" Text="Target °C"
+                     FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+          <Border Grid.Row="1" Grid.Column="2"
+                  BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
+            <NumericUpDown Value="{Binding TargetHotTemp}"
                            Minimum="0" Maximum="200"
                            FormatString="F1" Increment="1"
-                           Margin="8,4,0,4" HorizontalAlignment="Stretch" />
+                           ShowButtonSpinner="False"
+                           HorizontalContentAlignment="Center" />
+          </Border>
+        </Grid>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Target Hot Press (bar)"
-                       VerticalAlignment="Center" Margin="0,4" />
-            <NumericUpDown Grid.Row="2" Grid.Column="1"
-                           Value="{Binding TargetHotPressure}"
+        <!-- Target pressure centered below -->
+        <StackPanel HorizontalAlignment="Center" Margin="0,4,0,0">
+          <TextBlock Text="Target bar"
+                     FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+          <Border BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
+            <NumericUpDown Value="{Binding TargetHotPressure}"
                            Minimum="0" Maximum="5"
                            FormatString="F3" Increment="0.01"
-                           Margin="8,4,0,4" HorizontalAlignment="Stretch" />
-          </Grid>
-
-          <Separator Margin="0,4" />
-
-          <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
-            <TextBlock Text="Set Cold:" FontWeight="SemiBold" FontSize="16"
-                       VerticalAlignment="Center" />
-            <TextBlock Text="{Binding ColdPressure, StringFormat='{}{0:F3} bar'}"
-                       FontSize="20" FontWeight="Bold"
-                       Foreground="#2196F3"
-                       VerticalAlignment="Center" />
-          </StackPanel>
+                           ShowButtonSpinner="False"
+                           HorizontalContentAlignment="Center"
+                           MinWidth="100" />
+          </Border>
         </StackPanel>
-      </Border>
+
+        <Separator Margin="0,4" />
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
+          <TextBlock Text="Set Cold:" FontWeight="SemiBold" FontSize="16"
+                     VerticalAlignment="Center" />
+          <TextBlock Text="{Binding ColdPressure, StringFormat='{}{0:F3} bar'}"
+                     FontSize="20" FontWeight="Bold"
+                     Foreground="{DynamicResource SystemAccentColor}"
+                     VerticalAlignment="Center" />
+        </StackPanel>
+      </StackPanel>
     </DataTemplate>
   </Window.Resources>
 
-  <Grid RowDefinitions="Auto,*,*" ColumnDefinitions="*,*" Margin="8">
-    <TextBlock Grid.Row="0" Grid.ColumnSpan="2"
-               Text="Cold Tire Pressure Calculator"
-               FontSize="22" FontWeight="Bold"
-               HorizontalAlignment="Center" Margin="0,8,0,4" />
+  <Grid RowDefinitions="Auto,*,*" ColumnDefinitions="*,*">
 
+    <!-- Front arrow (broad, flat) centered at top -->
+    <Panel Grid.Row="0" Grid.ColumnSpan="2" Height="32" Margin="0,6,0,0">
+      <Polygon Points="0,28 100,0 200,28"
+               Stroke="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+               StrokeThickness="2"
+               HorizontalAlignment="Center" VerticalAlignment="Center" />
+    </Panel>
+
+    <!-- Vertical divider line (overlaps arrow row by 1px to close gap) -->
+    <Border Grid.Row="0" Grid.RowSpan="3" Grid.ColumnSpan="2"
+            HorizontalAlignment="Center" Width="2" Margin="0,37,0,8"
+            Background="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+
+    <!-- Horizontal divider line -->
+    <Border Grid.Row="1" Grid.RowSpan="2" Grid.ColumnSpan="2"
+            VerticalAlignment="Center" Height="2" Margin="8,0"
+            Background="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+
+    <!-- Four quadrants -->
     <ContentControl Grid.Row="1" Grid.Column="0"
                     Content="{Binding FrontLeft}"
                     ContentTemplate="{StaticResource CornerTemplate}" />


### PR DESCRIPTION

- Follow OS light/dark theme instead of hardcoded dark mode
- Replace title with setup-sheet style layout: front arrow, cross dividers
- Use NumericUpDown without spinners for numeric-only input
- Arrange inputs as inverted triangle (temps side-by-side, pressure below)
- Add blue/red outlines for cold/hot input fields
- Persist all inputs to %APPDATA% JSON file across sessions

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/84).
* #88
* #87
* #86
* #85
* __->__ #84