### PR TITLE
Android: fix keyboard type and rear-field obscuring

### DIFF
--- a/inferno-driving-coach/pyproject.toml
+++ b/inferno-driving-coach/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inferno-driving-coach"
-version = "0.12.0"
+version = "0.13.0"
 description = "MCP server for motorsports telemetry coaching — session analysis, day reviews, and driving KPIs"
 authors = [
     {name = "Christopher Dewan", email = "chris.dewan@m3rlin.net"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motorsports-data-notebook"
-version = "0.12.0"
+version = "0.13.0"
 description = ""
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/tire_pressure_calculator/Android/MainActivity.cs
+++ b/tire_pressure_calculator/Android/MainActivity.cs
@@ -1,5 +1,6 @@
 using Android.App;
 using Android.Content.PM;
+using Android.Views;
 using Avalonia;
 using Avalonia.Android;
 
@@ -10,7 +11,8 @@ namespace TirePressureCalculator.Android;
     Theme = "@style/MyTheme.NoActionBar",
     Icon = "@android:drawable/ic_menu_compass",
     MainLauncher = true,
-    ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
+    WindowSoftInputMode = SoftInput.AdjustResize | SoftInput.StateHidden,
+    ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode | ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden)]
 public class MainActivity : AvaloniaMainActivity<App>
 {
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
@@ -18,4 +20,14 @@ public class MainActivity : AvaloniaMainActivity<App>
         return base.CustomizeAppBuilder(builder)
             .LogToTrace();
     }
+
+#pragma warning disable CA1422 // Validate platform compatibility (OnBackPressed is obsolete on API 33+)
+    public override void OnBackPressed()
+    {
+        // If the view is zoomed into a quadrant, unzoom instead of closing.
+        if (TirePressureCalculator.Views.MainView.Instance?.TryHandleBack() == true)
+            return;
+        base.OnBackPressed();
+    }
+#pragma warning restore CA1422
 }

--- a/tire_pressure_calculator/Android/TirePressureCalculator.Android.csproj
+++ b/tire_pressure_calculator/Android/TirePressureCalculator.Android.csproj
@@ -6,8 +6,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationId>com.inferno.tirepressurecalculator</ApplicationId>
-    <ApplicationVersion>1</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <AndroidSdkDirectory Condition="'$(AndroidSdkDirectory)' == ''">$(ANDROID_HOME)</AndroidSdkDirectory>

--- a/tire_pressure_calculator/Core/App.axaml
+++ b/tire_pressure_calculator/Core/App.axaml
@@ -1,8 +1,22 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ti="using:Avalonia.Input.TextInput"
              x:Class="TirePressureCalculator.App"
              RequestedThemeVariant="Default">
   <Application.Styles>
     <FluentTheme />
+    <!-- All NumericUpDown controls in this app accept decimal numbers
+         (temperatures, pressures), so request the Number IME on mobile. -->
+    <Style Selector="NumericUpDown /template/ TextBox#PART_TextBox">
+      <Setter Property="ti:TextInputOptions.ContentType" Value="Number" />
+    </Style>
+    <!-- Last field in each corner (Target bar) gets Done; others get Next
+         so the IME advances focus within the corner before dismissing. -->
+    <Style Selector="NumericUpDown.last /template/ TextBox#PART_TextBox">
+      <Setter Property="ti:TextInputOptions.ReturnKeyType" Value="Done" />
+    </Style>
+    <Style Selector="NumericUpDown:not(.last) /template/ TextBox#PART_TextBox">
+      <Setter Property="ti:TextInputOptions.ReturnKeyType" Value="Next" />
+    </Style>
   </Application.Styles>
 </Application>

--- a/tire_pressure_calculator/Core/Views/MainView.axaml
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml
@@ -59,7 +59,8 @@
             <TextBlock Text="Target bar"
                        FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
             <Border BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
-              <NumericUpDown Value="{Binding TargetHotPressure}"
+              <NumericUpDown Classes="last"
+                             Value="{Binding TargetHotPressure}"
                              Minimum="0" Maximum="5"
                              FormatString="F3" Increment="0.01"
                              ShowButtonSpinner="False"
@@ -112,7 +113,8 @@
                      FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
           <Border Grid.Row="1" Grid.Column="4"
                   BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
