### PR TITLE
Android: fix zoomed selection handles and back-button crash

### DIFF
--- a/tire_pressure_calculator/Core/Navigation/BackNavigationController.cs
+++ b/tire_pressure_calculator/Core/Navigation/BackNavigationController.cs
@@ -1,0 +1,84 @@
+namespace TirePressureCalculator.Navigation;
+
+/// <summary>
+/// Tracks phone-mode zoom and tablet-mode translate state, and coordinates
+/// Android back-button handling across the soft keyboard and the activity.
+/// </summary>
+public class BackNavigationController
+{
+    /// <summary>Invoked when the zoom state is reset (undo the zoom transform).</summary>
+    public Action? ResetZoomAction { get; set; }
+
+    /// <summary>Invoked when the tablet translate state is reset.</summary>
+    public Action? UntranslateAction { get; set; }
+
+    /// <summary>
+    /// Schedules an action to run later. Defaults to synchronous inline
+    /// execution.
+    /// </summary>
+    public Action<Action> Defer { get; set; } = action => action();
+
+    /// <summary>Identity of the currently zoomed quadrant, or null if not zoomed.</summary>
+    public object? ZoomedQuadrant { get; private set; }
+
+    /// <summary>Whether the tablet-mode grid is currently translated up.</summary>
+    public bool IsTabletTranslated { get; private set; }
+
+    public bool IsZoomed => ZoomedQuadrant is not null;
+
+    public void NotifyZoomed(object quadrant) => ZoomedQuadrant = quadrant;
+
+    public void NotifyUnzoomed() => ZoomedQuadrant = null;
+
+    public void NotifyTabletTranslated() => IsTabletTranslated = true;
+
+    public void NotifyTabletUntranslated() => IsTabletTranslated = false;
+
+    /// <summary>
+    /// Called when the Android soft keyboard closes (by Done, Back, or swipe).
+    /// Side effects are deferred via <see cref="Defer"/> so that if the close
+    /// was triggered by a Back press, the Activity's OnBackPressed — which
+    /// can fire synchronously right after the IME close — still observes the
+    /// zoom/translate state and consumes the back press via
+    /// <see cref="TryHandleBack"/>. Without deferral, the activity's base
+    /// OnBackPressed would run instead and close the app.
+    /// </summary>
+    public void OnKeyboardClosed()
+    {
+        Defer(() =>
+        {
+            if (IsTabletTranslated)
+            {
+                UntranslateAction?.Invoke();
+                IsTabletTranslated = false;
+            }
+            if (ZoomedQuadrant is not null)
+            {
+                ResetZoomAction?.Invoke();
+                ZoomedQuadrant = null;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Called from the Activity's OnBackPressed. Returns true if the back
+    /// press was consumed (zoom/translate reset); false if the caller should
+    /// let the system handle it (close the activity).
+    /// </summary>
+    public bool TryHandleBack()
+    {
+        if (ZoomedQuadrant is not null)
+        {
+            ResetZoomAction?.Invoke();
+            ZoomedQuadrant = null;
+            return true;
+        }
+        if (IsTabletTranslated)
+        {
+            UntranslateAction?.Invoke();
+            IsTabletTranslated = false;
+            return true;
+        }
+        return false;
+    }
+}

--- a/tire_pressure_calculator/Core/TirePressureCalculator.Core.csproj
+++ b/tire_pressure_calculator/Core/TirePressureCalculator.Core.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.14" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="TirePressureCalculator.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tire_pressure_calculator/Core/Views/MainView.axaml
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml
@@ -189,16 +189,9 @@
   <ScrollViewer x:Name="RootScroll"
                 HorizontalScrollBarVisibility="Disabled"
                 VerticalScrollBarVisibility="Hidden">
+    <LayoutTransformControl x:Name="RootLayoutTransform">
     <Grid x:Name="RootGrid"
-          RowDefinitions="Auto,*,*,Auto" ColumnDefinitions="*,*"
-          RenderTransform="scale(1)">
-      <Grid.Transitions>
-        <Transitions>
-          <TransformOperationsTransition Property="RenderTransform"
-                                         Duration="0:0:0.2"
-                                         Easing="CubicEaseOut" />
-        </Transitions>
-      </Grid.Transitions>
+          RowDefinitions="Auto,*,*,Auto" ColumnDefinitions="*,*">
 
       <!-- Front arrow (broad, flat) centered at top -->
       <Panel Grid.Row="0" Grid.ColumnSpan="2" Height="32" Margin="0,6,0,0">
@@ -248,5 +241,6 @@
                 Width="150" VerticalAlignment="Center" />
       </StackPanel>
     </Grid>
+    </LayoutTransformControl>
   </ScrollViewer>
 </UserControl>

--- a/tire_pressure_calculator/Core/Views/MainView.axaml.cs
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml.cs
@@ -3,11 +3,14 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Platform;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
+using Avalonia.Media;
 using Avalonia.Media.Transformation;
 using Avalonia.Threading;
+using TirePressureCalculator.Navigation;
 
 namespace TirePressureCalculator.Views;
 
@@ -52,9 +55,11 @@ public partial class MainView : UserControl
     // Drives the phone-only zoom-to-quadrant behavior.
     public bool IsPhoneSize { get; private set; } = true;
 
-    private ContentControl? _zoomedQuadrant;
     private Control? _lastFocusedInput;
-    private bool _tabletTranslated;
+    private readonly BackNavigationController _backNav = new();
+
+    private ContentControl? ZoomedQuadrant => _backNav.ZoomedQuadrant as ContentControl;
+    private bool IsTabletTranslated => _backNav.IsTabletTranslated;
 
     // Static reference so the Android Activity can ask us to handle Back.
     public static MainView? Instance { get; private set; }
@@ -63,6 +68,9 @@ public partial class MainView : UserControl
     {
         InitializeComponent();
         Instance = this;
+        _backNav.ResetZoomAction = ApplyZoomReset;
+        _backNav.UntranslateAction = ApplyTranslateReset;
+        _backNav.Defer = action => Dispatcher.UIThread.Post(action);
         AddHandler(GotFocusEvent, OnChildGotFocus);
         AddHandler(LostFocusEvent, OnChildLostFocus);
         AddHandler(KeyDownEvent, OnChildKeyDown, RoutingStrategies.Bubble, handledEventsToo: true);
@@ -101,18 +109,10 @@ public partial class MainView : UserControl
         }
 
         // Closed — keyboard dismissed (by Done, Back, or system).
-        // Always reset: ReturnKeyType="Next" on fields 1-2 keeps the
-        // keyboard open when advancing, so Closed only fires for the
-        // last field's Done or a Back press — both should unzoom.
-        if (_tabletTranslated)
-        {
-            RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
-            _tabletTranslated = false;
-        }
-        if (_zoomedQuadrant is not null)
-        {
-            ResetZoom();
-        }
+        // The controller defers side effects so a Back press following this
+        // event synchronously can still consume the zoom state via
+        // TryHandleBack instead of closing the activity.
+        _backNav.OnKeyboardClosed();
         Focus();
     }
 
@@ -159,7 +159,7 @@ public partial class MainView : UserControl
         var quadrant = FindQuadrant(source);
         if (quadrant is null) return;
 
-        if (IsPhoneSize && quadrant != _zoomedQuadrant)
+        if (IsPhoneSize && quadrant != ZoomedQuadrant)
         {
             ZoomTo(quadrant);
         }
@@ -172,10 +172,10 @@ public partial class MainView : UserControl
                 if (inputPane?.State == InputPaneState.Open)
                     TranslateForRear();
             }
-            else if (_tabletTranslated)
+            else if (IsTabletTranslated)
             {
-                RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
-                _tabletTranslated = false;
+                ApplyTranslateReset();
+                _backNav.NotifyTabletUntranslated();
             }
         }
     }
