### PR TITLE
tire-etl: use AIM Log Date / Log Time for session timestamp

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,6 +39,25 @@ run:
 
 run-clean: clean run
 
+# Tire ETL pipeline — extract per-sample telemetry into data/tire_dataset/
+tire-etl *ARGS:
+    uv run python -m motorsports_data_notebook.tire_etl.cli extract {{ARGS}}
+
+# Parse run-notes into structured JSON via `claude -p`
+tire-notes *ARGS:
+    uv run python -m motorsports_data_notebook.tire_etl.cli enrich-notes {{ARGS}}
+
+# Fetch historical weather for sessions
+tire-weather *ARGS:
+    uv run python -m motorsports_data_notebook.tire_etl.cli enrich-weather {{ARGS}}
+
+# Ad-hoc SQL query over the dataset via DuckDB
+tire-query SQL:
+    uv run python -m motorsports_data_notebook.tire_etl.cli query "{{SQL}}"
+
+# Run all three phases in order (full refresh)
+tire-refresh: tire-etl tire-notes tire-weather
+
 # Emscripten SDK setup (one-time, needed for building libxrk Pyodide wheel)
 setup-emsdk:
     #!/usr/bin/env bash

--- a/scripts/tire_etl.py
+++ b/scripts/tire_etl.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Thin wrapper around motorsports_data_notebook.tire_etl.cli for scripting."""
+
+from __future__ import annotations
+
+import sys
+
+from motorsports_data_notebook.tire_etl.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/motorsports_data_notebook/tire_etl/__init__.py
+++ b/src/motorsports_data_notebook/tire_etl/__init__.py
@@ -7,6 +7,7 @@ Public API
 ----------
 - :func:`run_extract` — walk the AIM data tree and extract new sessions
 - :func:`run_enrich_notes` — parse run-note .txt files via ``claude -p``
+- :func:`run_enrich_weather` — fetch Open-Meteo historical weather
 - :data:`EXTRACTOR_VERSION` — bumped to force re-extraction of all sessions
 """
 
@@ -16,10 +17,12 @@ EXTRACTOR_VERSION = "0.2.0"
 
 from .extract import extract_session, run_extract  # noqa: E402
 from .notes_parser import run_enrich_notes  # noqa: E402
+from .weather import run_enrich_weather  # noqa: E402
 
 __all__ = [
     "EXTRACTOR_VERSION",
     "extract_session",
     "run_extract",
     "run_enrich_notes",
+    "run_enrich_weather",
 ]

--- a/src/motorsports_data_notebook/tire_etl/__init__.py
+++ b/src/motorsports_data_notebook/tire_etl/__init__.py
@@ -13,7 +13,7 @@ Public API
 
 from __future__ import annotations
 
-EXTRACTOR_VERSION = "0.2.0"
+EXTRACTOR_VERSION = "0.3.0"
 
 from .extract import extract_session, run_extract  # noqa: E402
 from .notes_parser import run_enrich_notes  # noqa: E402

