### PR TITLE
tire-etl: structured run-note enrichment via claude -p

### DIFF
--- a/src/motorsports_data_notebook/tire_etl/__init__.py
+++ b/src/motorsports_data_notebook/tire_etl/__init__.py
@@ -6,6 +6,7 @@ historical weather into a queryable Parquet dataset under ``data/tire_dataset/``
 Public API
 ----------
 - :func:`run_extract` — walk the AIM data tree and extract new sessions
+- :func:`run_enrich_notes` — parse run-note .txt files via ``claude -p``
 - :data:`EXTRACTOR_VERSION` — bumped to force re-extraction of all sessions
 """
 
@@ -14,9 +15,11 @@ from __future__ import annotations
 EXTRACTOR_VERSION = "0.2.0"
 
 from .extract import extract_session, run_extract  # noqa: E402
+from .notes_parser import run_enrich_notes  # noqa: E402
 
 __all__ = [
     "EXTRACTOR_VERSION",
     "extract_session",
     "run_extract",
+    "run_enrich_notes",
 ]

--- a/src/motorsports_data_notebook/tire_etl/notes_match.py
+++ b/src/motorsports_data_notebook/tire_etl/notes_match.py
@@ -1,0 +1,203 @@
+"""Match parsed run-notes to telemetry sessions by date + track (+ time).
+
+Produces a table keyed on ``session_id`` with the source note file and the
+session index within that file. Ambiguous matches (multiple candidate note
+sessions for one telemetry session) receive a lower ``match_confidence``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date as _date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pyarrow as pa
+
+from .notes_parser import NoteSession, ParsedNotes
+from .tracks import get_track, normalize_track_name
+
+
+@dataclass(frozen=True)
+class NoteMatch:
+    session_id: str
+    source_file: str
+    source_sha1: str
+    note_session_index: int
+    match_confidence: float
+    cold_pressure_bar_fl: float | None
+    cold_pressure_bar_fr: float | None
+    cold_pressure_bar_rl: float | None
+    cold_pressure_bar_rr: float | None
+    tire_compound_fl: str | None
+    tire_compound_fr: str | None
+    tire_compound_rl: str | None
+    tire_compound_rr: str | None
+    track_condition: str
+    ambient_temp_c: float | None
+    weather_text: str | None
+
+
+def _parse_local_time(hhmm: str | None) -> tuple[int, int] | None:
+    if not hhmm:
+        return None
+    try:
+        h, m = hhmm.split(":")
+        return int(h), int(m)
+    except (ValueError, AttributeError):
+        return None
+
+
+def _session_utc_to_local_minutes(
+    session_start_utc: datetime, track_canonical: str | None
+) -> int | None:
+    if track_canonical is None:
+        return None
+    ti = get_track(track_canonical)
+    if ti is None:
+        return None
+    local = session_start_utc.astimezone(ti.tzinfo())
+    return local.hour * 60 + local.minute
+
+
+def match_notes_to_sessions(
+    sessions: pa.Table,
+    parsed_notes: list[ParsedNotes],
+    *,
+    date_tolerance_days: int = 1,
+    time_tolerance_minutes: int = 90,
+) -> list[NoteMatch]:
+    """Return per-session match records for every resolvable session."""
+    matches: list[NoteMatch] = []
+    if len(sessions) == 0 or not parsed_notes:
+        return matches
+
+    # Index notes by (date, track_canonical)
+    note_entries: list[tuple[_date, str | None, ParsedNotes, NoteSession]] = []
+    for pn in parsed_notes:
+        file_date = pn.data.file_date
+        # Fall back to filename date embedded by the source (not available here);
+        # we rely on file_date being filled by the LLM.
+        try:
+            d = datetime.strptime(file_date, "%Y-%m-%d").date() if file_date else None
+        except ValueError:
+            d = None
+        note_track_can = normalize_track_name(pn.data.track or "")
+        if d is None:
+            continue
+        for ns in pn.data.sessions:
+            note_entries.append((d, note_track_can, pn, ns))
+
+    sess_ids = sessions.column("session_id").to_pylist()
+    sess_dates = sessions.column("date").to_pylist()
+    sess_tracks = sessions.column("track_canonical").to_pylist()
+    sess_utc = sessions.column("session_start_utc").to_pylist()
+
+    for i, sess_id in enumerate(sess_ids):
+        sess_date: _date = sess_dates[i]
+        track_can: str | None = sess_tracks[i]
+        # Candidate notes: within date window + same track.
+        candidates = [
+            entry
+            for entry in note_entries
+            if abs((entry[0] - sess_date).days) <= date_tolerance_days
+            and (track_can is None or entry[1] == track_can)
+        ]
+        if not candidates:
+            continue
+
+        # If only one candidate: high confidence.
+        if len(candidates) == 1:
+            _, _, pn, ns = candidates[0]
+            matches.append(_make_match(sess_id, pn, ns, confidence=1.0 if track_can else 0.9))
+            continue
+
+        # Multiple candidates: prefer time-of-day match.
+        sess_local_min = _session_utc_to_local_minutes(
+            sess_utc[i].replace(tzinfo=timezone.utc) if sess_utc[i].tzinfo is None else sess_utc[i],
+            track_can,
+        )
+        best = None
+        best_delta = None
+        for entry in candidates:
+            _, _, pn, ns = entry
+            lt = _parse_local_time(ns.start_time_local)
+            if lt is None or sess_local_min is None:
+                continue
+            nmin = lt[0] * 60 + lt[1]
+            delta = abs(nmin - sess_local_min)
+            if delta <= time_tolerance_minutes and (best_delta is None or delta < best_delta):
+                best = entry
+                best_delta = delta
+        if best is not None:
+            _, _, pn, ns = best
+            conf = max(0.5, 1.0 - (best_delta or 0) / (time_tolerance_minutes * 2))
+            matches.append(_make_match(sess_id, pn, ns, confidence=conf))
+        else:
+            # All candidates equally plausible — record first with low confidence.
+            _, _, pn, ns = candidates[0]
+            matches.append(_make_match(sess_id, pn, ns, confidence=0.3))
+
+    return matches
+
+
+def _make_match(
+    session_id: str, pn: ParsedNotes, ns: NoteSession, *, confidence: float
+) -> NoteMatch:
+    return NoteMatch(
+        session_id=session_id,
+        source_file=str(pn.source_file),
+        source_sha1=pn.source_sha1,
+        note_session_index=ns.session_index,
+        match_confidence=float(confidence),
+        cold_pressure_bar_fl=ns.cold_pressure_bar.fl,
+        cold_pressure_bar_fr=ns.cold_pressure_bar.fr,
+        cold_pressure_bar_rl=ns.cold_pressure_bar.rl,
+        cold_pressure_bar_rr=ns.cold_pressure_bar.rr,
+        tire_compound_fl=ns.tire_compound.fl,
+        tire_compound_fr=ns.tire_compound.fr,
+        tire_compound_rl=ns.tire_compound.rl,
+        tire_compound_rr=ns.tire_compound.rr,
+        track_condition=ns.track_condition,
+        ambient_temp_c=ns.ambient_temp_c,
+        weather_text=ns.weather_text,
+    )
+
+
+def matches_to_table(matches: list[NoteMatch]) -> pa.Table:
+    if not matches:
+        return pa.table(
+            {
+                "session_id": pa.array([], type=pa.string()),
+                "source_file": pa.array([], type=pa.string()),
+                "source_sha1": pa.array([], type=pa.string()),
+                "note_session_index": pa.array([], type=pa.int32()),
+                "match_confidence": pa.array([], type=pa.float32()),
+                "cold_pressure_bar_fl": pa.array([], type=pa.float32()),
+                "cold_pressure_bar_fr": pa.array([], type=pa.float32()),
+                "cold_pressure_bar_rl": pa.array([], type=pa.float32()),
+                "cold_pressure_bar_rr": pa.array([], type=pa.float32()),
+                "tire_compound_fl": pa.array([], type=pa.string()),
+                "tire_compound_fr": pa.array([], type=pa.string()),
+                "tire_compound_rl": pa.array([], type=pa.string()),
+                "tire_compound_rr": pa.array([], type=pa.string()),
+                "track_condition": pa.array([], type=pa.string()),
+                "ambient_temp_c": pa.array([], type=pa.float32()),
+                "weather_text": pa.array([], type=pa.string()),
+            }
+        )
+    cols: dict[str, list] = {k: [] for k in NoteMatch.__annotations__}
+    for m in matches:
+        for k in cols:
+            cols[k].append(getattr(m, k))
+    return pa.table(cols)
+
+
+def write_matches(dataset_root: Path, matches: list[NoteMatch]) -> None:
+    """Write the matches table to dataset_root/notes_matches.parquet."""
+    import pyarrow.parquet as pq
+
+    path = dataset_root / "notes_matches.parquet"
+    table = matches_to_table(matches)
+    tmp = path.with_suffix(".parquet.tmp")
+    pq.write_table(table, tmp, compression="zstd", compression_level=3)
+    tmp.replace(path)