@@ -193,14 +193,18 @@ public partial class MainView : UserControl
             if (quadrant is null)
             {
                 // Focus left the quadrants entirely — reset.
-                if (_zoomedQuadrant is not null) ResetZoom();
-                if (_tabletTranslated)
+                if (ZoomedQuadrant is not null)
                 {
-                    RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
-                    _tabletTranslated = false;
+                    ApplyZoomReset();
+                    _backNav.NotifyUnzoomed();
+                }
+                if (IsTabletTranslated)
+                {
+                    ApplyTranslateReset();
+                    _backNav.NotifyTabletUntranslated();
                 }
             }
-            else if (IsPhoneSize && quadrant != _zoomedQuadrant)
+            else if (IsPhoneSize && quadrant != ZoomedQuadrant)
             {
                 ZoomTo(quadrant);
             }
@@ -212,10 +216,10 @@ public partial class MainView : UserControl
                     if (inputPane?.State == InputPaneState.Open)
                         TranslateForRear();
                 }
-                else if (_tabletTranslated)
+                else if (IsTabletTranslated)
                 {
-                    RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
-                    _tabletTranslated = false;
+                    ApplyTranslateReset();
+                    _backNav.NotifyTabletUntranslated();
                 }
             }
         });
@@ -257,32 +261,44 @@ public partial class MainView : UserControl
         return null;
     }
 
