### PR TITLE
Add proportional temperature adjustment slider

### DIFF
--- a/tire_pressure_calculator/Settings.cs
+++ b/tire_pressure_calculator/Settings.cs
@@ -16,6 +16,7 @@ public class AppSettings
     public CornerSettings FrontRight { get; set; } = new();
     public CornerSettings RearLeft { get; set; } = new();
     public CornerSettings RearRight { get; set; } = new();
+    public double TempAdjustPercent { get; set; }
 
     private static string FilePath =>
         Path.Combine(

--- a/tire_pressure_calculator/Tests/MainViewModelTests.cs
+++ b/tire_pressure_calculator/Tests/MainViewModelTests.cs
@@ -27,15 +27,56 @@ public class MainViewModelTests
     }
 
     [Fact]
-    public void ResetCommand_ResetsAllCorners()
+    public void TempAdjustPercent_PropagatesToAllCorners()
+    {
+        var vm = new MainViewModel();
+        vm.TempAdjustPercent = 7.5;
+
+        Assert.Equal(7.5, vm.FrontLeft.TempAdjustPercent);
+        Assert.Equal(7.5, vm.FrontRight.TempAdjustPercent);
+        Assert.Equal(7.5, vm.RearLeft.TempAdjustPercent);
+        Assert.Equal(7.5, vm.RearRight.TempAdjustPercent);
+    }
+
+    [Fact]
+    public void TempAdjustLabel_Zero_ShowsZero()
+    {
+        var vm = new MainViewModel();
+        vm.TempAdjustPercent = 0;
+
+        Assert.Equal("Temp adjust: 0%", vm.TempAdjustLabel);
+    }
+
+    [Fact]
+    public void TempAdjustLabel_Positive_ShowsPlus()
+    {
+        var vm = new MainViewModel();
+        vm.TempAdjustPercent = 5.0;
+
+        Assert.Equal("Temp adjust: +5.0%", vm.TempAdjustLabel);
+    }
+
+    [Fact]
+    public void TempAdjustLabel_Negative_ShowsMinus()
+    {
+        var vm = new MainViewModel();
+        vm.TempAdjustPercent = -3.0;
+
+        Assert.Equal("Temp adjust: -3.0%", vm.TempAdjustLabel);
+    }
+
+    [Fact]
+    public void ResetCommand_ResetsAllCornersAndSlider()
     {
         var vm = new MainViewModel();
         vm.FrontLeft.CurrentTemp = 35.0;
         vm.FrontLeft.TargetHotTemp = 100.0;
         vm.RearRight.TargetHotPressure = 2.50;
+        vm.TempAdjustPercent = 10.0;
 
         vm.ResetCommand.Execute(null);
 
+        Assert.Equal(0.0, vm.TempAdjustPercent);
         Assert.Equal(20.0, vm.FrontLeft.CurrentTemp);
         Assert.Equal(80.0, vm.FrontLeft.TargetHotTemp);
         Assert.Equal(1.80, vm.RearRight.TargetHotPressure);

--- a/tire_pressure_calculator/Tests/TireCornerViewModelTests.cs
+++ b/tire_pressure_calculator/Tests/TireCornerViewModelTests.cs
@@ -71,6 +71,81 @@ public class TireCornerViewModelTests
     }
 
     [Fact]
