### PR TITLE
Reflow corner layout based on aspect ratio for mobile/tablet

### DIFF
--- a/tire_pressure_calculator/Core/Views/MainView.axaml
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml
@@ -1,18 +1,77 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:TirePressureCalculator.ViewModels"
+             xmlns:views="using:TirePressureCalculator.Views"
              x:Class="TirePressureCalculator.Views.MainView"
              x:DataType="vm:MainViewModel">
 
   <UserControl.Resources>
     <DataTemplate x:Key="CornerTemplate" x:DataType="vm:TireCornerViewModel">
-      <StackPanel Spacing="4" Margin="16,8">
+      <Viewbox Stretch="Uniform" StretchDirection="DownOnly"
+               HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+      <StackPanel Spacing="4" Margin="8,6">
         <TextBlock Text="{Binding Label}"
                    FontSize="18" FontWeight="Bold"
                    HorizontalAlignment="Center" />
 
-        <!-- Cold temp and hot temp side by side -->
-        <Grid ColumnDefinitions="*,8,*" RowDefinitions="Auto,Auto">
+        <!-- Medium (triangle) layout: Current and Target °C side by side, Target bar below -->
+        <StackPanel Spacing="4"
+                    IsVisible="{Binding IsMedium, RelativeSource={RelativeSource AncestorType=views:MainView}}">
+          <Grid ColumnDefinitions="*,8,*" RowDefinitions="Auto,Auto">
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Current °C"
+                       FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+            <Border Grid.Row="1" Grid.Column="0"
+                    BorderBrush="#406090FF" BorderThickness="1.5" CornerRadius="4">
+              <NumericUpDown Value="{Binding CurrentTemp}"
+                             Minimum="-40" Maximum="60"
+                             FormatString="F1" Increment="0.5"
+                             ShowButtonSpinner="False"
+                             HorizontalContentAlignment="Center" />
+            </Border>
+
+            <TextBlock Grid.Row="0" Grid.Column="2" Text="Target °C (Corr. °C)"
+                       FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+            <Border Grid.Row="1" Grid.Column="2"
+                    BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
+              <Panel>
+                <NumericUpDown Value="{Binding TargetHotTemp}"
+                               Minimum="0" Maximum="200"
+                               FormatString="F1" Increment="1"
+                               ShowButtonSpinner="False"
+                               HorizontalContentAlignment="Center" />
+                <TextBlock Text="{Binding TargetHotTempDisplay}"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           IsHitTestVisible="False" />
+                <Panel.Styles>
+                  <Style Selector="Panel:not(:focus-within) > NumericUpDown">
+                    <Setter Property="Foreground" Value="Transparent" />
+                  </Style>
+                  <Style Selector="Panel:focus-within > TextBlock">
+                    <Setter Property="IsVisible" Value="False" />
+                  </Style>
+                </Panel.Styles>
+              </Panel>
+            </Border>
+          </Grid>
+
+          <StackPanel HorizontalAlignment="Center" Margin="0,4,0,0">
+            <TextBlock Text="Target bar"
+                       FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+            <Border BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
+              <NumericUpDown Value="{Binding TargetHotPressure}"
+                             Minimum="0" Maximum="5"
+                             FormatString="F3" Increment="0.01"
+                             ShowButtonSpinner="False"
+                             HorizontalContentAlignment="Center"
+                             MinWidth="100" />
+            </Border>
+          </StackPanel>
+        </StackPanel>
+
+        <!-- Wide layout: all three fields in a single row -->
+        <Grid ColumnDefinitions="*,8,*,8,*" RowDefinitions="Auto,Auto"
+              IsVisible="{Binding IsWide, RelativeSource={RelativeSource AncestorType=views:MainView}}">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Current °C"
                      FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
           <Border Grid.Row="1" Grid.Column="0"
@@ -34,7 +93,6 @@
                              FormatString="F1" Increment="1"
                              ShowButtonSpinner="False"
                              HorizontalContentAlignment="Center" />
-              <!-- Overlay showing "80.0 (92.8)" when not editing -->
               <TextBlock Text="{Binding TargetHotTempDisplay}"
                          HorizontalAlignment="Center"
                          VerticalAlignment="Center"
@@ -49,10 +107,56 @@
               </Panel.Styles>
             </Panel>
           </Border>
+
+          <TextBlock Grid.Row="0" Grid.Column="4" Text="Target bar"
+                     FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+          <Border Grid.Row="1" Grid.Column="4"
+                  BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
+            <NumericUpDown Value="{Binding TargetHotPressure}"
+                           Minimum="0" Maximum="5"
+                           FormatString="F3" Increment="0.01"
+                           ShowButtonSpinner="False"
+                           HorizontalContentAlignment="Center" />
+          </Border>
         </Grid>
 