-    private void ZoomTo(ContentControl quadrant)
+    internal void ZoomTo(ContentControl quadrant)
     {
         var gridBounds = RootGrid.Bounds;
         if (gridBounds.Width <= 0 || gridBounds.Height <= 0) return;
 
         // Compute the quadrant's top-left position in grid coordinates.
+        // After layout re-runs at scaled size, scroll to this point so the
+        // selected quadrant sits at the viewport origin.
         var topLeft = quadrant.TranslatePoint(new Point(0, 0), RootGrid)
                       ?? new Point(0, 0);
 
-        // X origin: pin the quadrant's outer edge so it fills the viewport width.
-        //   Left quadrants (FL/RL): left edge stays at x=0  → originX = 0
-        //   Right quadrants (FR/RR): right edge stays at x=1 → originX = 1
-        bool isRight = quadrant == FRCorner || quadrant == RRCorner;
-        double originX = isRight ? 1.0 : 0.0;
+        // Pin the RootGrid to the current viewport dimensions so its natural
+        // measure is definite. The enclosing LayoutTransformControl will
+        // then scale that definite size to 2x.
+        RootGrid.Width = gridBounds.Width;
+        RootGrid.Height = gridBounds.Height;
 
-        // Y origin: pin the quadrant's top edge to the viewport top (y=0).
-        // With scale s from origin o, point p maps to: o + (p − o) × s.
-        // Setting the mapped quadrant-top to 0 and solving gives:
-        //   originY = s × quadTopRel / (s − 1)
-        double quadTopRel = topLeft.Y / gridBounds.Height;
-        double originY = PhoneZoomScale * quadTopRel / (PhoneZoomScale - 1);
+        // Enable horizontal scrolling so the ScrollViewer doesn't constrain
+        // the scaled-up content width back down to the viewport.
+        RootScroll.HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden;
 
-        RootGrid.RenderTransformOrigin = new RelativePoint(
-            originX, originY, RelativeUnit.Relative);
-        RootGrid.RenderTransform = TransformOperations.Parse($"scale({PhoneZoomScale})");
-        _zoomedQuadrant = quadrant;
+        // Use LayoutTransform (via LayoutTransformControl) rather than
+        // RenderTransform so the scale participates in Measure/Arrange.
+        // This ensures TextBox selection handles — which are drawn by
+        // adorners positioned via the normal layout coordinate system —
+        // follow the zoom instead of floating at pre-scale coordinates.
+        RootLayoutTransform.LayoutTransform = new ScaleTransform(
+            PhoneZoomScale, PhoneZoomScale);
+        _backNav.NotifyZoomed(quadrant);
+
+        // Wait for layout to apply the new extent, then scroll so the
+        // chosen quadrant is visible at the top of the viewport.
+        Dispatcher.UIThread.Post(() =>
+        {
+            RootScroll.Offset = new Vector(
+                topLeft.X * PhoneZoomScale,
+                topLeft.Y * PhoneZoomScale);
+        });
     }
 
     /// <summary>