--- a/src/motorsports_data_notebook/tire_etl/notes_parser.py
+++ b/src/motorsports_data_notebook/tire_etl/notes_parser.py
@@ -1,0 +1,233 @@
+"""Parse free-form run notes via ``claude -p``.
+
+The LLM call is cached to disk (and committed) keyed by content hashes:
+unchanged notes never re-invoke the model. The committed JSON IS the cache.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.resources
+import json
+import logging
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field, ValidationError
+
+from .paths import DEFAULT_NOTES_ROOT, default_dataset_root, notes_extracted_dir
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "claude-opus-4-7"
+_PROMPT_RESOURCE = ("motorsports_data_notebook.tire_etl", "notes_system_prompt.txt")
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema — mirrors the prompt exactly so validation is meaningful.
+# ---------------------------------------------------------------------------
+
+
+class CornerValue(BaseModel):
+    fl: float | None = None
+    fr: float | None = None
+    rl: float | None = None
+    rr: float | None = None
+
+
+class CornerStr(BaseModel):
+    fl: str | None = None
+    fr: str | None = None
+    rl: str | None = None
+    rr: str | None = None
+
+
+class NoteSession(BaseModel):
+    session_index: int
+    start_time_local: str | None = None
+    weather_text: str | None = None
+    ambient_temp_c: float | None = None
+    track_condition: Literal["dry", "damp", "wet", "snow", "unknown"] = "unknown"
+    cold_pressure_bar: CornerValue = Field(default_factory=CornerValue)
+    tire_compound: CornerStr = Field(default_factory=CornerStr)
+    setup_changes: list[str] = Field(default_factory=list)
+    incidents: list[str] = Field(default_factory=list)
+    notes: str = ""
+
+
+class NotesData(BaseModel):
+    file_date: str | None = None
+    track: str | None = None
+    car: str | None = None
+    sessions: list[NoteSession] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Cache + claude invocation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ParsedNotes:
+    source_file: Path
+    source_sha1: str
+    prompt_sha1: str
+    model: str
+    extracted_at: str
+    data: NotesData
+
+
+def _load_system_prompt() -> str:
+    package, resource = _PROMPT_RESOURCE
+    return importlib.resources.files(package).joinpath(resource).read_text()
+
+
+def _sha1(data: str) -> str:
+    return hashlib.sha1(data.encode("utf-8")).hexdigest()
+
+
+def _invoke_claude_p(
+    notes_text: str,
+    system_prompt: str,
+    model: str,
+    timeout_s: float = 300.0,
+) -> str:
+    """Call ``claude -p`` and return raw stdout.
+
+    Uses the non-interactive print mode. We pass the notes text as the user
+    prompt (suffixed so the system prompt leads), and request text output
+    (which the prompt instructs to be pure JSON).
+    """
+    combined = f"{system_prompt}\n\n---\nNOTES FILE CONTENTS:\n{notes_text}\n"
+    try:
+        proc = subprocess.run(
+            ["claude", "-p", "--model", model, combined],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=timeout_s,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "`claude` CLI not found on PATH. Install Claude Code: https://claude.com/claude-code"
+        ) from e
+    return proc.stdout.strip()
+
+
+def _strip_code_fences(text: str) -> str:
+    """LLMs sometimes wrap JSON in ```json fences despite instructions."""
+    t = text.strip()
+    if t.startswith("```"):
+        lines = t.splitlines()
+        # Drop leading fence (optionally with language) and trailing fence.
+        if lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        t = "\n".join(lines)
+    return t.strip()
+
+
+def parse_notes_file(
+    path: Path,
+    *,
+    dataset_root: Path | None = None,
+    model: str = DEFAULT_MODEL,
+    force: bool = False,
+) -> ParsedNotes:
+    """Return validated, cached parse of a single notes .txt file."""
+    if dataset_root is None:
+        dataset_root = default_dataset_root()
+    notes_text = path.read_text(encoding="utf-8", errors="replace")
+    source_sha1 = _sha1(notes_text)
+    prompt_text = _load_system_prompt()
+    prompt_sha1 = _sha1(prompt_text)
+    cache_key = f"{source_sha1}|{prompt_sha1}|{model}"
+
+    cache_path = notes_extracted_dir(dataset_root) / f"{path.stem}.json"
+    if cache_path.exists() and not force:
+        try:
+            cached = json.loads(cache_path.read_text(encoding="utf-8"))
+            if cached.get("_cache_key") == cache_key:
+                data = NotesData.model_validate(cached["data"])
+                return ParsedNotes(
+                    source_file=path,
+                    source_sha1=source_sha1,
+                    prompt_sha1=prompt_sha1,
+                    model=model,
+                    extracted_at=cached.get("_extracted_at", ""),
+                    data=data,
+                )
+        except (json.JSONDecodeError, ValidationError, KeyError):
+            logger.warning("cache invalid for %s — re-parsing", path.name)
+
+    raw = _invoke_claude_p(notes_text, prompt_text, model)
+    cleaned = _strip_code_fences(raw)
+    try:
+        payload = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"claude -p did not return valid JSON for {path.name}: {e}\n{cleaned[:500]}"
+        ) from e
+
+    data = NotesData.model_validate(payload)
+    extracted_at = datetime.now(tz=timezone.utc).isoformat(timespec="seconds")
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_payload = {
+        "_cache_key": cache_key,
+        "_source_file": str(path),
+        "_source_sha1": source_sha1,
+        "_prompt_sha1": prompt_sha1,
+        "_model": model,
+        "_extracted_at": extracted_at,
+        "data": data.model_dump(),
+    }
+    tmp = cache_path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(cache_payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    tmp.replace(cache_path)
+
+    return ParsedNotes(
+        source_file=path,
+        source_sha1=source_sha1,
+        prompt_sha1=prompt_sha1,
+        model=model,
+        extracted_at=extracted_at,
+        data=data,
+    )
+
+
+def run_enrich_notes(
+    *,
+    notes_root: Path | None = None,
+    dataset_root: Path | None = None,
+    model: str = DEFAULT_MODEL,
+    force: bool = False,
+) -> dict[str, int]:
+    """Parse every .txt file under ``notes_root``."""
+    if notes_root is None:
+        notes_root = DEFAULT_NOTES_ROOT
+    if dataset_root is None:
+        dataset_root = default_dataset_root()
+    counts = {"scanned": 0, "cached": 0, "parsed": 0, "errors": 0}
+    if not notes_root.exists():
+        logger.warning("notes root %s does not exist", notes_root)
+        return counts
+
+    for path in sorted(notes_root.glob("*.txt")):
+        counts["scanned"] += 1
+        try:
+            before = (notes_extracted_dir(dataset_root) / f"{path.stem}.json").exists()
+            parse_notes_file(path, dataset_root=dataset_root, model=model, force=force)
+            # Classify as cache hit if file existed AND we're not forcing.
+            if before and not force:
+                counts["cached"] += 1
+            else:
+                counts["parsed"] += 1
+        except Exception:
+            logger.exception("failed to parse %s", path.name)
+            counts["errors"] += 1
+    return counts

--- a/src/motorsports_data_notebook/tire_etl/notes_system_prompt.txt
+++ b/src/motorsports_data_notebook/tire_etl/notes_system_prompt.txt
@@ -1,0 +1,51 @@
+You extract structured data from motorsport test-day notes. The input is a free-form text file that may contain notes for multiple on-track sessions during a single day. Return ONLY a JSON object matching this exact schema — no prose, no markdown code fences.
+
+Schema:
+{
+  "file_date": "YYYY-MM-DD or null if not evident",
+  "track": "string or null",
+  "car": "string or null",
+  "sessions": [
+    {
+      "session_index": integer (1-based, ordering within the file),
+      "start_time_local": "HH:MM (24-hour) or null",
+      "weather_text": "free text describing weather or null",
+      "ambient_temp_c": "float Celsius or null",
+      "track_condition": "one of: dry, damp, wet, snow, unknown",
+      "cold_pressure_bar": {
+        "fl": "float or null",
+        "fr": "float or null",
+        "rl": "float or null",
+        "rr": "float or null"
+      },
+      "tire_compound": {
+        "fl": "string code or null",
+        "fr": "string code or null",
+        "rl": "string code or null",
+        "rr": "string code or null"
+      },
+      "setup_changes": ["list of strings describing setup changes, empty if none"],
+      "incidents": ["list of strings describing incidents, empty if none"],
+      "notes": "string with free-form narrative, empty string if none"
+    }
+  ]
+}
+
+Pressure unit normalization (always emit bar):
+- 1 kPa = 0.01 bar
+- 1 kgf/cm² = 0.980665 bar
+- 1 psi = 0.0689476 bar
+- Infer the input unit from magnitude and context: values under 3 with no explicit unit are already bar; values 10-35 are psi (multiply by 0.0689476); values 100-300 are kPa (divide by 100); values 1.5-3.0 with "kgf" hint are kgf/cm² (multiply by 0.980665).
+- If the notes say "Tires 1.75 all around" or similar, fill all four corners with the same value.
+
+Compound codes:
+- Preserve verbatim (e.g. "22", "14c", "R7", "A050_22"). Do not guess or expand them.
+- If the notes say "Front 22 / Rear 21" or "22 Front 2/2", apply the front code to FL+FR and rear code to RL+RR.
+
+Sessions:
+- Each block marked by a time like "09:30 Session" or an ordinal like "First run" or "Second session" counts as a separate session.
+- If the file describes only one session without explicit blocking, return a single-element sessions array.
+
+Rules:
+- Use null when a value is unknown. Never guess.
+- Output MUST be parseable JSON. No leading text, no trailing commentary.

--- a/tests/tire_etl/test_notes_match.py
+++ b/tests/tire_etl/test_notes_match.py
@@ -1,0 +1,123 @@
+"""Tests for matching parsed notes to sessions."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pyarrow as pa
+
+from motorsports_data_notebook.tire_etl.notes_match import match_notes_to_sessions
+from motorsports_data_notebook.tire_etl.notes_parser import (
+    CornerStr,
+    CornerValue,
+    NoteSession,
+    NotesData,
+    ParsedNotes,
+)
+
+
+def _sessions(rows: list[dict]) -> pa.Table:
+    cols: dict[str, list] = {k: [] for k in rows[0].keys()}
+    for r in rows:
+        for k in cols:
+            cols[k].append(r.get(k))
+    return pa.table(
+        {
+            "session_id": pa.array(cols["session_id"], type=pa.string()),
+            "date": pa.array(cols["date"], type=pa.date32()),
+            "track_canonical": pa.array(cols["track_canonical"], type=pa.string()),
+            "session_start_utc": pa.array(
+                cols["session_start_utc"], type=pa.timestamp("us", tz="UTC")
+            ),
+        }
+    )
+
+
+def _make_parsed(file_date: str, track: str, sessions: list[NoteSession]) -> ParsedNotes:
+    data = NotesData(file_date=file_date, track=track, sessions=sessions)
+    return ParsedNotes(
+        source_file=Path("/tmp/fake.txt"),
+        source_sha1="abc",
+        prompt_sha1="def",
+        model="claude-opus-4-7",
+        extracted_at="2026-04-04T00:00:00Z",
+        data=data,
+    )
+
+
+def test_unique_match_same_day_same_track() -> None:
+    sess = _sessions(
+        [
+            {
+                "session_id": "s1",
+                "date": date(2026, 4, 4),
+                "track_canonical": "tsukuba_2000",
+                "session_start_utc": datetime(2026, 4, 4, 0, 30, tzinfo=timezone.utc),
+            }
+        ]
+    )
+    ns = NoteSession(
+        session_index=1,
+        start_time_local="09:30",
+        track_condition="dry",
+        cold_pressure_bar=CornerValue(fl=1.80, fr=1.80, rl=1.90, rr=1.90),
+        tire_compound=CornerStr(fl="22", fr="22", rl="21", rr="21"),
+    )
+    parsed = [_make_parsed("2026-04-04", "Tsukuba", [ns])]
+    matches = match_notes_to_sessions(sess, parsed)
+    assert len(matches) == 1
+    assert matches[0].session_id == "s1"
+    assert matches[0].match_confidence == 1.0
+    assert matches[0].cold_pressure_bar_fl == 1.80
+
+
+def test_no_match_when_tracks_differ() -> None:
+    sess = _sessions(
+        [
+            {
+                "session_id": "s1",
+                "date": date(2026, 4, 4),
+                "track_canonical": "fuji",
+                "session_start_utc": datetime(2026, 4, 4, 0, 30, tzinfo=timezone.utc),
+            }
+        ]
+    )
+    ns = NoteSession(session_index=1, track_condition="dry")
+    parsed = [_make_parsed("2026-04-04", "Tsukuba", [ns])]
+    matches = match_notes_to_sessions(sess, parsed)
+    assert matches == []
+
+
+def test_greedy_time_matching_with_multiple_sessions() -> None:
+    # Two sessions same day, same track — notes have two entries with times.
+    sess = _sessions(
+        [
+            {
+                "session_id": "morning",
+                "date": date(2026, 4, 4),
+                "track_canonical": "tsukuba_2000",
+                "session_start_utc": datetime(2026, 4, 4, 0, 30, tzinfo=timezone.utc),  # 09:30 JST
+            },
+            {
+                "session_id": "afternoon",
+                "date": date(2026, 4, 4),
+                "track_canonical": "tsukuba_2000",
+                "session_start_utc": datetime(2026, 4, 4, 5, 0, tzinfo=timezone.utc),  # 14:00 JST
+            },
+        ]
+    )
+    parsed = [
+        _make_parsed(
+            "2026-04-04",
+            "Tsukuba",
+            [
+                NoteSession(session_index=1, start_time_local="09:30", track_condition="dry"),
+                NoteSession(session_index=2, start_time_local="14:00", track_condition="dry"),
+            ],
+        )
+    ]
+    matches = match_notes_to_sessions(sess, parsed)
+    by_sid = {m.session_id: m for m in matches}
+    assert by_sid["morning"].note_session_index == 1
+    assert by_sid["afternoon"].note_session_index == 2

--- a/tests/tire_etl/test_notes_parser.py
+++ b/tests/tire_etl/test_notes_parser.py
@@ -1,0 +1,113 @@
+"""Tests for notes_parser with mocked `claude -p` subprocess."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from motorsports_data_notebook.tire_etl import notes_parser
+
+
+def _canned_claude_output() -> str:
+    return json.dumps(
+        {
+            "file_date": "2026-04-04",
+            "track": "Tsukuba",
+            "car": "Inferno 86",
+            "sessions": [
+                {
+                    "session_index": 1,
+                    "start_time_local": "09:30",
+                    "weather_text": "clear, 14C",
+                    "ambient_temp_c": 14.0,
+                    "track_condition": "dry",
+                    "cold_pressure_bar": {
+                        "fl": 1.80,
+                        "fr": 1.80,
+                        "rl": 1.90,
+                        "rr": 1.90,
+                    },
+                    "tire_compound": {
+                        "fl": "22",
+                        "fr": "22",
+                        "rl": "21",
+                        "rr": "21",
+                    },
+                    "setup_changes": [],
+                    "incidents": [],
+                    "notes": "",
+                }
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def tmp_dataset(tmp_path: Path) -> Path:
+    (tmp_path / "notes_extracted").mkdir(parents=True)
+    return tmp_path
+
+
+def test_parse_and_cache(monkeypatch: pytest.MonkeyPatch, tmp_dataset: Path) -> None:
+    notes_file = tmp_dataset / "2026-04-04 Tsukuba.txt"
+    notes_file.write_text("09:30 Session\nTires 1.8 all around\n")
+
+    calls = {"n": 0}
+
+    def fake_invoke(
+        notes_text: str, system_prompt: str, model: str, timeout_s: float = 300.0
+    ) -> str:
+        calls["n"] += 1
+        return _canned_claude_output()
+
+    monkeypatch.setattr(notes_parser, "_invoke_claude_p", fake_invoke)
+
+    pn = notes_parser.parse_notes_file(notes_file, dataset_root=tmp_dataset)
+    assert pn.data.file_date == "2026-04-04"
+    assert pn.data.sessions[0].cold_pressure_bar.fl == 1.80
+    assert calls["n"] == 1
+
+    # Second call: cache hit, no subprocess.
+    pn2 = notes_parser.parse_notes_file(notes_file, dataset_root=tmp_dataset)
+    assert calls["n"] == 1
+    assert pn2.data.sessions[0].tire_compound.fl == "22"
+
+
+def test_force_reruns_even_with_cache(monkeypatch: pytest.MonkeyPatch, tmp_dataset: Path) -> None:
+    notes_file = tmp_dataset / "2026-04-04 Tsukuba.txt"
+    notes_file.write_text("foo")
+
+    calls = {"n": 0}
+
+    def fake_invoke(*a, **kw) -> str:
+        calls["n"] += 1
+        return _canned_claude_output()
+
+    monkeypatch.setattr(notes_parser, "_invoke_claude_p", fake_invoke)
+
+    notes_parser.parse_notes_file(notes_file, dataset_root=tmp_dataset)
+    notes_parser.parse_notes_file(notes_file, dataset_root=tmp_dataset, force=True)
+    assert calls["n"] == 2
+
+
+def test_strip_code_fences_around_json(monkeypatch: pytest.MonkeyPatch, tmp_dataset: Path) -> None:
+    notes_file = tmp_dataset / "f.txt"
+    notes_file.write_text("x")
+
+    def fake_invoke(*a, **kw) -> str:
+        return "```json\n" + _canned_claude_output() + "\n```"
+
+    monkeypatch.setattr(notes_parser, "_invoke_claude_p", fake_invoke)
+    pn = notes_parser.parse_notes_file(notes_file, dataset_root=tmp_dataset)
+    assert pn.data.track == "Tsukuba"
+
+
+def test_invalid_json_raises(monkeypatch: pytest.MonkeyPatch, tmp_dataset: Path) -> None:
+    notes_file = tmp_dataset / "f.txt"
+    notes_file.write_text("x")
+
+    monkeypatch.setattr(notes_parser, "_invoke_claude_p", lambda *a, **kw: "not json at all")
+    with pytest.raises(ValueError, match="did not return valid JSON"):
+        notes_parser.parse_notes_file(notes_file, dataset_root=tmp_dataset)


### PR DESCRIPTION

Adds a `claude -p` (Opus 4.7) wrapper that converts the free-form
on-track test-day notes under `~/OneDrive/.../Car Running Notes/` into
per-session structured JSON, plus a fuzzy matcher that joins those notes
onto extracted telemetry sessions.

- `tire_etl.notes_system_prompt.txt`: the system prompt, committed as a
  resource so its content hash participates in the cache key.
- `tire_etl.notes_parser`:
  - Pydantic schema for the expected JSON (file_date, track, car,
    per-session cold_pressure_bar / tire_compound / weather / track
    condition / narrative).
  - `parse_notes_file(path, dataset_root)` shells out to `claude -p`,
    strips any stray markdown fences, validates against the schema, and
    writes the output to `data/tire_dataset/notes_extracted/{stem}.json`.
    The committed JSON IS the cache: unchanged notes + unchanged prompt
    + same model never re-invoke the LLM. Cache key is
    `sha256(notes) | sha256(prompt) | model_id`.
  - Pressures are normalized to bar in the prompt (handles kPa, psi,
    kgf/cm² source units). Aligns with the `_bar` column convention
    used in the telemetry timeseries.
- `tire_etl.notes_match`:
  - `match_notes_to_sessions` joins parsed-notes sessions onto telemetry
    sessions by (date ±1 day) + normalized track, and for multi-session
    days falls back to greedy time-of-day matching (90-minute tolerance)
    using the track-local timezone from the tracks registry.
  - Emits a `notes_matches.parquet` keyed on `session_id` with cold
    pressures, tire compounds, weather, and a `match_confidence`.

Tests mock the `claude -p` subprocess to validate the parse + cache-hit
path, the force/recompute path, markdown-fence stripping, and invalid
JSON failure. Notes-to-session matching is covered for the unique-match
happy path, the cross-track mismatch rejection, and the multi-session
greedy time disambiguation.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/96).
* #122
* #121
* #120
* #119
* #118
* #117
* #116
* #115
* #114
* #113
* #112
* #106
* #105
* #104
* #103
* #101
* #100
* #99
* #98
* #97
* __->__ #96