-        <!-- Target pressure centered below -->
-        <StackPanel HorizontalAlignment="Center" Margin="0,4,0,0">
+        <!-- Narrow layout: all three fields stacked vertically at full width -->
+        <StackPanel Spacing="4"
+                    IsVisible="{Binding IsNarrow, RelativeSource={RelativeSource AncestorType=views:MainView}}">
+          <TextBlock Text="Current °C"
+                     FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+          <Border BorderBrush="#406090FF" BorderThickness="1.5" CornerRadius="4">
+            <NumericUpDown Value="{Binding CurrentTemp}"
+                           Minimum="-40" Maximum="60"
+                           FormatString="F1" Increment="0.5"
+                           ShowButtonSpinner="False"
+                           HorizontalContentAlignment="Center" />
+          </Border>
+
+          <TextBlock Text="Target °C (Corr. °C)"
+                     FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+          <Border BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
+            <Panel>
+              <NumericUpDown Value="{Binding TargetHotTemp}"
+                             Minimum="0" Maximum="200"
+                             FormatString="F1" Increment="1"
+                             ShowButtonSpinner="False"
+                             HorizontalContentAlignment="Center" />
+              <TextBlock Text="{Binding TargetHotTempDisplay}"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center"
+                         IsHitTestVisible="False" />
+              <Panel.Styles>
+                <Style Selector="Panel:not(:focus-within) > NumericUpDown">
+                  <Setter Property="Foreground" Value="Transparent" />
+                </Style>
+                <Style Selector="Panel:focus-within > TextBlock">
+                  <Setter Property="IsVisible" Value="False" />
+                </Style>
+              </Panel.Styles>
+            </Panel>
+          </Border>
+
           <TextBlock Text="Target bar"
                      FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
           <Border BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
@@ -60,8 +164,7 @@
                            Minimum="0" Maximum="5"
                            FormatString="F3" Increment="0.01"
                            ShowButtonSpinner="False"
-                           HorizontalContentAlignment="Center"
-                           MinWidth="100" />
+                           HorizontalContentAlignment="Center" />
           </Border>
         </StackPanel>
 
@@ -76,6 +179,7 @@
                      VerticalAlignment="Center" />
         </StackPanel>
       </StackPanel>
+      </Viewbox>
     </DataTemplate>
   </UserControl.Resources>
 

--- a/tire_pressure_calculator/Core/Views/MainView.axaml.cs
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml.cs
@@ -1,11 +1,62 @@
+using Avalonia;
 using Avalonia.Controls;
 
 namespace TirePressureCalculator.Views;
 
 public partial class MainView : UserControl
 {
+    // Aspect ratio thresholds for selecting between the three layouts.
+    // Narrow (tall):  aspect < NarrowThreshold → stack fields vertically
+    // Wide:           aspect > WideThreshold   → put all 3 fields in a row
+    // Medium:         in between               → triangle (side-by-side + below)
+    private const double NarrowThreshold = 1.0;
+    private const double WideThreshold = 1.7;
+
+    public static readonly StyledProperty<bool> IsNarrowProperty =
+        AvaloniaProperty.Register<MainView, bool>(nameof(IsNarrow));
+
+    public static readonly StyledProperty<bool> IsWideProperty =
+        AvaloniaProperty.Register<MainView, bool>(nameof(IsWide));
+
+    public bool IsNarrow
+    {
+        get => GetValue(IsNarrowProperty);
+        private set => SetValue(IsNarrowProperty, value);
+    }
+
+    public bool IsWide
+    {
+        get => GetValue(IsWideProperty);
+        private set => SetValue(IsWideProperty, value);
+    }
+
+    // True when neither narrow nor wide — the default triangle layout used
+    // for tablets, desktop, and ~4:3 / ~3:2 aspect ratios.
+    public bool IsMedium => !IsNarrow && !IsWide;
+
+    public static readonly DirectProperty<MainView, bool> IsMediumProperty =
+        AvaloniaProperty.RegisterDirect<MainView, bool>(nameof(IsMedium), o => o.IsMedium);
+
     public MainView()
     {
         InitializeComponent();
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == BoundsProperty)
+        {
+            var b = Bounds;
+            if (b.Height <= 0) return;
+            double aspect = b.Width / b.Height;
+            bool wasMedium = IsMedium;
+            IsNarrow = aspect < NarrowThreshold;
+            IsWide = aspect > WideThreshold;
+            if (IsMedium != wasMedium)
+            {
+                RaisePropertyChanged(IsMediumProperty, wasMedium, IsMedium);
+            }
+        }
     }
 }


### PR DESCRIPTION

When the view is taller than wide (phone portrait), stack all three
editable fields (Current °C, Target °C, Target bar) vertically at full
width. When wider than tall (desktop, tablet landscape, foldable open),
keep the existing side-by-side layout with Current/Target °C in columns
and Target bar below.

Layout is driven by bounds, not platform — so tablets, foldables, and
rotated phones all get the appropriate layout automatically.
