### PR TITLE
Bump version to 0.13.0

### DIFF
--- a/inferno-driving-coach/pyproject.toml
+++ b/inferno-driving-coach/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inferno-driving-coach"
-version = "0.12.0"
+version = "0.13.0"
 description = "MCP server for motorsports telemetry coaching — session analysis, day reviews, and driving KPIs"
 authors = [
     {name = "Christopher Dewan", email = "chris.dewan@m3rlin.net"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motorsports-data-notebook"
-version = "0.12.0"
+version = "0.13.0"
 description = ""
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/tire_pressure_calculator/Android/TirePressureCalculator.Android.csproj
+++ b/tire_pressure_calculator/Android/TirePressureCalculator.Android.csproj
@@ -6,8 +6,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationId>com.inferno.tirepressurecalculator</ApplicationId>
-    <ApplicationVersion>1</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <AndroidSdkDirectory Condition="'$(AndroidSdkDirectory)' == ''">$(ANDROID_HOME)</AndroidSdkDirectory>

--- a/tire_pressure_calculator/Directory.Build.props
+++ b/tire_pressure_calculator/Directory.Build.props
@@ -1,0 +1,25 @@
+<Project>
+
+  <!--
+    Inherit the project version from the root pyproject.toml so the .NET
+    builds (Desktop, Android) always ship with the same version number as
+    the Python package and notebooks. Updating pyproject.toml is enough —
+    no need to touch .csproj files at release time.
+  -->
+  <PropertyGroup>
+    <_PyprojectPath>$(MSBuildThisFileDirectory)../pyproject.toml</_PyprojectPath>
+    <_PyprojectText>$([System.IO.File]::ReadAllText('$(_PyprojectPath)'))</_PyprojectText>
+    <Version>$([System.Text.RegularExpressions.Regex]::Match($(_PyprojectText), 'version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"').Groups[1].Value)</Version>
+    <AssemblyVersion>$(Version).0</AssemblyVersion>
+    <FileVersion>$(Version).0</FileVersion>
+
+    <!-- Android-specific: user-visible version string; ApplicationVersion (build number)
+         must be a monotonically increasing integer, so we encode it from semver. -->
+    <ApplicationDisplayVersion>$(Version)</ApplicationDisplayVersion>
+    <_VersionMajor>$([System.Text.RegularExpressions.Regex]::Match($(Version), '^([0-9]+)').Groups[1].Value)</_VersionMajor>
+    <_VersionMinor>$([System.Text.RegularExpressions.Regex]::Match($(Version), '^[0-9]+\.([0-9]+)').Groups[1].Value)</_VersionMinor>
+    <_VersionPatch>$([System.Text.RegularExpressions.Regex]::Match($(Version), '^[0-9]+\.[0-9]+\.([0-9]+)').Groups[1].Value)</_VersionPatch>
+    <ApplicationVersion>$([MSBuild]::Add($([MSBuild]::Add($([MSBuild]::Multiply($(_VersionMajor), 10000)), $([MSBuild]::Multiply($(_VersionMinor), 100)))), $(_VersionPatch)))</ApplicationVersion>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION

Inherits version for .NET projects (Desktop, Android) from
pyproject.toml via Directory.Build.props, so all artifacts
(notebooks, MCP server, desktop/android apps) share one
version number. Bumping pyproject.toml is now enough.