-            <NumericUpDown Value="{Binding TargetHotPressure}"
+            <NumericUpDown Classes="last"
+                           Value="{Binding TargetHotPressure}"
                            Minimum="0" Maximum="5"
                            FormatString="F3" Increment="0.01"
                            ShowButtonSpinner="False"
@@ -160,7 +162,8 @@
           <TextBlock Text="Target bar"
                      FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
           <Border BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
-            <NumericUpDown Value="{Binding TargetHotPressure}"
+            <NumericUpDown Classes="last"
+                           Value="{Binding TargetHotPressure}"
                            Minimum="0" Maximum="5"
                            FormatString="F3" Increment="0.01"
                            ShowButtonSpinner="False"
@@ -183,54 +186,67 @@
     </DataTemplate>
   </UserControl.Resources>
 
-  <Grid RowDefinitions="Auto,*,*,Auto" ColumnDefinitions="*,*">
+  <ScrollViewer x:Name="RootScroll"
+                HorizontalScrollBarVisibility="Disabled"
+                VerticalScrollBarVisibility="Hidden">
+    <Grid x:Name="RootGrid"
+          RowDefinitions="Auto,*,*,Auto" ColumnDefinitions="*,*"
+          RenderTransform="scale(1)">
+      <Grid.Transitions>
+        <Transitions>
+          <TransformOperationsTransition Property="RenderTransform"
+                                         Duration="0:0:0.2"
+                                         Easing="CubicEaseOut" />
+        </Transitions>
+      </Grid.Transitions>
 
-    <!-- Front arrow (broad, flat) centered at top -->
-    <Panel Grid.Row="0" Grid.ColumnSpan="2" Height="32" Margin="0,6,0,0">
-      <Polygon Points="0,28 100,0 200,28"
-               Stroke="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-               StrokeThickness="2"
-               HorizontalAlignment="Center" VerticalAlignment="Center" />
-    </Panel>
+      <!-- Front arrow (broad, flat) centered at top -->
+      <Panel Grid.Row="0" Grid.ColumnSpan="2" Height="32" Margin="0,6,0,0">
+        <Polygon Points="0,28 100,0 200,28"
+                 Stroke="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                 StrokeThickness="2"
+                 HorizontalAlignment="Center" VerticalAlignment="Center" />
+      </Panel>
 
-    <!-- Vertical divider line (overlaps arrow row by 1px to close gap) -->
-    <Border Grid.Row="0" Grid.RowSpan="3" Grid.ColumnSpan="2"
-            HorizontalAlignment="Center" Width="2" Margin="0,37,0,8"
-            Background="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+      <!-- Vertical divider line (overlaps arrow row by 1px to close gap) -->
+      <Border Grid.Row="0" Grid.RowSpan="3" Grid.ColumnSpan="2"
+              HorizontalAlignment="Center" Width="2" Margin="0,37,0,8"
+              Background="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
 
-    <!-- Horizontal divider line -->
-    <Border Grid.Row="1" Grid.RowSpan="2" Grid.ColumnSpan="2"
-            VerticalAlignment="Center" Height="2" Margin="8,0"
-            Background="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+      <!-- Horizontal divider line -->
+      <Border Grid.Row="1" Grid.RowSpan="2" Grid.ColumnSpan="2"
+              VerticalAlignment="Center" Height="2" Margin="8,0"
+              Background="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
 