--- a/src/motorsports_data_notebook/tire_etl/cli.py
+++ b/src/motorsports_data_notebook/tire_etl/cli.py
@@ -1,0 +1,181 @@
+"""Command-line entry points for the tire ETL pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date as _date
+from pathlib import Path
+
+from .paths import (
+    DEFAULT_AIM_ROOT,
+    DEFAULT_NOTES_ROOT,
+    default_dataset_root,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_since(s: str | None) -> _date | None:
+    if not s:
+        return None
+    return _date.fromisoformat(s)
+
+
+def _common_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--aim-root", type=Path, default=DEFAULT_AIM_ROOT)
+    p.add_argument("--notes-root", type=Path, default=DEFAULT_NOTES_ROOT)
+    p.add_argument("--dataset-root", type=Path, default=default_dataset_root())
+
+
+def _cmd_extract(args: argparse.Namespace) -> int:
+    from .extract import run_extract
+
+    counts = run_extract(
+        aim_root=args.aim_root,
+        dataset_root=args.dataset_root,
+        since=_parse_since(args.since),
+        only_car=args.only_car,
+        force=args.force,
+        retry_errors=args.retry_errors,
+    )
+    print(
+        f"extract: scanned={counts['scanned']} skipped={counts['skipped']}"
+        f" extracted={counts['extracted']} errors={counts['errors']}"
+    )
+    return 0 if counts["errors"] == 0 else 1
+
+
+def _cmd_enrich_notes(args: argparse.Namespace) -> int:
+    from .notes_parser import DEFAULT_MODEL, run_enrich_notes
+
+    counts = run_enrich_notes(
+        notes_root=args.notes_root,
+        dataset_root=args.dataset_root,
+        model=args.model,
+        force=args.force,
+    )
+    print(
+        f"notes: scanned={counts['scanned']} cached={counts['cached']}"
+        f" parsed={counts['parsed']} errors={counts['errors']} model={args.model or DEFAULT_MODEL}"
+    )
+    return 0 if counts["errors"] == 0 else 1
+
+
+def _cmd_enrich_weather(args: argparse.Namespace) -> int:
+    from .weather import run_enrich_weather
+
+    counts = run_enrich_weather(dataset_root=args.dataset_root)
+    print(f"weather: tracks={counts['tracks']} dates={counts['dates']}")
+    return 0
+
+
+def _cmd_match_notes(args: argparse.Namespace) -> int:
+    """Match parsed notes to sessions and write notes_matches.parquet."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from .notes_match import match_notes_to_sessions, write_matches
+    from .notes_parser import ParsedNotes, NotesData
+    from .paths import notes_extracted_dir, sessions_dir
+    import json
+    from datetime import datetime as _dt
+
+    sess_root = sessions_dir(args.dataset_root)
+    if not sess_root.exists():
+        print("no sessions partitions found", file=sys.stderr)
+        return 1
+    tables = [pq.read_table(p) for p in sorted(sess_root.glob("*.parquet"))]
+    if not tables:
+        print("no sessions found", file=sys.stderr)
+        return 1
+    sessions = pa.concat_tables(tables, promote_options="default")
+
+    parsed: list[ParsedNotes] = []
+    nex = notes_extracted_dir(args.dataset_root)
+    for p in sorted(nex.glob("*.json")):
+        try:
+            payload = json.loads(p.read_text(encoding="utf-8"))
+            data = NotesData.model_validate(payload["data"])
+            parsed.append(
+                ParsedNotes(
+                    source_file=Path(payload.get("_source_file", str(p))),
+                    source_sha1=payload.get("_source_sha1", ""),
+                    prompt_sha1=payload.get("_prompt_sha1", ""),
+                    model=payload.get("_model", ""),
+                    extracted_at=payload.get("_extracted_at", ""),
+                    data=data,
+                )
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("skipping malformed %s: %s", p, e)
+
+    matches = match_notes_to_sessions(sessions, parsed)
+    write_matches(args.dataset_root, matches)
+    print(f"match-notes: sessions={len(sessions)} notes={len(parsed)} matches={len(matches)}")
+    return 0
+
+
+def _cmd_query(args: argparse.Namespace) -> int:
+    import duckdb
+
+    # Register session/laps/timeseries as DuckDB views.
+    con = duckdb.connect(":memory:")
+    root = args.dataset_root
+    con.execute(f"CREATE VIEW sessions AS SELECT * FROM read_parquet('{root}/sessions/*.parquet')")
+    con.execute(f"CREATE VIEW laps AS SELECT * FROM read_parquet('{root}/laps/*.parquet')")
+    con.execute(
+        f"CREATE VIEW timeseries AS SELECT * FROM read_parquet('{root}/timeseries/*/*.parquet')"
+    )
+    result = con.execute(args.sql).fetch_arrow_table()
+    print(result.to_pandas().to_string(index=False))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="tire_etl")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("extract", help="Extract AIM sessions into the dataset")
+    _common_args(p)
+    p.add_argument("--since", help="YYYY-MM-DD: only sessions on/after this date")
+    p.add_argument("--only-car", help="Only process files whose car field matches this string")
+    p.add_argument("--force", action="store_true", help="Re-extract even if manifest matches")
+    p.add_argument(
+        "--retry-errors",
+        action="store_true",
+        help="Re-try sessions previously recorded as errors",
+    )
+    p.set_defaults(func=_cmd_extract)
+
+    p = sub.add_parser("enrich-notes", help="Parse run notes via `claude -p`")
+    _common_args(p)
+    p.add_argument("--model", default="claude-opus-4-7", help="Claude model to use")
+    p.add_argument("--force", action="store_true", help="Ignore cached JSON and re-run")
+    p.set_defaults(func=_cmd_enrich_notes)
+
+    p = sub.add_parser("enrich-weather", help="Fetch Open-Meteo historical weather")
+    _common_args(p)
+    p.set_defaults(func=_cmd_enrich_weather)
+
+    p = sub.add_parser("match-notes", help="Match parsed notes to sessions")
+    _common_args(p)
+    p.set_defaults(func=_cmd_match_notes)
+
+    p = sub.add_parser("query", help="Run a DuckDB SQL query over the dataset")
+    _common_args(p)
+    p.add_argument("sql", help="SQL query")
+    p.set_defaults(func=_cmd_query)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/motorsports_data_notebook/tire_etl/extract.py
+++ b/src/motorsports_data_notebook/tire_etl/extract.py
@@ -85,13 +85,35 @@ def _extract_session_datetime_utc(
     from .tracks import get_track
 
     meta = getattr(log, "metadata", {}) or {}
+
+    # AIM RaceStudio splits the start timestamp into two fields:
+    #   "Log Date": "MM/DD/YYYY" (US format, confirmed empirically)
+    #   "Log Time": "HH:MM:SS"   (track-local, 24-hour)
+    # Combine and parse in the track's local tz.
+    log_date = meta.get("Log Date")
+    log_time = meta.get("Log Time")
+    if log_date and log_time:
+        try:
+            dt_local = datetime.strptime(f"{log_date} {log_time}", "%m/%d/%Y %H:%M:%S")
+            tz_name = None
+            if track_canonical:
+                ti = get_track(track_canonical)
+                if ti:
+                    tz_name = ti.timezone
+            if tz_name:
+                from zoneinfo import ZoneInfo
+
+                return dt_local.replace(tzinfo=ZoneInfo(tz_name)).astimezone(timezone.utc)
+            return dt_local.replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+
+    # Legacy / alternate metadata spellings we've seen on other loggers.
     raw = None
     for key in ("Session date", "session date", "Date", "date", "Start time", "start_time"):
         if key in meta and meta[key]:
             raw = str(meta[key])
             break
-
-    # Try several common AIM formats: "YYYY-MM-DD HH:MM:SS", ISO, etc.
     if raw:
         for fmt in (
             "%Y-%m-%d %H:%M:%S",

--- a/src/motorsports_data_notebook/tire_etl/notes_match.py
+++ b/src/motorsports_data_notebook/tire_etl/notes_match.py
@@ -7,14 +7,49 @@ sessions for one telemetry session) receive a lower ``match_confidence``.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
-from datetime import date as _date, datetime, timedelta, timezone
+from datetime import date as _date, datetime, timezone
 from pathlib import Path
 
 import pyarrow as pa
 
 from .notes_parser import NoteSession, ParsedNotes
-from .tracks import get_track, normalize_track_name
+from .tracks import get_track, known_canonicals, normalize_track_name
+
+_FILENAME_DATE_RE = re.compile(r"(?P<y>\d{4})-(?P<m>\d{1,2})-(?P<d>\d{1,2})")
+
+
+def infer_date_track_from_filename(path: Path) -> tuple[_date | None, str | None]:
+    """Best-effort recovery of (date, track_canonical) from a notes filename.
+
+    The LLM can't always find a date in the body of a notes file when it's
+    only present in the filename (e.g. ``2026-04-04 Tsukuba.txt``). This
+    helper fills that gap so matching still works.
+    """
+    stem = path.stem
+    d: _date | None = None
+    m = _FILENAME_DATE_RE.search(stem)
+    if m:
+        try:
+            d = _date(int(m.group("y")), int(m.group("m")), int(m.group("d")))
+        except ValueError:
+            d = None
+    lower = stem.lower()
+    track: str | None = None
+    for canonical in known_canonicals():
+        # Strip the suffix ("_2000" etc.) and match the leading token.
+        head = canonical.split("_")[0]
+        if head in lower:
+            track = canonical
+            break
+    # Alias check (e.g. "kksii" doesn't map to a track token directly).
+    if track is None:
+        for tok in ("tsukuba", "sodegaura", "fuji", "motegi", "marutai"):
+            if tok in lower:
+                track = normalize_track_name(tok)
+                break
+    return d, track
 
 
 @dataclass(frozen=True)
@@ -75,13 +110,19 @@ def match_notes_to_sessions(
     note_entries: list[tuple[_date, str | None, ParsedNotes, NoteSession]] = []
     for pn in parsed_notes:
         file_date = pn.data.file_date
-        # Fall back to filename date embedded by the source (not available here);
-        # we rely on file_date being filled by the LLM.
         try:
             d = datetime.strptime(file_date, "%Y-%m-%d").date() if file_date else None
         except ValueError:
             d = None
         note_track_can = normalize_track_name(pn.data.track or "")
+        # Fall back to the notes filename for date/track when the LLM didn't
+        # extract them from the body.
+        if d is None or note_track_can is None:
+            fb_date, fb_track = infer_date_track_from_filename(pn.source_file)
+            if d is None:
+                d = fb_date
+            if note_track_can is None:
+                note_track_can = fb_track
         if d is None:
             continue
         for ns in pn.data.sessions:

--- a/src/motorsports_data_notebook/tire_etl/weather.py
+++ b/src/motorsports_data_notebook/tire_etl/weather.py
@@ -1,0 +1,201 @@
+"""Open-Meteo Historical Weather Archive client with per-(track, year) cache.
+
+Free API, no key required:
+  https://archive-api.open-meteo.com/v1/archive
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date as _date
+from pathlib import Path
+
+import httpx
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+
+from .paths import default_dataset_root, weather_dir
+from .tracks import get_track, known_canonicals
+
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://archive-api.open-meteo.com/v1/archive"
+_HOURLY_VARS = [
+    "temperature_2m",
+    "relative_humidity_2m",
+    "surface_pressure",
+    "wind_speed_10m",
+    "wind_direction_10m",
+    "precipitation",
+    "cloud_cover",
+]
+
+
+@dataclass(frozen=True)
+class WeatherRange:
+    track_canonical: str
+    start: _date
+    end: _date
+
+
+def _fetch_open_meteo(lat: float, lon: float, start: _date, end: _date) -> dict:
+    params = {
+        "latitude": f"{lat:.4f}",
+        "longitude": f"{lon:.4f}",
+        "start_date": start.isoformat(),
+        "end_date": end.isoformat(),
+        "hourly": ",".join(_HOURLY_VARS),
+        "timezone": "UTC",
+    }
+    resp = httpx.get(_API_URL, params=params, timeout=60.0)
+    resp.raise_for_status()
+    payload = resp.json()
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _parse_response_to_table(payload: dict) -> pa.Table:
+    hourly = payload.get("hourly", {})
+    times = hourly.get("time", [])
+    rows: dict[str, list] = {"ts_utc": times}
+    for var in _HOURLY_VARS:
+        rows[var] = hourly.get(var, [None] * len(times))
+    return pa.table(
+        {
+            "ts_utc": pa.array(rows["ts_utc"], type=pa.string()),
+            "temperature_2m": pa.array(rows["temperature_2m"], type=pa.float32()),
+            "relative_humidity_2m": pa.array(rows["relative_humidity_2m"], type=pa.float32()),
+            "surface_pressure": pa.array(rows["surface_pressure"], type=pa.float32()),
+            "wind_speed_10m": pa.array(rows["wind_speed_10m"], type=pa.float32()),
+            "wind_direction_10m": pa.array(rows["wind_direction_10m"], type=pa.float32()),
+            "precipitation": pa.array(rows["precipitation"], type=pa.float32()),
+            "cloud_cover": pa.array(rows["cloud_cover"], type=pa.float32()),
+        }
+    )
+
+
+def _cache_path(dataset_root: Path, track_canonical: str, year: int) -> Path:
+    return weather_dir(dataset_root) / track_canonical / f"{year}.parquet"
+
+
+def _load_cache(path: Path) -> pa.Table | None:
+    if not path.exists():
+        return None
+    return pq.read_table(path)
+
+
+def _dates_already_covered(table: pa.Table | None) -> set[str]:
+    if table is None or len(table) == 0:
+        return set()
+    ts = table.column("ts_utc").to_pylist()
+    return {t[:10] for t in ts}  # "2026-04-18T00:00"[:10] -> "2026-04-18"
+
+
+def _merge_and_write(path: Path, existing: pa.Table | None, new: pa.Table) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if existing is None or len(existing) == 0:
+        combined = new
+    else:
+        existing_ts = set(existing.column("ts_utc").to_pylist())
+        new_ts_list = new.column("ts_utc").to_pylist()
+        keep_mask = [t not in existing_ts for t in new_ts_list]
+        filtered_new = new.filter(pa.array(keep_mask))
+        combined = pa.concat_tables([existing, filtered_new], promote_options="default")
+    indices = pc.sort_indices(combined, sort_keys=[("ts_utc", "ascending")])
+    combined = combined.take(indices)
+    tmp = path.with_suffix(".parquet.tmp")
+    pq.write_table(combined, tmp, compression="zstd", compression_level=3)
+    tmp.replace(path)
+
+
+def fetch_for_track(
+    track_canonical: str,
+    dates: list[_date],
+    *,
+    dataset_root: Path | None = None,
+) -> None:
+    """Fetch + cache weather for the union of ``dates`` for one track."""
+    if dataset_root is None:
+        dataset_root = default_dataset_root()
+    if not dates:
+        return
+    ti = get_track(track_canonical)
+    if ti is None:
+        logger.warning("unknown track %s — skipping weather fetch", track_canonical)
+        return
+
+    # Group dates by year so we write one partition at a time.
+    by_year: dict[int, list[_date]] = {}
+    for d in dates:
+        by_year.setdefault(d.year, []).append(d)
+
+    for year, ds in by_year.items():
+        path = _cache_path(dataset_root, track_canonical, year)
+        existing = _load_cache(path)
+        covered = _dates_already_covered(existing)
+        missing = sorted({d for d in ds if d.isoformat() not in covered})
+        if not missing:
+            continue
+        # Fetch a single contiguous range spanning missing dates; the API is
+        # cheap and this minimizes request count.
+        try:
+            payload = _fetch_open_meteo(ti.lat, ti.lon, missing[0], missing[-1])
+        except httpx.HTTPError as e:
+            logger.warning(
+                "Open-Meteo fetch failed for %s %s..%s: %s",
+                track_canonical,
+                missing[0],
+                missing[-1],
+                e,
+            )
+            continue
+        new_tbl = _parse_response_to_table(payload)
+        _merge_and_write(path, existing, new_tbl)
+        logger.info(
+            "weather: %s %s..%s -> %d rows", track_canonical, missing[0], missing[-1], len(new_tbl)
+        )
+
+
+def run_enrich_weather(
+    sessions: pa.Table | None = None,
+    *,
+    dataset_root: Path | None = None,
+) -> dict[str, int]:
+    """Fetch weather for every (track_canonical, date) in ``sessions``.
+
+    If ``sessions`` is None, reads sessions from the dataset parquet partitions.
+    """
+    from .paths import sessions_dir
+
+    if dataset_root is None:
+        dataset_root = default_dataset_root()
+    if sessions is None:
+        sess_root = sessions_dir(dataset_root)
+        if not sess_root.exists():
+            return {"tracks": 0, "dates": 0}
+        tables = []
+        for p in sorted(sess_root.glob("*.parquet")):
+            tables.append(pq.read_table(p))
+        if not tables:
+            return {"tracks": 0, "dates": 0}
+        sessions = pa.concat_tables(tables, promote_options="default")
+
+    n_tracks = 0
+    n_dates = 0
+    seen: dict[str, set[_date]] = {}
+    for track_can, d in zip(
+        sessions.column("track_canonical").to_pylist(),
+        sessions.column("date").to_pylist(),
+    ):
+        if track_can is None or d is None:
+            continue
+        if track_can not in known_canonicals():
+            continue
+        seen.setdefault(track_can, set()).add(d)
+    for track_canonical, dates in seen.items():
+        fetch_for_track(track_canonical, sorted(dates), dataset_root=dataset_root)
+        n_tracks += 1
+        n_dates += len(dates)
+    return {"tracks": n_tracks, "dates": n_dates}

--- a/tests/tire_etl/test_cli.py
+++ b/tests/tire_etl/test_cli.py
@@ -1,0 +1,76 @@
+"""Tests for the tire_etl CLI argument parser."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from motorsports_data_notebook.tire_etl.cli import _parse_since, build_parser
+
+
+def test_build_parser_lists_all_subcommands() -> None:
+    parser = build_parser()
+    # argparse exposes subparsers via the internal `_SubParsersAction`
+    # choices map.
+    subactions = [
+        action for action in parser._actions if hasattr(action, "choices") and action.choices
+    ]
+    assert subactions, "expected at least one subparsers action"
+    sub = subactions[0]
+    assert set(sub.choices.keys()) >= {
+        "extract",
+        "enrich-notes",
+        "enrich-weather",
+        "match-notes",
+        "query",
+    }
+
+
+def test_extract_subcommand_accepts_common_flags() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "extract",
+            "--aim-root",
+            "/tmp/aim",
+            "--dataset-root",
+            "/tmp/dataset",
+            "--since",
+            "2026-04-01",
+            "--only-car",
+            "Inferno 86",
+            "--force",
+            "--retry-errors",
+        ]
+    )
+    assert args.cmd == "extract"
+    assert args.since == "2026-04-01"
+    assert args.only_car == "Inferno 86"
+    assert args.force is True
+    assert args.retry_errors is True
+
+
+def test_enrich_notes_subcommand_has_model_default() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["enrich-notes"])
+    assert args.cmd == "enrich-notes"
+    assert args.model == "claude-opus-4-7"
+    assert args.force is False
+
+
+def test_query_subcommand_requires_sql_positional() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["query", "SELECT 1"])
+    assert args.cmd == "query"
+    assert args.sql == "SELECT 1"
+    with pytest.raises(SystemExit):
+        parser.parse_args(["query"])  # missing positional
+
+
+def test_parse_since_returns_date_or_none() -> None:
+    assert _parse_since(None) is None
+    assert _parse_since("") is None
+    assert _parse_since("2026-04-01") == date(2026, 4, 1)
+    with pytest.raises(ValueError):
+        _parse_since("not-a-date")

