### PR TITLE
Persist tire pressure settings in browser localStorage

### DIFF
--- a/tire_pressure_calculator/Browser/LocalStorageSettingsStorage.cs
+++ b/tire_pressure_calculator/Browser/LocalStorageSettingsStorage.cs
@@ -1,0 +1,18 @@
+using System.Runtime.InteropServices.JavaScript;
+
+namespace TirePressureCalculator;
+
+internal sealed partial class LocalStorageSettingsStorage : ISettingsStorage
+{
+    private const string Key = "tire-pressure-calculator/settings";
+
+    public string? Read() => GetItem(Key);
+
+    public void Write(string contents) => SetItem(Key, contents);
+
+    [JSImport("globalThis.localStorage.getItem")]
+    private static partial string? GetItem(string key);
+
+    [JSImport("globalThis.localStorage.setItem")]
+    private static partial void SetItem(string key, string value);
+}

--- a/tire_pressure_calculator/Browser/Program.cs
+++ b/tire_pressure_calculator/Browser/Program.cs
@@ -5,8 +5,11 @@ namespace TirePressureCalculator;
 
 internal sealed class Program
 {
-    private static Task Main(string[] args) =>
-        BuildAvaloniaApp().StartBrowserAppAsync("out");
+    private static Task Main(string[] args)
+    {
+        AppSettings.Storage = new LocalStorageSettingsStorage();
+        return BuildAvaloniaApp().StartBrowserAppAsync("out");
+    }
 
     public static AppBuilder BuildAvaloniaApp() =>
         AppBuilder.Configure<App>();

--- a/tire_pressure_calculator/Browser/TirePressureCalculator.Browser.csproj
+++ b/tire_pressure_calculator/Browser/TirePressureCalculator.Browser.csproj
@@ -8,6 +8,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 
+    <!-- Required by [JSImport] code generator for marshalling shims. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
     <WasmMainJSPath>AppBundle\main.js</WasmMainJSPath>
     <InvariantGlobalization>true</InvariantGlobalization>
 

--- a/tire_pressure_calculator/Core/Settings.cs
+++ b/tire_pressure_calculator/Core/Settings.cs
@@ -10,6 +10,14 @@ public class CornerSettings
     public double TargetHotPressure { get; set; } = 1.80;
 }
 
+// Platform-pluggable persistence: Desktop/Android use the on-disk default,
+// the Browser head swaps in a localStorage-backed implementation.
+public interface ISettingsStorage
+{
+    string? Read();
+    void Write(string contents);
+}
+
 public class AppSettings
 {
     public CornerSettings FrontLeft { get; set; } = new();
@@ -18,19 +26,15 @@ public class AppSettings
     public CornerSettings RearRight { get; set; } = new();
     public double TempAdjustPercent { get; set; }
 
-    private static string FilePath =>
-        Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "TirePressureCalculator",
-            "settings.json");
+    public static ISettingsStorage Storage { get; set; } = new FileSettingsStorage();
 
     public static AppSettings Load()
     {
         try
         {
-            if (File.Exists(FilePath))
+            var json = Storage.Read();
+            if (!string.IsNullOrEmpty(json))
             {
-                var json = File.ReadAllText(FilePath);
                 return JsonSerializer.Deserialize(json, SettingsContext.Default.AppSettings) ?? new();
             }
         }
@@ -42,12 +46,28 @@ public class AppSettings
     {
         try
         {
-            var dir = Path.GetDirectoryName(FilePath)!;
-            Directory.CreateDirectory(dir);
             var json = JsonSerializer.Serialize(this, SettingsContext.Default.AppSettings);
-            File.WriteAllText(FilePath, json);
+            Storage.Write(json);
         }
         catch { }
+    }
+}
+
+public class FileSettingsStorage : ISettingsStorage
+{
+    private static string FilePath =>
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TirePressureCalculator",
+            "settings.json");
+
+    public string? Read() => File.Exists(FilePath) ? File.ReadAllText(FilePath) : null;
+
+    public void Write(string contents)
+    {
+        var dir = Path.GetDirectoryName(FilePath)!;
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(FilePath, contents);
     }
 }
 


### PR DESCRIPTION

Brings the browser build to feature parity with Desktop and Android,
which both persist user inputs across sessions via Settings.cs.

Refactors AppSettings.Load/Save to delegate to a pluggable
ISettingsStorage, with the existing file-based storage extracted as
FileSettingsStorage (the Core default, unchanged behavior for Desktop
and Android). The Browser head registers a LocalStorageSettingsStorage
backed by globalThis.localStorage via [JSImport].

JSImport requires AllowUnsafeBlocks for its marshalling shims; added
to the Browser csproj only.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/109).
* __->__ #109
* #108