-    <!-- Four quadrants -->
-    <ContentControl Grid.Row="1" Grid.Column="0"
-                    Content="{Binding FrontLeft}"
-                    ContentTemplate="{StaticResource CornerTemplate}" />
-    <ContentControl Grid.Row="1" Grid.Column="1"
-                    Content="{Binding FrontRight}"
-                    ContentTemplate="{StaticResource CornerTemplate}" />
-    <ContentControl Grid.Row="2" Grid.Column="0"
-                    Content="{Binding RearLeft}"
-                    ContentTemplate="{StaticResource CornerTemplate}" />
-    <ContentControl Grid.Row="2" Grid.Column="1"
-                    Content="{Binding RearRight}"
-                    ContentTemplate="{StaticResource CornerTemplate}" />
-    <!-- Bottom bar: reset + slider -->
-    <Button Grid.Row="3" Grid.Column="0"
-            Content="Reset to Defaults"
-            Command="{Binding ResetCommand}"
-            HorizontalAlignment="Left" VerticalAlignment="Center"
-            Margin="8,4,0,8" />
-    <StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal"
-                HorizontalAlignment="Right" VerticalAlignment="Center"
-                Margin="0,4,8,8" Spacing="8">
-      <TextBlock Text="{Binding TempAdjustLabel}"
-                 VerticalAlignment="Center" FontSize="12" />
-      <Slider Value="{Binding TempAdjustPercent}"
-              Minimum="-15" Maximum="15"
-              TickFrequency="0.5" IsSnapToTickEnabled="True"
-              Width="150" VerticalAlignment="Center" />
-    </StackPanel>
-  </Grid>
+      <!-- Four quadrants -->
+      <ContentControl x:Name="FLCorner" Grid.Row="1" Grid.Column="0"
+                      Content="{Binding FrontLeft}"
+                      ContentTemplate="{StaticResource CornerTemplate}" />
+      <ContentControl x:Name="FRCorner" Grid.Row="1" Grid.Column="1"
+                      Content="{Binding FrontRight}"
+                      ContentTemplate="{StaticResource CornerTemplate}" />
+      <ContentControl x:Name="RLCorner" Grid.Row="2" Grid.Column="0"
+                      Content="{Binding RearLeft}"
+                      ContentTemplate="{StaticResource CornerTemplate}" />
+      <ContentControl x:Name="RRCorner" Grid.Row="2" Grid.Column="1"
+                      Content="{Binding RearRight}"
+                      ContentTemplate="{StaticResource CornerTemplate}" />
+      <!-- Bottom bar: reset + slider -->
+      <Button Grid.Row="3" Grid.Column="0"
+              Content="Reset to Defaults"
+              Command="{Binding ResetCommand}"
+              HorizontalAlignment="Left" VerticalAlignment="Center"
+              Margin="8,4,0,8" />
+      <StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal"
+                  HorizontalAlignment="Right" VerticalAlignment="Center"
+                  Margin="0,4,8,8" Spacing="8">
+        <TextBlock Text="{Binding TempAdjustLabel}"
+                   VerticalAlignment="Center" FontSize="12" />
+        <Slider Value="{Binding TempAdjustPercent}"
+                Minimum="-15" Maximum="15"
+                TickFrequency="0.5" IsSnapToTickEnabled="True"
+                Width="150" VerticalAlignment="Center" />
+      </StackPanel>
+    </Grid>
+  </ScrollViewer>
 </UserControl>

--- a/tire_pressure_calculator/Core/Views/MainView.axaml.cs
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml.cs
@@ -1,16 +1,29 @@
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Platform;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
+using Avalonia.Media.Transformation;
+using Avalonia.Threading;
 
 namespace TirePressureCalculator.Views;
 
 public partial class MainView : UserControl
 {
-    // Aspect ratio thresholds for selecting between the three layouts.
-    // Narrow (tall):  aspect < NarrowThreshold → stack fields vertically
-    // Wide:           aspect > WideThreshold   → put all 3 fields in a row
-    // Medium:         in between               → triangle (side-by-side + below)
+    // Aspect ratio thresholds for selecting between the three CornerTemplate
+    // layouts (narrow-stacked, medium-triangle, wide-row).
     private const double NarrowThreshold = 1.0;
     private const double WideThreshold = 1.7;
+
+    // Android standard tablet threshold: if the smallest dimension is >= 600 DIPs,
+    // we treat the device as tablet-sized.
+    private const double PhoneSizeThreshold = 600.0;
+
+    // How much to scale the focused quadrant on phone when an input is tapped.
+    private const double PhoneZoomScale = 2.0;
 
     public static readonly StyledProperty<bool> IsNarrowProperty =
         AvaloniaProperty.Register<MainView, bool>(nameof(IsNarrow));
@@ -30,16 +43,77 @@ public partial class MainView : UserControl
         private set => SetValue(IsWideProperty, value);
     }
 
-    // True when neither narrow nor wide — the default triangle layout used
-    // for tablets, desktop, and ~4:3 / ~3:2 aspect ratios.
     public bool IsMedium => !IsNarrow && !IsWide;
 
     public static readonly DirectProperty<MainView, bool> IsMediumProperty =
         AvaloniaProperty.RegisterDirect<MainView, bool>(nameof(IsMedium), o => o.IsMedium);
 