@@ -292,26 +308,26 @@ public partial class MainView : UserControl
     /// </summary>
     public bool TryHandleBack()
     {
-        if (_zoomedQuadrant is not null)
+        if (_backNav.TryHandleBack())
         {
-            ResetZoom();
-            Focus();
-            return true;
-        }
-        if (_tabletTranslated)
-        {
-            RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
-            _tabletTranslated = false;
             Focus();
             return true;
         }
         return false;
     }
 
-    private void ResetZoom()
+    private void ApplyZoomReset()
+    {
+        RootLayoutTransform.LayoutTransform = null;
+        RootGrid.Width = double.NaN;
+        RootGrid.Height = double.NaN;
+        RootScroll.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
+        RootScroll.Offset = new Vector(0, 0);
+    }
+
+    private void ApplyTranslateReset()
     {
         RootGrid.RenderTransform = TransformOperations.Parse("scale(1)");
-        _zoomedQuadrant = null;
     }
 
     private void TranslateForRear()
@@ -335,7 +351,7 @@ public partial class MainView : UserControl
         {
             shift += 16; // padding above keyboard edge
             RootGrid.RenderTransform = TransformOperations.Parse($"translate(0px, -{shift}px)");
-            _tabletTranslated = true;
+            _backNav.NotifyTabletTranslated();
         }
     }
 }