--- a/tests/tire_etl/test_extract.py
+++ b/tests/tire_etl/test_extract.py
@@ -11,7 +11,17 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from motorsports_data_notebook.tire_etl.extract import _rename_to_canonical
+from datetime import datetime, timezone
+
+from motorsports_data_notebook.tire_etl.extract import (
+    _extract_session_datetime_utc,
+    _rename_to_canonical,
+)
+
+
+class _FakeLog:
+    def __init__(self, metadata: dict) -> None:
+        self.metadata = metadata
 
 
 def test_rename_converts_aim_names_to_canonical() -> None:
@@ -86,3 +96,29 @@ def test_rename_noop_when_profile_has_no_matches() -> None:
     ts = pa.table({"something_else": pa.array([1.0, 2.0])})
     out = _rename_to_canonical(ts, profile_names=profile)
     assert out.schema.names == ["something_else"]
+
+
+def test_session_time_from_aim_log_date_and_log_time() -> None:
+    """AIM's `Log Date` (MM/DD/YYYY) + `Log Time` must be parsed and converted
+    from track-local tz to UTC. Real AIM fleet data uses these keys; the old
+    fallback (midnight local) was dropping within-day resolution and causing
+    weather joins to land on the wrong hour (e.g. missing rain)."""
+    log = _FakeLog({"Log Date": "04/04/2026", "Log Time": "12:57:49"})
+    dt = _extract_session_datetime_utc(log, "2026-04-04", "tsukuba_2000")
+    # 12:57:49 JST = 03:57:49 UTC
+    assert dt == datetime(2026, 4, 4, 3, 57, 49, tzinfo=timezone.utc)
+
+
+def test_session_time_from_aim_log_date_unambiguous_month_day() -> None:
+    """MM/DD vs DD/MM was resolved empirically against a 04/17 file — 04/17 is
+    only valid as MM/DD, so we must parse that format."""
+    log = _FakeLog({"Log Date": "04/17/2026", "Log Time": "12:23:55"})
+    dt = _extract_session_datetime_utc(log, "2026-04-17", "tsukuba_2000")
+    assert dt == datetime(2026, 4, 17, 3, 23, 55, tzinfo=timezone.utc)
+
+
+def test_session_time_falls_back_to_midnight_local_when_metadata_missing() -> None:
+    log = _FakeLog({})
+    dt = _extract_session_datetime_utc(log, "2026-04-04", "tsukuba_2000")
+    # Midnight JST = 15:00 UTC previous day
+    assert dt == datetime(2026, 4, 3, 15, 0, 0, tzinfo=timezone.utc)