+    // True when the smallest screen dimension is below the tablet threshold.
+    // Drives the phone-only zoom-to-quadrant behavior.
+    public bool IsPhoneSize { get; private set; } = true;
+
+    private ContentControl? _zoomedQuadrant;
+    private Control? _lastFocusedInput;
+    private bool _tabletTranslated;
+
+    // Static reference so the Android Activity can ask us to handle Back.
+    public static MainView? Instance { get; private set; }
+
     public MainView()
     {
         InitializeComponent();
+        Instance = this;
+        AddHandler(GotFocusEvent, OnChildGotFocus);
+        AddHandler(LostFocusEvent, OnChildLostFocus);
+        AddHandler(KeyDownEvent, OnChildKeyDown, RoutingStrategies.Bubble, handledEventsToo: true);
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+
+        // Subscribe to InputPane (soft keyboard) state changes so we can
+        // unzoom when the keyboard is dismissed (Done button or Back key).
+        var inputPane = TopLevel.GetTopLevel(this)?.InputPane;
+        if (inputPane is not null)
+            inputPane.StateChanged += OnInputPaneStateChanged;
+    }
+
+    private void OnInputPaneStateChanged(object? sender, InputPaneStateEventArgs e)
+    {
+        if (Application.Current?.ApplicationLifetime is not ISingleViewApplicationLifetime) return;
+
+        if (e.NewState == InputPaneState.Open)
+        {
+            // Tablet: translate the grid up so rear fields sit above the keyboard.
+            if (!IsPhoneSize)
+            {
+                Dispatcher.UIThread.Post(() =>
+                {
+                    var focused = TopLevel.GetTopLevel(this)?.FocusManager?
+                        .GetFocusedElement() as Control;
+                    var quadrant = FindQuadrant(focused);
+                    if (quadrant == RLCorner || quadrant == RRCorner)
+                        TranslateForRear();
+                });
+            }
+            return;
+        }
+
+        // Closed — keyboard dismissed (by Done, Back, or system).
+        // Always reset: ReturnKeyType="Next" on fields 1-2 keeps the
+        // keyboard open when advancing, so Closed only fires for the
+        // last field's Done or a Back press — both should unzoom.
+        if (_tabletTranslated)
+        {
+            RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
+            _tabletTranslated = false;
+        }
+        if (_zoomedQuadrant is not null)
+        {
+            ResetZoom();
+        }
+        Focus();
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -49,6 +123,7 @@ public partial class MainView : UserControl
         {
             var b = Bounds;
             if (b.Height <= 0) return;
+
             double aspect = b.Width / b.Height;
             bool wasMedium = IsMedium;
             IsNarrow = aspect < NarrowThreshold;
@@ -57,6 +132,210 @@ public partial class MainView : UserControl
             {
                 RaisePropertyChanged(IsMediumProperty, wasMedium, IsMedium);
             }
+
+            IsPhoneSize = System.Math.Min(b.Width, b.Height) < PhoneSizeThreshold;
+        }
+    }
+
+    private void OnChildGotFocus(object? sender, GotFocusEventArgs e)
+    {
+        var source = e.Source as Control;
+
+        // Select all text so new input replaces the existing value.
+        // For touch, PointerReleased fires after GotFocus and repositions
+        // the caret, so we delay past it. For keyboard (Tab), run immediately.
+        if (source is TextBox tb)
+        {
+            if (e.NavigationMethod == NavigationMethod.Pointer)
+                DispatcherTimer.RunOnce(() => tb.SelectAll(), System.TimeSpan.FromMilliseconds(50));
+            else
+                Dispatcher.UIThread.Post(() => tb.SelectAll());
+        }
+
+        // Only adjust layout on single-view lifetimes (Android). Desktop ignores this.
+        if (Application.Current?.ApplicationLifetime is not ISingleViewApplicationLifetime) return;
+
+        _lastFocusedInput = source;
+        var quadrant = FindQuadrant(source);
+        if (quadrant is null) return;
+
+        if (IsPhoneSize && quadrant != _zoomedQuadrant)
+        {
+            ZoomTo(quadrant);
+        }
+        else if (!IsPhoneSize)
+        {
+            // Tablet: translate the grid up if rear fields are behind the keyboard.
+            var inputPane = TopLevel.GetTopLevel(this)?.InputPane;
+            if (quadrant == RLCorner || quadrant == RRCorner)
+            {
+                if (inputPane?.State == InputPaneState.Open)
+                    TranslateForRear();
+            }
+            else if (_tabletTranslated)
+            {
+                RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
+                _tabletTranslated = false;
+            }
+        }
+    }
+
+    private void OnChildLostFocus(object? sender, RoutedEventArgs e)
+    {
+        if (Application.Current?.ApplicationLifetime is not ISingleViewApplicationLifetime) return;
+
+        // Defer until the next focus event lands — a focus shift between two
+        // inputs in the same quadrant should not trigger an unzoom/unscroll.
+        Dispatcher.UIThread.Post(() =>
+        {
+            var focused = TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement() as Control;
+            var quadrant = FindQuadrant(focused);
+            if (quadrant is null)
+            {
+                // Focus left the quadrants entirely — reset.
+                if (_zoomedQuadrant is not null) ResetZoom();
+                if (_tabletTranslated)
+                {
+                    RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
+                    _tabletTranslated = false;
+                }
+            }
+            else if (IsPhoneSize && quadrant != _zoomedQuadrant)
+            {
+                ZoomTo(quadrant);
+            }
+            else if (!IsPhoneSize)
+            {
+                var inputPane = TopLevel.GetTopLevel(this)?.InputPane;
+                if (quadrant == RLCorner || quadrant == RRCorner)
+                {
+                    if (inputPane?.State == InputPaneState.Open)
+                        TranslateForRear();
+                }
+                else if (_tabletTranslated)
+                {
+                    RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
+                    _tabletTranslated = false;
+                }
+            }
+        });
+    }
+
+    private void OnChildKeyDown(object? sender, KeyEventArgs e)
+    {
+        // Enter on the soft keyboard should dismiss focus, which chains into
+        // OnChildLostFocus and reverses the zoom/scroll.
+        if (e.Key == Key.Enter || e.Key == Key.Return)
+        {
+            Focus();
+        }
+    }
+
+    private ContentControl? FindQuadrant(Control? control)
+    {
+        while (control is not null)
+        {
+            if (control == FLCorner || control == FRCorner ||
+                control == RLCorner || control == RRCorner)
+            {
+                return (ContentControl)control;
+            }
+            control = (control as ILogical)?.LogicalParent as Control
+                     ?? control.Parent as Control;
+        }
+        return null;
+    }
+
+    private static T? FindAncestorOfType<T>(Control? control) where T : Control
+    {
+        while (control is not null)
+        {
+            if (control is T match) return match;
+            control = (control as ILogical)?.LogicalParent as Control
+                     ?? control.Parent as Control;
+        }
+        return null;
+    }
+
+    private void ZoomTo(ContentControl quadrant)
+    {
+        var gridBounds = RootGrid.Bounds;
+        if (gridBounds.Width <= 0 || gridBounds.Height <= 0) return;
+
+        // Compute the quadrant's top-left position in grid coordinates.
+        var topLeft = quadrant.TranslatePoint(new Point(0, 0), RootGrid)
+                      ?? new Point(0, 0);
+
+        // X origin: pin the quadrant's outer edge so it fills the viewport width.
+        //   Left quadrants (FL/RL): left edge stays at x=0  → originX = 0
+        //   Right quadrants (FR/RR): right edge stays at x=1 → originX = 1
+        bool isRight = quadrant == FRCorner || quadrant == RRCorner;
+        double originX = isRight ? 1.0 : 0.0;
+
+        // Y origin: pin the quadrant's top edge to the viewport top (y=0).
+        // With scale s from origin o, point p maps to: o + (p − o) × s.
+        // Setting the mapped quadrant-top to 0 and solving gives:
+        //   originY = s × quadTopRel / (s − 1)
+        double quadTopRel = topLeft.Y / gridBounds.Height;
+        double originY = PhoneZoomScale * quadTopRel / (PhoneZoomScale - 1);
+
+        RootGrid.RenderTransformOrigin = new RelativePoint(
+            originX, originY, RelativeUnit.Relative);
+        RootGrid.RenderTransform = TransformOperations.Parse($"scale({PhoneZoomScale})");
+        _zoomedQuadrant = quadrant;
+    }
+
+    /// <summary>
+    /// Called by the Android Activity when the Back button is pressed.
+    /// Returns true if the back was consumed (zoom reset), false to
+    /// let the system handle it (close the app).
+    /// </summary>
+    public bool TryHandleBack()
+    {
+        if (_zoomedQuadrant is not null)
+        {
+            ResetZoom();
+            Focus();
+            return true;
+        }
+        if (_tabletTranslated)
+        {
+            RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
+            _tabletTranslated = false;
+            Focus();
+            return true;
+        }
+        return false;
+    }
+
+    private void ResetZoom()
+    {
+        RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
+        _zoomedQuadrant = null;
+    }
+
+    private void TranslateForRear()
+    {
+        // Use InputPane.OccludedRect to find exactly how much the keyboard
+        // covers, then translate the grid up so the rear row clears it.
+        var inputPane = TopLevel.GetTopLevel(this)?.InputPane;
+        if (inputPane is null) return;
+
+        var occluded = inputPane.OccludedRect;
+        if (occluded.Height <= 0) return;
+
+        var rlBottom = RLCorner.TranslatePoint(
+            new Point(0, RLCorner.Bounds.Height), this);
+        if (!rlBottom.HasValue) return;
+
+        double visibleBottom = Bounds.Height - occluded.Height;
+        double shift = rlBottom.Value.Y - visibleBottom;
+
+        if (shift > 0)
+        {
+            shift += 16; // padding above keyboard edge
+            RootGrid.RenderTransform = TransformOperations.Parse($"translate(0px, -{shift}px)");
+            _tabletTranslated = true;
         }
     }
 }