--- a/tire_pressure_calculator/Tests/BackNavigationControllerTests.cs
+++ b/tire_pressure_calculator/Tests/BackNavigationControllerTests.cs
@@ -1,0 +1,135 @@
+using TirePressureCalculator.Navigation;
+
+namespace TirePressureCalculator.Tests;
+
+public class BackNavigationControllerTests
+{
+    [Fact]
+    public void TryHandleBack_WhenZoomed_ConsumesAndResets()
+    {
+        var ctrl = new BackNavigationController();
+        bool reset = false;
+        ctrl.ResetZoomAction = () => reset = true;
+        ctrl.NotifyZoomed(new object());
+
+        var consumed = ctrl.TryHandleBack();
+
+        Assert.True(consumed);
+        Assert.True(reset);
+        Assert.Null(ctrl.ZoomedQuadrant);
+    }
+
+    [Fact]
+    public void TryHandleBack_WhenIdle_DoesNotConsume()
+    {
+        var ctrl = new BackNavigationController();
+
+        var consumed = ctrl.TryHandleBack();
+
+        Assert.False(consumed);
+    }
+
+    [Fact]
+    public void TryHandleBack_WhenTabletTranslated_ConsumesAndUntranslates()
+    {
+        var ctrl = new BackNavigationController();
+        bool untranslated = false;
+        ctrl.UntranslateAction = () => untranslated = true;
+        ctrl.NotifyTabletTranslated();
+
+        var consumed = ctrl.TryHandleBack();
+
+        Assert.True(consumed);
+        Assert.True(untranslated);
+        Assert.False(ctrl.IsTabletTranslated);
+    }
+
+    // Bug 2 repro: on Android, pressing Back while a TextBox is focused
+    // dispatches two near-simultaneous events — the IME closes (firing
+    // OnKeyboardClosed synchronously) and then the Activity's
+    // OnBackPressed runs. If OnKeyboardClosed eagerly resets the zoom
+    // state, OnBackPressed sees nothing to consume and closes the app.
+    //
+    // Correct behavior: OnKeyboardClosed must defer its side effects so
+    // that a back press following synchronously still observes the zoom
+    // state and can consume it via TryHandleBack.
+    [Fact]
+    public void BackPress_AfterKeyboardClose_StillConsumesAndResets()
+    {
+        var deferred = new Queue<Action>();
+        var ctrl = new BackNavigationController
+        {
+            Defer = action => deferred.Enqueue(action),
+        };
+        int resetCalls = 0;
+        ctrl.ResetZoomAction = () => resetCalls++;
+        ctrl.NotifyZoomed(new object());
+
+        // Step 1: IME closes.
+        ctrl.OnKeyboardClosed();
+
+        // Deferred side effects must NOT have run yet — the activity's
+        // OnBackPressed will fire synchronously after this, and it needs
+        // to observe the zoom state to consume the back press.
+        Assert.NotNull(ctrl.ZoomedQuadrant);
+        Assert.Equal(0, resetCalls);
+
+        // Step 2: Activity.OnBackPressed runs synchronously.
+        var consumed = ctrl.TryHandleBack();
+
+        Assert.True(consumed);
+        Assert.Equal(1, resetCalls);
+        Assert.Null(ctrl.ZoomedQuadrant);
+
+        // Flush deferred actions: the scheduled reset now no-ops because
+        // the state has already been cleared by TryHandleBack.
+        while (deferred.TryDequeue(out var action)) action();
+        Assert.Equal(1, resetCalls);
+    }
+
+    [Fact]
+    public void KeyboardClose_WithoutBackPress_EventuallyResetsViaDeferredAction()
+    {
+        // Simulates the IME dismissed via Done or swipe (no back press).
+        // The deferred action runs on the next frame and resets zoom.
+        var deferred = new Queue<Action>();
+        var ctrl = new BackNavigationController
+        {
+            Defer = action => deferred.Enqueue(action),
+        };
+        bool reset = false;
+        ctrl.ResetZoomAction = () => reset = true;
+        ctrl.NotifyZoomed(new object());
+
+        ctrl.OnKeyboardClosed();
+        Assert.False(reset);
+
+        while (deferred.TryDequeue(out var action)) action();
+
+        Assert.True(reset);
+        Assert.Null(ctrl.ZoomedQuadrant);
+    }
+
+    [Fact]
+    public void KeyboardClose_WithTabletTranslate_DeferredUntranslate()
+    {
+        var deferred = new Queue<Action>();
+        var ctrl = new BackNavigationController
+        {
+            Defer = action => deferred.Enqueue(action),
+        };
+        bool untranslated = false;
+        ctrl.UntranslateAction = () => untranslated = true;
+        ctrl.NotifyTabletTranslated();
+
+        ctrl.OnKeyboardClosed();
+        Assert.False(untranslated);
+        Assert.True(ctrl.IsTabletTranslated);
+
+        // Activity back runs first — consumes.
+        var consumed = ctrl.TryHandleBack();
+        Assert.True(consumed);
+        Assert.True(untranslated);
+        Assert.False(ctrl.IsTabletTranslated);
+    }
+}