+    public void AdjustedHotTemp_NoAdjustment_EqualsTarget()
+    {
+        var vm = CreateDefault();
+        Assert.Equal(80.0, vm.AdjustedHotTemp);
+    }
+
+    [Fact]
+    public void AdjustedHotTemp_PositiveAdjust_IncreasesTemp()
+    {
+        var vm = CreateDefault();
+        vm.TempAdjustPercent = 5.0;
+
+        // 5% of (80 + 273.15)K = 5% of 353.15K
+        double expectedK = 353.15 * 1.05;
+        double expected = Math.Round(expectedK - 273.15, 1);
+        Assert.Equal(expected, vm.AdjustedHotTemp);
+    }
+
+    [Fact]
+    public void AdjustedHotTemp_NegativeAdjust_DecreasesTemp()
+    {
+        var vm = CreateDefault();
+        vm.TempAdjustPercent = -5.0;
+
+        double expectedK = 353.15 * 0.95;
+        double expected = Math.Round(expectedK - 273.15, 1);
+        Assert.Equal(expected, vm.AdjustedHotTemp);
+    }
+
+    [Fact]
+    public void ColdPressure_WithTempAdjust_UsesAdjustedTemp()
+    {
+        var vm = CreateDefault();
+        double pressureNoAdjust = vm.ColdPressure;
+
+        vm.TempAdjustPercent = 5.0;
+        double pressureWithAdjust = vm.ColdPressure;
+
+        // Higher hot temp -> lower cold pressure
+        Assert.True(pressureWithAdjust < pressureNoAdjust);
+    }
+
+    [Fact]
+    public void IsAdjusted_ZeroPercent_ReturnsFalse()
+    {
+        var vm = CreateDefault();
+        Assert.False(vm.IsAdjusted);
+    }
+
+    [Fact]
+    public void IsAdjusted_NonZeroPercent_ReturnsTrue()
+    {
+        var vm = CreateDefault();
+        vm.TempAdjustPercent = 3.0;
+        Assert.True(vm.IsAdjusted);
+    }
+
+    [Fact]
+    public void TargetHotTempDisplay_NoAdjust_ShowsBaseOnly()
+    {
+        var vm = CreateDefault();
+        Assert.Equal("80.0", vm.TargetHotTempDisplay);
+    }
+
+    [Fact]
+    public void TargetHotTempDisplay_WithAdjust_ShowsBothValues()
+    {
+        var vm = CreateDefault();
+        vm.TempAdjustPercent = 5.0;
+
+        Assert.Contains("80.0", vm.TargetHotTempDisplay);
+        Assert.Contains("(", vm.TargetHotTempDisplay);
+    }
+
+    [Fact]
     public void ResetToDefaults_RestoresInitialValues()
     {
         var vm = CreateDefault();

--- a/tire_pressure_calculator/ViewModels/MainViewModel.cs
+++ b/tire_pressure_calculator/ViewModels/MainViewModel.cs
@@ -1,8 +1,10 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
 namespace TirePressureCalculator.ViewModels;
 
-public class MainViewModel
+public class MainViewModel : INotifyPropertyChanged
 {
     public TireCornerViewModel FrontLeft { get; }
     public TireCornerViewModel FrontRight { get; }
@@ -11,10 +13,34 @@ public class MainViewModel
     public ICommand ResetCommand { get; }
 
     private readonly AppSettings _settings;
+    private double _tempAdjustPercent;
+
+    public double TempAdjustPercent
+    {
+        get => _tempAdjustPercent;
+        set
+        {
+            if (_tempAdjustPercent == value) return;
+            _tempAdjustPercent = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(TempAdjustLabel));
+            FrontLeft.TempAdjustPercent = value;
+            FrontRight.TempAdjustPercent = value;
+            RearLeft.TempAdjustPercent = value;
+            RearRight.TempAdjustPercent = value;
+            _settings.TempAdjustPercent = value;
+            _settings.Save();
+        }
+    }
+
+    public string TempAdjustLabel => _tempAdjustPercent == 0
+        ? "Temp adjust: 0%"
+        : $"Temp adjust: {_tempAdjustPercent:+0.0;-0.0}%";
 
     public MainViewModel()
     {
         _settings = AppSettings.Load();
+        _tempAdjustPercent = _settings.TempAdjustPercent;
 
         FrontLeft = CreateCorner("FL", _settings.FrontLeft);
         FrontRight = CreateCorner("FR", _settings.FrontRight);
@@ -23,6 +49,7 @@ public class MainViewModel
 
         ResetCommand = new RelayCommand(() =>
         {
+            TempAdjustPercent = 0;
             FrontLeft.ResetToDefaults();
             FrontRight.ResetToDefaults();
             RearLeft.ResetToDefaults();
@@ -37,7 +64,8 @@ public class MainViewModel
             Label = label,
             CurrentTemp = s.CurrentTemp,
             TargetHotTemp = s.TargetHotTemp,
-            TargetHotPressure = s.TargetHotPressure
+            TargetHotPressure = s.TargetHotPressure,
+            TempAdjustPercent = _tempAdjustPercent
         };
         vm.PropertyChanged += (_, _) =>
         {
@@ -48,6 +76,11 @@ public class MainViewModel
         };
         return vm;
     }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }
 
 public class RelayCommand(Action execute) : ICommand

--- a/tire_pressure_calculator/ViewModels/TireCornerViewModel.cs
+++ b/tire_pressure_calculator/ViewModels/TireCornerViewModel.cs
@@ -9,6 +9,7 @@ public class TireCornerViewModel : INotifyPropertyChanged
     private double _currentTemp = 20.0;
     private double _targetHotTemp = 80.0;
     private double _targetHotPressure = 1.80;
+    private double _tempAdjustPercent;
 
     public string Label
     {
@@ -25,7 +26,15 @@ public class TireCornerViewModel : INotifyPropertyChanged
     public double TargetHotTemp
     {
         get => _targetHotTemp;
-        set { if (SetField(ref _targetHotTemp, value)) OnPropertyChanged(nameof(ColdPressure)); }
+        set
+        {
+            if (SetField(ref _targetHotTemp, value))
+            {
+                OnPropertyChanged(nameof(AdjustedHotTemp));
+                OnPropertyChanged(nameof(TargetHotTempDisplay));
+                OnPropertyChanged(nameof(ColdPressure));
+            }
+        }
     }
 
     public double TargetHotPressure
@@ -34,12 +43,43 @@ public class TireCornerViewModel : INotifyPropertyChanged
         set { if (SetField(ref _targetHotPressure, value)) OnPropertyChanged(nameof(ColdPressure)); }
     }
 
+    public double TempAdjustPercent
+    {
+        get => _tempAdjustPercent;
+        set
+        {
+            if (SetField(ref _tempAdjustPercent, value))
+            {
+                OnPropertyChanged(nameof(AdjustedHotTemp));
+                OnPropertyChanged(nameof(IsAdjusted));
+                OnPropertyChanged(nameof(TargetHotTempDisplay));
+                OnPropertyChanged(nameof(ColdPressure));
+            }
+        }
+    }
+
+    public double AdjustedHotTemp
+    {
+        get
+        {
+            double baseK = _targetHotTemp + 273.15;
+            double adjustedK = baseK * (1.0 + _tempAdjustPercent / 100.0);
+            return Math.Round(adjustedK - 273.15, 1);
+        }
+    }
+
+    public bool IsAdjusted => _tempAdjustPercent != 0.0;
+
+    public string TargetHotTempDisplay => IsAdjusted
+        ? $"{_targetHotTemp:F1} ({AdjustedHotTemp:F1})"
+        : $"{_targetHotTemp:F1}";
+
     public double ColdPressure
     {
         get
         {
             double tColdK = _currentTemp + 273.15;
-            double tHotK = _targetHotTemp + 273.15;
+            double tHotK = AdjustedHotTemp + 273.15;
             if (tHotK <= 0) return 0;
             // Convert gauge pressure to absolute, apply Gay-Lussac's Law, convert back
             double pHotAbs = _targetHotPressure + 1.0;

--- a/tire_pressure_calculator/Views/MainWindow.axaml
+++ b/tire_pressure_calculator/Views/MainWindow.axaml
@@ -4,8 +4,8 @@
         x:Class="TirePressureCalculator.Views.MainWindow"
         x:DataType="vm:MainViewModel"
         Title="Tire Pressure Calculator"
-        Width="700" Height="520"
-        MinWidth="600" MinHeight="400">
+        Width="720" Height="560"
+        MinWidth="620" MinHeight="480">
 
   <Window.Resources>
     <DataTemplate x:Key="CornerTemplate" x:DataType="vm:TireCornerViewModel">
@@ -27,15 +27,30 @@
                            HorizontalContentAlignment="Center" />
           </Border>
 
-          <TextBlock Grid.Row="0" Grid.Column="2" Text="Target °C"
+          <TextBlock Grid.Row="0" Grid.Column="2" Text="Target °C (Corr. °C)"
                      FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
           <Border Grid.Row="1" Grid.Column="2"
                   BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
-            <NumericUpDown Value="{Binding TargetHotTemp}"
-                           Minimum="0" Maximum="200"
-                           FormatString="F1" Increment="1"
-                           ShowButtonSpinner="False"
-                           HorizontalContentAlignment="Center" />
+            <Panel>
+              <NumericUpDown Value="{Binding TargetHotTemp}"
+                             Minimum="0" Maximum="200"
+                             FormatString="F1" Increment="1"
+                             ShowButtonSpinner="False"
+                             HorizontalContentAlignment="Center" />
+              <!-- Overlay showing "80.0 (92.8)" when not editing -->
+              <TextBlock Text="{Binding TargetHotTempDisplay}"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center"
+                         IsHitTestVisible="False" />
+              <Panel.Styles>
+                <Style Selector="Panel:not(:focus-within) > NumericUpDown">
+                  <Setter Property="Foreground" Value="Transparent" />
+                </Style>
+                <Style Selector="Panel:focus-within > TextBlock">
+                  <Setter Property="IsVisible" Value="False" />
+                </Style>
+              </Panel.Styles>
+            </Panel>
           </Border>
         </Grid>
 
@@ -100,10 +115,21 @@
     <ContentControl Grid.Row="2" Grid.Column="1"
                     Content="{Binding RearRight}"
                     ContentTemplate="{StaticResource CornerTemplate}" />
-    <!-- Reset button -->
-    <Button Grid.Row="3" Grid.ColumnSpan="2"
+    <!-- Bottom bar: reset + slider -->
+    <Button Grid.Row="3" Grid.Column="0"
             Content="Reset to Defaults"
             Command="{Binding ResetCommand}"
-            HorizontalAlignment="Left" Margin="8,4,0,8" />
+            HorizontalAlignment="Left" VerticalAlignment="Center"
+            Margin="8,4,0,8" />
+    <StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal"
+                HorizontalAlignment="Right" VerticalAlignment="Center"
+                Margin="0,4,8,8" Spacing="8">
+      <TextBlock Text="{Binding TempAdjustLabel}"
+                 VerticalAlignment="Center" FontSize="12" />
+      <Slider Value="{Binding TempAdjustPercent}"
+              Minimum="-15" Maximum="15"
+              TickFrequency="0.5" IsSnapToTickEnabled="True"
+              Width="150" VerticalAlignment="Center" />
+    </StackPanel>
   </Grid>
 </Window>


### PR DESCRIPTION

Slider scales all target hot temps by the same proportion in Kelvin
space (-15% to +15%) to adjust for ambient condition shifts. Corrected
value displays inline in the target temp field as "80.0 (92.8)".
Cold pressure calculation uses the adjusted temperature. Slider
position persists across sessions.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/86).
* #88
* #87
* __->__ #86