### PR TITLE
Make inferno-driving-coach and inferno-analyzer versions track the root pyproject.toml

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -21,7 +21,10 @@ jobs:
         working-directory: inferno-driving-coach
         run: |
           cp -r ../src/motorsports_data_notebook src/
-          uv build --out-dir dist
+          # --wheel only: dynamic version (via tool.setuptools.dynamic) reads the
+          # root pyproject.toml at build time, which isn't available inside the
+          # sdist-then-wheel temp dir. Direct wheel build sees the real source tree.
+          uv build --wheel --out-dir dist
           rm -rf src/motorsports_data_notebook
 
       - name: Upload artifact

--- a/desktop_app/pyproject.toml
+++ b/desktop_app/pyproject.toml
@@ -1,6 +1,9 @@
 [project]
 name = "inferno-analyzer"
-version = "0.1.0"
+# Version is read from the root pyproject.toml at build time via
+# tool.setuptools.dynamic below, so every release artifact ships at the
+# same version with no per-file bump.
+dynamic = ["version"]
 description = "Standalone desktop app for motorsports telemetry analysis (suspension + driver consistency)"
 authors = [
     {name = "Christopher Dewan", email = "chris.dewan@m3rlin.net"}
@@ -34,8 +37,14 @@ dev = [
 requires = ["setuptools>=75.0.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.dynamic]
+version = {attr = "_root_version.VERSION"}
+
 [tool.setuptools.packages.find]
 where = ["src"]
+# _root_version.py is a build-time helper; setuptools only needs it on
+# sys.path during version resolution, not in the published wheel.
+exclude = ["_root_version*"]
 
 [tool.uv.sources]
 motorsports-data-notebook = { workspace = true }

--- a/desktop_app/src/_root_version.py
+++ b/desktop_app/src/_root_version.py
@@ -1,0 +1,16 @@
+"""Build-time helper: exposes the project version from the root pyproject.toml.
+
+Setuptools resolves `tool.setuptools.dynamic.version = {attr = "_root_version.VERSION"}`
+by importing this module, which reads `../../pyproject.toml` so every release
+artifact ships at the same version with no per-file bump.
+
+This module is intentionally outside any package and is excluded from the wheel.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tomllib
+
+_ROOT_PYPROJECT = pathlib.Path(__file__).resolve().parents[2] / "pyproject.toml"
+VERSION: str = tomllib.loads(_ROOT_PYPROJECT.read_text())["project"]["version"]

--- a/inferno-driving-coach/pyproject.toml
+++ b/inferno-driving-coach/pyproject.toml
@@ -1,6 +1,9 @@
 [project]
 name = "inferno-driving-coach"
-version = "0.14.0"
+# Version is read from the root pyproject.toml at build time via
+# tool.setuptools.dynamic below, so every release artifact ships at the
+# same version with no per-file bump.
+dynamic = ["version"]
 description = "MCP server for motorsports telemetry coaching — session analysis, day reviews, and driving KPIs"
 authors = [
     {name = "Christopher Dewan", email = "chris.dewan@m3rlin.net"}
@@ -35,8 +38,14 @@ inferno-driving-coach = "inferno_driving_coach:main"
 requires = ["setuptools>=75.0.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.dynamic]
+version = {attr = "_root_version.VERSION"}
+
 [tool.setuptools.packages.find]
 where = ["src"]
+# _root_version.py is a build-time helper; setuptools only needs it on
+# sys.path during version resolution, not in the published wheel.
+exclude = ["_root_version*"]
 
 [tool.setuptools.package-data]
 inferno_driving_coach = ["data/*.md"]

--- a/inferno-driving-coach/src/_root_version.py
+++ b/inferno-driving-coach/src/_root_version.py
@@ -1,0 +1,16 @@
+"""Build-time helper: exposes the project version from the root pyproject.toml.
+
+Setuptools resolves `tool.setuptools.dynamic.version = {attr = "_root_version.VERSION"}`
+by importing this module, which reads `../../pyproject.toml` so every release
+artifact ships at the same version with no per-file bump.
+
+This module is intentionally outside any package and is excluded from the wheel.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tomllib
+
+_ROOT_PYPROJECT = pathlib.Path(__file__).resolve().parents[2] / "pyproject.toml"
+VERSION: str = tomllib.loads(_ROOT_PYPROJECT.read_text())["project"]["version"]


### PR DESCRIPTION

The MCP server publish failed on v0.15.0 because its pyproject.toml
still said 0.14.0 — that wheel name was already on PyPI from the v0.14.0
release, so the upload was rejected as a duplicate. desktop_app was the
same drift waiting to happen (frozen at 0.1.0 since project inception).

Both projects now use setuptools' dynamic version with `attr =
"_root_version.VERSION"`. The helper module reads the root
pyproject.toml at build time and surfaces VERSION; it's excluded from
the wheel so consumers don't import a runtime dependency on the source
tree. Same single-source-of-truth philosophy that Directory.Build.props
already uses for the .NET projects.

publish-mcp.yml switches `uv build` → `uv build --wheel` so the wheel
is built directly from the source tree (where the parent pyproject.toml
exists). Building the sdist intermediate would copy the project into a
temp dir without the parent file and fail to resolve the version; PyPI
only needs the wheel anyway, especially for a package that bundles
vendored source.

Effect: every release tags both `inferno-driving-coach` and
`inferno-analyzer` with the root version, no manual bump.