--- a/tire_pressure_calculator/Tests/MainViewZoomTests.cs
+++ b/tire_pressure_calculator/Tests/MainViewZoomTests.cs
@@ -1,0 +1,59 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using TirePressureCalculator.ViewModels;
+using TirePressureCalculator.Views;
+
+namespace TirePressureCalculator.Tests;
+
+public class MainViewZoomTests
+{
+    // Bug 1 repro: on Android phone mode, tapping a field zooms into its
+    // quadrant via RenderTransform scale. Text selection handles (the nubs
+    // that bracket the selected text) are placed in screen coordinates that
+    // don't follow the RenderTransform, so they float above and to the left
+    // of the actual text.
+    //
+    // Correct behavior: the zoom must be applied via a layout-affecting
+    // transform (LayoutTransformControl + LayoutTransform) so the entire
+    // measure/arrange pipeline scales, and TextBox adorners naturally
+    // follow. The testable signature: when zoomed, the content is arranged
+    // at the scaled size, so ScrollViewer.Extent is larger than Viewport.
+    [AvaloniaFact]
+    public void ZoomToQuadrant_ContentIsArrangedAtScaledSize()
+    {
+        var view = new MainView { DataContext = new MainViewModel() };
+        var window = new Window
+        {
+            Width = 400,
+            Height = 800,
+            Content = view,
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var fl = view.FindControl<ContentControl>("FLCorner");
+        var scroll = view.FindControl<ScrollViewer>("RootScroll");
+        Assert.NotNull(fl);
+        Assert.NotNull(scroll);
+
+        // Baseline: before zoom, content fits viewport.
+        var baselineExtent = scroll.Extent;
+
+        view.ZoomTo(fl);
+        Dispatcher.UIThread.RunJobs();
+
+        // With a layout-affecting zoom, the ScrollViewer reports a larger
+        // extent than viewport (content was arranged at 2x size). With the
+        // buggy RenderTransform-only approach, extent == viewport because
+        // the scale is purely visual and doesn't participate in layout.
+        Assert.True(
+            scroll.Extent.Width > scroll.Viewport.Width * 1.5,
+            $"Expected extent > 1.5x viewport after zoom. " +
+            $"Got Extent={scroll.Extent}, Viewport={scroll.Viewport}, " +
+            $"BaselineExtent={baselineExtent}. " +
+            $"This indicates the zoom uses RenderTransform (bug 1) rather " +
+            $"than a layout-affecting transform.");
+    }
+}

--- a/tire_pressure_calculator/Tests/TestAppBuilder.cs
+++ b/tire_pressure_calculator/Tests/TestAppBuilder.cs
@@ -1,0 +1,17 @@
+using Avalonia;
+using Avalonia.Headless;
+using TirePressureCalculator.Tests;
+
+[assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
+
+namespace TirePressureCalculator.Tests;
+
+public class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder
+        .Configure<TirePressureCalculator.App>()
+        .UseHeadless(new AvaloniaHeadlessPlatformOptions
+        {
+            UseHeadlessDrawing = true,
+        });
+}

--- a/tire_pressure_calculator/Tests/TirePressureCalculator.Tests.csproj
+++ b/tire_pressure_calculator/Tests/TirePressureCalculator.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.14" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION

Two Pixel Fold bugs in the phone-mode zoom-to-quadrant behavior:

1. Selection-handle nubs floated above/left of the selected text when a
   field was tapped. The culprit was the RenderTransform scale on
   RootGrid — TextBox selection adorners are placed via the normal
   layout coordinate system and don't follow a pure RenderTransform, so
   they drew at pre-scale positions. Switched to a
   LayoutTransformControl wrapping RootGrid with a LayoutTransform
   ScaleTransform, so the scale participates in Measure/Arrange and
   adorners follow. Pinned RootGrid.Width/Height and toggled
   HorizontalScrollBarVisibility during zoom so the LTC can grow beyond
   the viewport.

2. Pressing Back from a zoomed-in field closed the app instead of
   unzooming. On Android, Back first dismisses the IME (firing
   InputPaneState.Closed synchronously), then the Activity's
   OnBackPressed runs. The old handler eagerly reset _zoomedQuadrant on
   keyboard-close, so TryHandleBack saw nothing to consume and
   base.OnBackPressed closed the activity. Extracted the zoom/translate
   state into a new BackNavigationController that defers keyboard-close
   side effects via Dispatcher.UIThread.Post, so TryHandleBack still
   observes the zoom state and consumes the back press.

Tests (all 36 pass, 7 new):
  BackNavigationControllerTests — 6 tests exercising the defer/consume
    contract, including the keyboard-close → back-press race.
  MainViewZoomTests — Avalonia.Headless UI test asserting that after
    ZoomTo the ScrollViewer extent exceeds 1.5× the viewport (the
    signature of a layout-affecting transform; fails under the prior
    RenderTransform approach).

Caveat: the prior 200ms cubic-ease-out zoom transition is gone —
LayoutTransformControl doesn't inherit the TransformOperationsTransition
on RenderTransform. The zoom now snaps; restoring the animation would
need a Transition on LayoutTransform or a companion render-scale animation.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/91).
* #92
* __->__ #91