### PR TITLE
Mobile input UX fixes for the browser build, bump to 0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motorsports-data-notebook"
-version = "0.14.0"
+version = "0.15.0"
 description = ""
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/tire_pressure_calculator/Browser/AppBundle/app.css
+++ b/tire_pressure_calculator/Browser/AppBundle/app.css
@@ -27,6 +27,14 @@ html, body {
   touch-action: none;
 }
 
+/* Avalonia's WASM uses a hidden HTML input for IME and virtual-keyboard
+   handling. iOS Safari auto-zooms on focus whenever an input is smaller
+   than 16px, so force the threshold and keep the keyboard from triggering
+   a stuck zoom. */
+input, textarea, [contenteditable] {
+  font-size: 16px !important;
+}
+
 #loading {
   position: absolute;
   inset: 0;

--- a/tire_pressure_calculator/Browser/AppBundle/index.html
+++ b/tire_pressure_calculator/Browser/AppBundle/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Inferno Tire Pressure Calculator</title>
 
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/tire_pressure_calculator/Browser/AppBundle/main.js
+++ b/tire_pressure_calculator/Browser/AppBundle/main.js
@@ -16,6 +16,25 @@ if (out && loading) {
     observer.observe(out, { childList: true, subtree: true });
 }
 
+// Avalonia uses a hidden HTML input for IME / virtual-keyboard handling.
+// Every value in this app is numeric, so hint a decimal keypad so phones
+// don't open a full QWERTY layout.
+const hintDecimalKeypad = (root) => {
+    if (!(root instanceof Element)) return;
+    if (root.matches?.("input, textarea") && !root.inputMode) {
+        root.inputMode = "decimal";
+    }
+    for (const el of root.querySelectorAll?.("input, textarea") ?? []) {
+        if (!el.inputMode) el.inputMode = "decimal";
+    }
+};
+const inputObserver = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+        for (const node of m.addedNodes) hintDecimalKeypad(node);
+    }
+});
+inputObserver.observe(document.body, { childList: true, subtree: true });
+
 const dotnetRuntime = await dotnet
     .withDiagnosticTracing(false)
     .withApplicationArgumentsFromQuery()

--- a/tire_pressure_calculator/Core/Views/MainView.axaml
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml
@@ -3,7 +3,8 @@
              xmlns:vm="using:TirePressureCalculator.ViewModels"
              xmlns:views="using:TirePressureCalculator.Views"
              x:Class="TirePressureCalculator.Views.MainView"
-             x:DataType="vm:MainViewModel">
+             x:DataType="vm:MainViewModel"
+             Background="Transparent">
 
   <UserControl.Resources>
     <DataTemplate x:Key="CornerTemplate" x:DataType="vm:TireCornerViewModel">

--- a/tire_pressure_calculator/Core/Views/MainView.axaml.cs
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml.cs
@@ -74,6 +74,7 @@ public partial class MainView : UserControl
         AddHandler(GotFocusEvent, OnChildGotFocus);
         AddHandler(LostFocusEvent, OnChildLostFocus);
         AddHandler(KeyDownEvent, OnChildKeyDown, RoutingStrategies.Bubble, handledEventsToo: true);
+        AddHandler(PointerPressedEvent, OnBackgroundPointerPressed, RoutingStrategies.Bubble, handledEventsToo: true);
     }
 
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -225,14 +226,35 @@ public partial class MainView : UserControl
         });
     }
 
+    private void OnBackgroundPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // Tap outside any text input dismisses focus, which chains into
+        // OnChildLostFocus and reverses the zoom/translate.
+        if (FindAncestorOfType<TextBox>(e.Source as Control) is null)
+        {
+            TopLevel.GetTopLevel(this)?.FocusManager?.ClearFocus();
+        }
+    }
+
     private void OnChildKeyDown(object? sender, KeyEventArgs e)
     {
-        // Enter on the soft keyboard should dismiss focus, which chains into
-        // OnChildLostFocus and reverses the zoom/scroll.
-        if (e.Key == Key.Enter || e.Key == Key.Return)
+        if (e.Key != Key.Enter && e.Key != Key.Return) return;
+
+        // Advance focus to the next field on Enter — what every form on every
+        // platform does. Falls back to dismissing focus (which chains into
+        // OnChildLostFocus and reverses zoom/translate) when there's no next.
+        var focused = TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement();
+        if (focused is InputElement el)
         {
-            Focus();
+            var next = KeyboardNavigationHandler.GetNext(el, NavigationDirection.Next);
+            if (next is not null && !ReferenceEquals(next, el))
+            {
+                next.Focus(NavigationMethod.Tab);
+                e.Handled = true;
+                return;
+            }
         }
+        TopLevel.GetTopLevel(this)?.FocusManager?.ClearFocus();
     }
 
     private ContentControl? FindQuadrant(Control? control)


### PR DESCRIPTION

Four mobile-input papercuts in the WASM build, all rooted in Avalonia's
hidden HTML input that backs IME / virtual-keyboard handling:

- iOS Safari auto-zoomed on focus because the hidden input was < 16px,
  and user-scalable=no prevented manual zoom-out. Forced the input to
  16px and dropped user-scalable so any stray zoom is recoverable.
- Phones showed a QWERTY keyboard instead of a decimal keypad because
  the input had no inputmode hint. A MutationObserver sets
  inputmode="decimal" on any input Avalonia inserts.
- Enter dismissed focus instead of advancing — universally wrong on web
  forms and inconsistent with how mobile users expect to move through
  fields. Now advances via KeyboardNavigationHandler.GetNext, falling
  back to dismiss only past the last field.
- Tapping outside an input didn't unzoom the focused quadrant because
  empty UserControl areas weren't hit-testable (Background=null) and
  Focus() returns false on a non-focusable UserControl. Set
  Background="Transparent" so taps register, and use
  FocusManager.ClearFocus() to actually drop focus.

Version bump to 0.15.0 in prep for a release that publishes the WASM
build to tires.inferno.racing.
