### PR TITLE
Slim browser bundle from 32 MB to 14 MB

### DIFF
--- a/tire_pressure_calculator/Browser/TirePressureCalculator.Browser.csproj
+++ b/tire_pressure_calculator/Browser/TirePressureCalculator.Browser.csproj
@@ -14,9 +14,13 @@
     <!-- WASM threads need COOP/COEP response headers, which GitHub Pages can't set. -->
     <WasmEnableThreads>false</WasmEnableThreads>
 
-    <!-- Release publish: AOT cuts cold-start latency; skip for Debug to keep iteration fast. -->
-    <RunAOTCompilation Condition="'$(Configuration)' == 'Release'">true</RunAOTCompilation>
-    <WasmStripILAfterAOT Condition="'$(Configuration)' == 'Release'">true</WasmStripILAfterAOT>
+    <!-- AOT bloats the bundle by ~17 MB with no user-perceptible perf gain for a
+         UI-bound calculator that's idle 99% of the time; interpreter is fine. -->
+    <RunAOTCompilation>false</RunAOTCompilation>
+
+    <!-- Strip debug payloads from Release bundles. -->
+    <WasmEmitSymbolMap Condition="'$(Configuration)' == 'Release'">false</WasmEmitSymbolMap>
+    <DebuggerSupport Condition="'$(Configuration)' == 'Release'">false</DebuggerSupport>
 
     <!-- Overridden by CI for the preview build (subfolder deploy). -->
     <StaticWebAssetBasePath Condition="'$(StaticWebAssetBasePath)' == ''">/</StaticWebAssetBasePath>
@@ -33,5 +37,16 @@
   <ItemGroup>
     <WasmExtraFilesToDeploy Include="AppBundle\**" />
   </ItemGroup>
+
+  <!-- Source maps for JS files in the runtime are only useful for debugging the WASM
+       host itself; they ship as ~500 KB of dead weight in production. -->
+  <Target Name="StripJsSourceMapsFromAppBundle"
+          AfterTargets="WasmGenerateAppBundle"
+          Condition="'$(Configuration)' == 'Release'">
+    <ItemGroup>
+      <_TpcStripMaps Include="$(WasmAppDir)**\*.js.map" />
+    </ItemGroup>
+    <Delete Files="@(_TpcStripMaps)" />
+  </Target>
 
 </Project>


### PR DESCRIPTION

Three changes to the Browser csproj:

- Disable AOT compilation. AOT adds 17 MB of bundled native runtime,
  shaving microseconds off method dispatch in an app that spends 99% of
  its life waiting for the user to type a tire pressure. Interpreter
  mode is fine here and is a massive win on cellular cold-load.
- WasmEmitSymbolMap=false in Release: drops 1.8 MB of debug symbols
  no production user can read.
- DebuggerSupport=false in Release: ships only what's needed for the
  app to run, not for the dotnet host to be debuggable.

Also adds a post-bundle MSBuild target that strips the five .js.map
source maps for the dotnet runtime/host JS, another ~500 KB of payload
only useful for debugging Avalonia.Browser itself.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/108).
* #109
* __->__ #108