--- a/tests/tire_etl/test_notes_match.py
+++ b/tests/tire_etl/test_notes_match.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 import pyarrow as pa
 
-from motorsports_data_notebook.tire_etl.notes_match import match_notes_to_sessions
+from motorsports_data_notebook.tire_etl.notes_match import (
+    infer_date_track_from_filename,
+    match_notes_to_sessions,
+)
 from motorsports_data_notebook.tire_etl.notes_parser import (
     CornerStr,
     CornerValue,
@@ -87,6 +90,51 @@ def test_no_match_when_tracks_differ() -> None:
     parsed = [_make_parsed("2026-04-04", "Tsukuba", [ns])]
     matches = match_notes_to_sessions(sess, parsed)
     assert matches == []
+
+
+def test_infer_date_track_from_filename_standard() -> None:
+    d, t = infer_date_track_from_filename(Path("/tmp/2026-04-04 Tsukuba.txt"))
+    assert d == date(2026, 4, 4)
+    assert t == "tsukuba_2000"
+
+
+def test_infer_date_track_from_filename_with_car_token() -> None:
+    d, t = infer_date_track_from_filename(Path("/tmp/Tsukuba KKSII 2026-04-04.txt"))
+    assert d == date(2026, 4, 4)
+    assert t == "tsukuba_2000"
+
+
+def test_infer_date_track_from_filename_no_match() -> None:
+    d, t = infer_date_track_from_filename(Path("/tmp/random_notes.txt"))
+    assert d is None
+    assert t is None
+
+
+def test_filename_fallback_enables_match_when_body_has_null_metadata() -> None:
+    sess = _sessions(
+        [
+            {
+                "session_id": "s1",
+                "date": date(2026, 4, 4),
+                "track_canonical": "tsukuba_2000",
+                "session_start_utc": datetime(2026, 4, 4, 0, 30, tzinfo=timezone.utc),
+            }
+        ]
+    )
+    ns = NoteSession(session_index=1, track_condition="dry")
+    # Notes data has null file_date / track — forces fallback to filename.
+    data = NotesData(file_date=None, track=None, sessions=[ns])
+    pn = ParsedNotes(
+        source_file=Path("/tmp/Tsukuba KKSII 2026-04-04.txt"),
+        source_sha1="abc",
+        prompt_sha1="def",
+        model="claude-opus-4-7",
+        extracted_at="2026-04-04T00:00:00Z",
+        data=data,
+    )
+    matches = match_notes_to_sessions(sess, [pn])
+    assert len(matches) == 1
+    assert matches[0].session_id == "s1"
 
 
 def test_greedy_time_matching_with_multiple_sessions() -> None:

--- a/tests/tire_etl/test_weather.py
+++ b/tests/tire_etl/test_weather.py
@@ -1,0 +1,61 @@
+"""Tests for Open-Meteo client + caching."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+import pyarrow.parquet as pq
+import respx
+
+from motorsports_data_notebook.tire_etl import weather
+
+
+def _canned_payload() -> dict:
+    return {
+        "hourly": {
+            "time": ["2026-04-04T00:00", "2026-04-04T01:00", "2026-04-04T02:00"],
+            "temperature_2m": [10.0, 11.0, 12.0],
+            "relative_humidity_2m": [60.0, 62.0, 65.0],
+            "surface_pressure": [1013.0, 1013.5, 1014.0],
+            "wind_speed_10m": [5.0, 6.0, 7.0],
+            "wind_direction_10m": [90.0, 95.0, 100.0],
+            "precipitation": [0.0, 0.0, 0.1],
+            "cloud_cover": [20.0, 30.0, 40.0],
+        }
+    }
+
+
+@respx.mock
+def test_fetch_for_track_writes_cache(tmp_path: Path) -> None:
+    route = respx.get(weather._API_URL).mock(
+        return_value=httpx.Response(200, json=_canned_payload())
+    )
+    weather.fetch_for_track("tsukuba_2000", [date(2026, 4, 4)], dataset_root=tmp_path)
+    assert route.call_count == 1
+
+    out = tmp_path / "weather_hourly" / "tsukuba_2000" / "2026.parquet"
+    assert out.exists()
+    tbl = pq.read_table(out)
+    assert len(tbl) == 3
+    assert set(tbl.schema.names) >= {"ts_utc", "temperature_2m", "precipitation"}
+
+
+@respx.mock
+def test_fetch_skips_already_covered_dates(tmp_path: Path) -> None:
+    route = respx.get(weather._API_URL).mock(
+        return_value=httpx.Response(200, json=_canned_payload())
+    )
+    weather.fetch_for_track("tsukuba_2000", [date(2026, 4, 4)], dataset_root=tmp_path)
+    weather.fetch_for_track("tsukuba_2000", [date(2026, 4, 4)], dataset_root=tmp_path)
+    # Second call should hit cache, not the API.
+    assert route.call_count == 1
+
+
+@respx.mock
+def test_unknown_track_skipped(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    respx.get(weather._API_URL).mock(return_value=httpx.Response(200, json=_canned_payload()))
+    weather.fetch_for_track("nonexistent", [date(2026, 4, 4)], dataset_root=tmp_path)
+    assert not (tmp_path / "weather_hourly" / "nonexistent").exists()


### PR DESCRIPTION

Real AIM RaceStudio files expose the GPS-synced logger RTC as two
metadata fields: `Log Date` (MM/DD/YYYY, US format, verified against a
04/17 sample) and `Log Time` (HH:MM:SS, 24-hour, track-local). The
previous extractor checked several other spellings (`Session date`,
`Date`, `Start time`, …) none of which AIM emits, so every session
fell through to a "midnight local" fallback. That produced identical
session_start_utc values for every session on the same day, and any
weather join using that timestamp landed on the wrong hour — on
2026-04-04 it picked 00:00 UTC (no rain in that bucket) when the real
session start was 12:57:49 JST = 03:57 UTC (rain active).

The libxrk API does not expose a separate GPS-UTC channel (timecodes
are millisecond offsets from session start only), so the logger RTC
from the metadata is the authoritative timestamp source.

- `extract._extract_session_datetime_utc` now combines `Log Date` +
  `Log Time` and converts track-local to UTC via `ZoneInfo`.
- Legacy / alternate spellings are kept as fallbacks for non-MXP
  loggers and iRacing IBT files.
- Bump `EXTRACTOR_VERSION` 0.2.0 -> 0.3.0 so already-extracted sessions
  get re-processed with correct timestamps on the next run.

Tests exercise:
- The canonical `Log Date` / `Log Time` path with tz conversion.
- The `04/17/2026` disambiguation (only valid as MM/DD).
- The fallback to midnight-local when metadata is empty.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/100).
* #122
* #121
* #120
* #119
* #118
* #117
* #116
* #115
* #114
* #113
* #112
* #106
* #105
* #104
* #103
* #101
* __->__ #100
* #99
* #98
* #97