--- a/tire_pressure_calculator/Directory.Build.props
+++ b/tire_pressure_calculator/Directory.Build.props
@@ -1,0 +1,25 @@
+<Project>
+
+  <!--
+    Inherit the project version from the root pyproject.toml so the .NET
+    builds (Desktop, Android) always ship with the same version number as
+    the Python package and notebooks. Updating pyproject.toml is enough —
+    no need to touch .csproj files at release time.
+  -->
+  <PropertyGroup>
+    <_PyprojectPath>$(MSBuildThisFileDirectory)../pyproject.toml</_PyprojectPath>
+    <_PyprojectText>$([System.IO.File]::ReadAllText('$(_PyprojectPath)'))</_PyprojectText>
+    <Version>$([System.Text.RegularExpressions.Regex]::Match($(_PyprojectText), 'version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"').Groups[1].Value)</Version>
+    <AssemblyVersion>$(Version).0</AssemblyVersion>
+    <FileVersion>$(Version).0</FileVersion>
+
+    <!-- Android-specific: user-visible version string; ApplicationVersion (build number)
+         must be a monotonically increasing integer, so we encode it from semver. -->
+    <ApplicationDisplayVersion>$(Version)</ApplicationDisplayVersion>
+    <_VersionMajor>$([System.Text.RegularExpressions.Regex]::Match($(Version), '^([0-9]+)').Groups[1].Value)</_VersionMajor>
+    <_VersionMinor>$([System.Text.RegularExpressions.Regex]::Match($(Version), '^[0-9]+\.([0-9]+)').Groups[1].Value)</_VersionMinor>
+    <_VersionPatch>$([System.Text.RegularExpressions.Regex]::Match($(Version), '^[0-9]+\.[0-9]+\.([0-9]+)').Groups[1].Value)</_VersionPatch>
+    <ApplicationVersion>$([MSBuild]::Add($([MSBuild]::Add($([MSBuild]::Multiply($(_VersionMajor), 10000)), $([MSBuild]::Multiply($(_VersionMinor), 100)))), $(_VersionPatch)))</ApplicationVersion>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION

Three issues on Android:

1. All numeric inputs (Current/Target °C, Target bar) now request the
   numeric IME via a global style that sets TextInputOptions.ContentType
   to Number on the inner TextBox of every NumericUpDown. Number includes
   the decimal separator and minus sign (unlike Digits), which we need
   for negative temps and decimal pressures.

2. WindowSoftInputMode = AdjustResize | StateHidden on MainActivity so
   the window reflows when the IME appears (vs. the default, which let
   the keyboard overlay the focused field). Extended ConfigurationChanges
   with Keyboard | KeyboardHidden to avoid activity recreation and visual
   flicker when the IME shows/hides.

3. Size-aware focus behavior on Android only:
   - On phone-sized screens (smallest dimension < 600 DIPs), tapping any
     input animates a RenderTransform zoom into the focused quadrant so
     the user can see what they're typing; any focus loss (Enter, tap
     outside) zooms back out.
   - On tablet-sized screens (>= 600 DIPs), tapping a rear-row field
     (RL/RR) scrolls the ScrollViewer so the rear is above the keyboard;
     front-row fields don't scroll (they're already visible).

Desktop layout and tests are unchanged. All 29 tests pass.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/90).
* #92
* #91
* __->__ #90
* #89