### PR TITLE
tire-model: cold-pressure predictor + CLI + held-out validation

### DIFF
--- a/justfile
+++ b/justfile
@@ -58,6 +58,26 @@ tire-query SQL:
 # Run all three phases in order (full refresh)
 tire-refresh: tire-etl tire-notes tire-weather
 
+# Detect candidate broken TPMS sensors (low-variance channels) for human review
+tire-sensor-audit *ARGS:
+    uv run python -m motorsports_data_notebook.tire_model.cli audit-sensors {{ARGS}}
+
+# Fit the energy-balance tire warmup model from the committed dataset
+tire-build-warmup-table *ARGS:
+    uv run python -m motorsports_data_notebook.tire_model.cli build-warmup-table {{ARGS}}
+
+# Predict per-corner cold pressures (see `tire-predict --help`)
+tire-predict *ARGS:
+    uv run python -m motorsports_data_notebook.tire_model.cli predict {{ARGS}}
+
+# Per-corner MAE report vs. notes-recorded cold pressures (uses production model)
+tire-predict-validate *ARGS:
+    uv run python -m motorsports_data_notebook.tire_model.cli validate {{ARGS}}
+
+# Held-out validation: train without N sessions, predict per-lap T_hot, report residuals
+tire-predict-holdout *ARGS:
+    uv run python -m motorsports_data_notebook.tire_model.cli holdout {{ARGS}}
+
 # Emscripten SDK setup (one-time, needed for building libxrk Pyodide wheel)
 setup-emsdk:
     #!/usr/bin/env bash

--- a/scripts/tire_predict.py
+++ b/scripts/tire_predict.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Thin wrapper around motorsports_data_notebook.tire_model.cli for scripting."""
+
+from __future__ import annotations
+
+import sys
+
+from motorsports_data_notebook.tire_model.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/motorsports_data_notebook/tire_model/__init__.py
+++ b/src/motorsports_data_notebook/tire_model/__init__.py
@@ -12,11 +12,14 @@ from .energy_balance import (
     t_road_proxy_c,
     warmup_curve_c,
 )
+from .predict import Prediction, predict_cold_pressure
 from .warmup_table import build_warmup_table
 
 __all__ = [
+    "Prediction",
     "build_warmup_table",
     "gay_lussac_cold_pressure_bar",
+    "predict_cold_pressure",
     "t_effective_c",
     "t_road_proxy_c",
     "warmup_curve_c",

--- a/src/motorsports_data_notebook/tire_model/cli.py
+++ b/src/motorsports_data_notebook/tire_model/cli.py
@@ -1,0 +1,332 @@
+"""CLI for the tire warmup model: build-warmup-table, predict, validate."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from ..tire_etl.paths import default_dataset_root
+from .predict import CORNERS, Prediction, predict_cold_pressure
+from .warmup_table import build_warmup_table
+
+logger = logging.getLogger(__name__)
+
+
+def _add_dataset_root_arg(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--dataset-root",
+        type=Path,
+        default=None,
+        help="Override the dataset root (defaults to repo data/tire_dataset).",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="tire-model", description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_build = sub.add_parser(
+        "build-warmup-table",
+        help="Fit the energy-balance model and write tire_model.json + warmup_table.parquet.",
+    )
+    _add_dataset_root_arg(p_build)
+    p_build.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="Force rebuild (currently always rebuilds; flag reserved for future)",
+    )
+
+    p_predict = sub.add_parser(
+        "predict",
+        help="Predict per-corner cold pressures for a target lap.",
+    )
+    _add_dataset_root_arg(p_predict)
+    p_predict.add_argument("--track", required=True)
+    p_predict.add_argument("--car", required=True)
+    p_predict.add_argument(
+        "--lap",
+        type=int,
+        required=True,
+        help="Target lap_within_stint (0 = out-lap; 5 = 5 laps in).",
+    )
+    p_predict.add_argument(
+        "--ambient", type=float, required=True, help="Ambient air temperature in °C."
+    )
+    p_predict.add_argument(
+        "--track-temp",
+        type=float,
+        default=None,
+        help="Optional measured track-surface temperature in °C.",
+    )
+    p_predict.add_argument(
+        "--cloud-cover",
+        type=float,
+        default=None,
+        help="0..100; used only if --track-temp is omitted.",
+    )
+    p_predict.add_argument(
+        "--g2-typ",
+        type=float,
+        default=None,
+        help="Override the looked-up <g²> for this (track, car).",
+    )
+    p_predict.add_argument(
+        "--lap-time-s",
+        type=float,
+        default=None,
+        help="Override the looked-up median lap time in seconds.",
+    )
+    group = p_predict.add_argument_group("Target hot pressures (bar gauge)")
+    group.add_argument(
+        "--hot-all", type=float, default=None, help="Shorthand: same target for all 4 corners."
+    )
+    group.add_argument("--hot-fl", type=float, default=None)
+    group.add_argument("--hot-fr", type=float, default=None)
+    group.add_argument("--hot-rl", type=float, default=None)
+    group.add_argument("--hot-rr", type=float, default=None)
+
+    p_validate = sub.add_parser(
+        "validate",
+        help="MAE report vs. notes-recorded cold pressures (uses production model).",
+    )
+    _add_dataset_root_arg(p_validate)
+
+    p_audit = sub.add_parser(
+        "audit-sensors",
+        help=(
+            "Detect (session, corner) channels that look stuck/broken (low std). "
+            "Lists candidates with evidence; you decide which to add to sensor_blacklist.yaml."
+        ),
+    )
+    _add_dataset_root_arg(p_audit)
+
+    p_holdout = sub.add_parser(
+        "holdout",
+        help="Held-out validation: exclude sessions from training, predict per-lap T_hot, report residuals.",
+    )
+    _add_dataset_root_arg(p_holdout)
+    p_holdout.add_argument(
+        "--n-per-bucket",
+        type=int,
+        default=2,
+        help="Number of held-out sessions per (track, car) bucket.",
+    )
+    p_holdout.add_argument(
+        "--min-bucket-size",
+        type=int,
+        default=10,
+        help="Only hold out from buckets with at least this many sessions.",
+    )
+
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.cmd == "build-warmup-table":
+        return _cmd_build(args)
+    if args.cmd == "predict":
+        return _cmd_predict(args)
+    if args.cmd == "validate":
+        return _cmd_validate(args)
+    if args.cmd == "holdout":
+        return _cmd_holdout(args)
+    if args.cmd == "audit-sensors":
+        return _cmd_audit_sensors(args)
+    parser.print_help()
+    return 2
+
+
+def _cmd_build(args: argparse.Namespace) -> int:
+    root = args.dataset_root or default_dataset_root()
+    logger.info("Building tire model artifacts at %s", root)
+    model = build_warmup_table(root, rebuild=args.rebuild)
+    n_k = len(model["K_buckets"])
+    n_tau = len(model["tau_sec_by_car_corner"])
+    n_c = len(model["c_track_by_track"])
+    logger.info(
+        "Wrote tire_model.json + warmup_table.parquet: %d K, %d τ, %d c_track entries",
+        n_k,
+        n_tau,
+        n_c,
+    )
+    return 0
+
+
+def _resolve_hot_pressures(args: argparse.Namespace) -> dict[str, float]:
+    if args.hot_all is not None:
+        return {c: float(args.hot_all) for c in CORNERS}
+    by_corner = {
+        "fl": args.hot_fl,
+        "fr": args.hot_fr,
+        "rl": args.hot_rl,
+        "rr": args.hot_rr,
+    }
+    missing = [c for c, v in by_corner.items() if v is None]
+    if missing:
+        raise SystemExit(
+            f"Must provide --hot-all OR all of --hot-fl/--hot-fr/--hot-rl/--hot-rr; missing: {missing}"
+        )
+    return {c: float(v) for c, v in by_corner.items()}
+
+
+def _cmd_predict(args: argparse.Namespace) -> int:
+    targets = _resolve_hot_pressures(args)
+    result = predict_cold_pressure(
+        track=args.track,
+        car=args.car,
+        lap_within_stint=args.lap,
+        target_hot_pressure_bar=targets,
+        ambient_temp_c=args.ambient,
+        track_temp_c=args.track_temp,
+        cloud_cover_pct=args.cloud_cover,
+        g2_typ_override=args.g2_typ,
+        lap_time_typ_override_s=args.lap_time_s,
+        dataset_root=args.dataset_root,
+    )
+    _print_prediction(result, args)
+    return 0
+
+
+def _print_prediction(result: dict[str, Prediction], args: argparse.Namespace) -> None:
+    # Header from the first corner (all share track-level lookups)
+    any_p = next(iter(result.values()))
+    print(
+        f"Track:        {args.track:<20} c_track = {any_p.c_track:.2f}"
+        f" ± {any_p.c_track_stderr:.3f}     ⟨g²⟩ = {any_p.g2_typ:.2f} G²"
+    )
+    print(f"Car:          {args.car:<20} lap_time_typ = {any_p.lap_time_typ_s:.1f} s")
+    print(f"                                  t at lap {args.lap} = {any_p.t_at_lap_n_s:.1f} s")
+    print(
+        f"T_air = {any_p.t_air_c:.1f} °C    T_road = {any_p.t_road_c:.1f} °C    "
+        f"T_eff = {any_p.t_eff_c:.1f} °C (w_road=0.20)"
+    )
+    print()
+    header = (
+        f"{'Corner':6} {'K(K/G²)':>9} {'τ_sec(s)':>9} {'warmup':>7} {'ΔT∞(K)':>8} "
+        f"{'HotT(°C)':>9} {'HotIn(bar)':>11} {'Cold(bar)':>10} {'±(bar)':>7} "
+        f"{'K source':<18} {'n':>4}"
+    )
+    print(header)
+    for c in CORNERS:
+        p = result[c]
+        # Propagate uncertainty: dominant term is K stderr × c_track × g²
+        dT_inf_stderr = p.K_stderr * p.c_track * p.g2_typ
+        # Roughly: |dCold/dT_hot| · stderr of T_hot
+        t_hot_k = p.predicted_hot_temp_c + 273.15
+        t_cold_k = p.t_air_c + 273.15
+        # P_cold = (HotIn+1) · T_cold_K / T_hot_K  →  ∂/∂T_hot = -(HotIn+1) · T_cold_K / T_hot_K²
+        d_cold_d_thot = -(p.target_hot_pressure_bar + 1.0) * t_cold_k / (t_hot_k**2)
+        cold_stderr = abs(d_cold_d_thot) * (dT_inf_stderr * p.warmup_frac)
+        src = ",".join(p.K_source_bucket) if p.K_source_bucket else "prior"
+        print(
+            f"{c.upper():6} {p.K_kelvin_per_g2:>9.1f} {p.tau_sec:>9.0f} {p.warmup_frac:>7.2f} "
+            f"{p.delta_t_inf_kelvin:>8.1f} {p.predicted_hot_temp_c:>9.1f} "
+            f"{p.target_hot_pressure_bar:>11.3f} {p.cold_pressure_bar:>10.3f} "
+            f"{cold_stderr:>7.3f} ({src})".ljust(0) + f"{'':<4}{p.K_n_samples:>4}"
+        )
+    print()
+    print("ΔT_∞ = K · c_track · ⟨g²⟩       Hot T = T_eff + ΔT_∞ · warmup_frac")
+    print("Cold  = (HotIn + 1)·(T_air+273)/(HotT+273) − 1")
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    from .validate import run_validation  # local import keeps CLI cold-load fast
+
+    return run_validation(dataset_root=args.dataset_root)
+
+
+def _cmd_holdout(args: argparse.Namespace) -> int:
+    from .validate import run_holdout_validation
+
+    return run_holdout_validation(
+        dataset_root=args.dataset_root,
+        n_per_bucket=args.n_per_bucket,
+        min_bucket_size=args.min_bucket_size,
+    )
+
+
+def _cmd_audit_sensors(args: argparse.Namespace) -> int:
+    """Detect candidate broken sensors and print them for human review."""
+    from .warmup_table import (
+        _attach_weather,
+        _compute_stint_clock,
+        _load_filtered_laps,
+        _load_weather,
+        detect_suspect_corners,
+        load_sensor_blacklist,
+    )
+
+    root = args.dataset_root or default_dataset_root()
+    laps = _load_filtered_laps(root)
+    laps = _attach_weather(laps, _load_weather(root))
+    laps = _compute_stint_clock(laps)
+    candidates = detect_suspect_corners(laps)
+
+    blacklisted = load_sensor_blacklist(root)
+
+    if candidates.empty:
+        print("No suspect (session, corner) channels detected.")
+        return 0
+
+    print(f"=== Sensor audit: {len(candidates)} candidate (session, corner) channels ===")
+    print(
+        "Heuristic: tpms_temp_{c}_end has std < 1.0 °C across ≥ 4 tire-usable laps "
+        "(channel looks stuck)."
+    )
+    print(
+        "Review each entry; add confirmed broken ones to "
+        "`data/tire_dataset/sensor_blacklist.yaml` to exclude from training."
+    )
+    print()
+    candidates = candidates.sort_values(["car", "track_canonical", "date", "session_id", "corner"])
+
+    import pandas as _pd
+
+    _pd.set_option("display.width", 240)
+    _pd.set_option("display.max_columns", 30)
+    _pd.set_option("display.max_colwidth", 80)
+    # Show whether each candidate is already in the blacklist
+    candidates = candidates.copy()
+    candidates["already_blacklisted"] = [
+        (sid, c) in blacklisted for sid, c in zip(candidates["session_id"], candidates["corner"])
+    ]
+    cols = [
+        "session_id",
+        "car",
+        "track_canonical",
+        "date",
+        "corner",
+        "n_laps",
+        "std_c",
+        "min_c",
+        "max_c",
+        "mean_c",
+        "first_5_values",
+        "already_blacklisted",
+    ]
+    print(candidates[cols].to_string(index=False))
+    print()
+    n_new = int((~candidates["already_blacklisted"]).sum())
+    n_known = int(candidates["already_blacklisted"].sum())
+    print(f"  {n_new} not yet in sensor_blacklist.yaml    {n_known} already blacklisted")
+    print()
+    if n_new > 0:
+        print("Suggested YAML entries (copy into data/tire_dataset/sensor_blacklist.yaml):")
+        print()
+        for _, row in candidates[~candidates["already_blacklisted"]].iterrows():
+            print(f"  - session_id: {row['session_id']}")
+            print(f"    corner: {row['corner']}")
+            print(
+                f"    reason: \"std={row['std_c']:.2f} °C across {row['n_laps']} laps "
+                f"(min={row['min_c']:.1f}, max={row['max_c']:.1f})\""
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/motorsports_data_notebook/tire_model/predict.py
+++ b/src/motorsports_data_notebook/tire_model/predict.py
@@ -1,0 +1,270 @@
+"""Inference: turn (track, car, lap, ambient, target hot pressures) → cold pressures.
+
+Reads the JSON artifact written by :func:`build_warmup_table`, applies the
+fallback chain documented in the plan (K[car, corner] → K[car] → global; track
+falls back to ``c_track = 1.0``; ⟨g²⟩ falls back to (track) mean → global), and
+returns per-corner :class:`Prediction` records with full provenance.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from ..tire_etl.paths import default_dataset_root
+from .energy_balance import (
+    P_ATM_BAR,
+    T_ZERO_C_TO_K,
+    gay_lussac_cold_pressure_bar,
+    t_effective_c,
+    t_road_proxy_c,
+    warmup_curve_c,
+)
+
+CORNERS = ("fl", "fr", "rl", "rr")
+
+
+@dataclass(frozen=True)
+class Prediction:
+    corner: str
+    cold_pressure_bar: float
+    predicted_hot_temp_c: float
+    target_hot_pressure_bar: float
+    K_kelvin_per_g2: float
+    tau_sec: float
+    c_track: float
+    g2_typ: float
+    lap_time_typ_s: float
+    t_at_lap_n_s: float
+    warmup_frac: float
+    delta_t_inf_kelvin: float
+    t_eff_c: float
+    t_air_c: float
+    t_road_c: float
+    K_source_bucket: tuple[str, ...]
+    K_from_prior: bool
+    K_n_samples: int
+    K_stderr: float
+    tau_stderr: float
+    c_track_stderr: float
+
+
+def _load_model(dataset_root: Path | None) -> dict[str, Any]:
+    root = Path(dataset_root) if dataset_root else default_dataset_root()
+    artifact = root / "tire_model.json"
+    if not artifact.exists():
+        raise FileNotFoundError(
+            f"No tire_model.json at {artifact}. Run `just tire-build-warmup-table` first."
+        )
+    with artifact.open() as f:
+        model: dict[str, Any] = json.load(f)
+    return model
+
+
+def _lookup_tau(model: dict[str, Any], car: str, corner: str) -> tuple[float, float]:
+    for r in model["tau_sec_by_car_corner"]:
+        if r["car"] == car and r["corner"] == corner:
+            return float(r["value_seconds"]), float(r["stderr_seconds"])
+    # fallback to mean over (car) if any
+    same_car = [r for r in model["tau_sec_by_car_corner"] if r["car"] == car]
+    if same_car:
+        vals = [r["value_seconds"] for r in same_car]
+        return float(sum(vals) / len(vals)), 0.0
+    return float(model["priors_when_no_fit"]["tau_sec_seconds"]), 0.0
+
+
+def _lookup_k(
+    model: dict[str, Any], car: str, corner: str
+) -> tuple[float, float, int, bool, tuple[str, ...]]:
+    """Return (K, stderr, n_samples, from_prior, source_bucket_tuple)."""
+    for r in model["K_buckets"]:
+        if r["key"]["car"] == car and r["key"]["corner"] == corner:
+            return (
+                float(r["value_kelvin_per_g2"]),
+                float(r["stderr_kelvin_per_g2"]),
+                int(r["n_samples"]),
+                bool(r["from_prior"]),
+                (car, corner),
+            )
+    # (car) fallback: average K over corners
+    same_car = [r for r in model["K_buckets"] if r["key"]["car"] == car]
+    if same_car:
+        vals = [r["value_kelvin_per_g2"] for r in same_car]
+        n = sum(int(r["n_samples"]) for r in same_car)
+        return float(sum(vals) / len(vals)), 0.0, n, False, (car,)
+    # global fallback
+    prior_k = float(model["priors_when_no_fit"]["K_kelvin_per_g2"])
+    return prior_k, 0.0, 0, True, ()
+
+
+def _lookup_c_track(model: dict[str, Any], track: str) -> tuple[float, float, bool]:
+    """Return (c_track, stderr, from_prior)."""
+    for r in model["c_track_by_track"]:
+        if r["track_canonical"] == track:
+            return float(r["value"]), float(r["stderr"]), False
+    prior_c = float(model["priors_when_no_fit"]["c_track"])
+    return prior_c, 0.0, True
+
+
+def _lookup_g2(model: dict[str, Any], track: str, car: str) -> tuple[float, int, str]:
+    """Return (g2_typ, n_laps_used, source). Source is one of 'exact', 'track', 'global', 'override'."""
+    for r in model["g2_typ_by_track_car"]:
+        if r["track_canonical"] == track and r["car"] == car:
+            return float(r["g2_typ"]), int(r["n_laps_used"]), "exact"
+    same_track = [r for r in model["g2_typ_by_track_car"] if r["track_canonical"] == track]
+    if same_track:
+        vals = [r["g2_typ"] for r in same_track]
+        n = sum(int(r["n_laps_used"]) for r in same_track)
+        return float(sum(vals) / len(vals)), n, "track"
+    all_g2 = [r["g2_typ"] for r in model["g2_typ_by_track_car"]]
+    if all_g2:
+        return float(sum(all_g2) / len(all_g2)), 0, "global"
+    return 0.7, 0, "global"
+
+
+def _lookup_lap_time(model: dict[str, Any], track: str, car: str) -> tuple[float, int, str]:
+    for r in model["lap_time_typ_by_track_car"]:
+        if r["track_canonical"] == track and r["car"] == car:
+            return float(r["lap_time_typ_s"]), int(r["n_laps_used"]), "exact"
+    same_track = [r for r in model["lap_time_typ_by_track_car"] if r["track_canonical"] == track]
+    if same_track:
+        vals = [r["lap_time_typ_s"] for r in same_track]
+        n = sum(int(r["n_laps_used"]) for r in same_track)
+        return float(sum(vals) / len(vals)), n, "track"
+    return 90.0, 0, "global"
+
+
+def predict_cold_pressure(
+    *,
+    track: str,
+    car: str,
+    lap_within_stint: int,
+    target_hot_pressure_bar: dict[str, float],
+    ambient_temp_c: float,
+    track_temp_c: float | None = None,
+    cloud_cover_pct: float | None = None,
+    g2_typ_override: float | None = None,
+    lap_time_typ_override_s: float | None = None,
+    dataset_root: Path | None = None,
+    _model: dict[str, Any] | None = None,
+) -> dict[str, Prediction]:
+    """Predict per-corner cold pressure for a target lap.
+
+    Parameters
+    ----------
+    track
+        ``track_canonical`` string (e.g. ``"tsukuba_2000"``).
+    car
+        Car string as it appears in ``sessions/*.parquet`` (e.g. ``"KK-SII"``).
+    lap_within_stint
+        0-indexed lap number within a stint. ``5`` means "5 laps in" — the
+        prediction is at the END of that lap.
+    target_hot_pressure_bar
+        Dict keyed by corner ``{"fl", "fr", "rl", "rr"}``, values in bar gauge.
+    ambient_temp_c
+        Outside air temperature in °C (T_air for Gay-Lussac).
+    track_temp_c
+        Optional measured track surface temperature in °C. If ``None``, the
+        proxy ``T_air + Δ_sun · (1 - cloud_cover/100)`` is used (see
+        :func:`energy_balance.t_road_proxy_c`).
+    cloud_cover_pct
+        0..100, used only if ``track_temp_c is None``. ``None`` ⇒ no sun
+        offset (T_road = T_air).
+    g2_typ_override
+        Override the looked-up ⟨g²⟩ for the (track, car) bucket. Useful for
+        brand-new tracks.
+    lap_time_typ_override_s
+        Override the looked-up median lap time. Useful when the user wants a
+        race-pace prediction that differs from session median.
+    """
+    model = _model if _model is not None else _load_model(dataset_root)
+
+    # Lookups
+    g2_typ, g2_n, _g2_source = _lookup_g2(model, track, car)
+    if g2_typ_override is not None:
+        g2_typ = float(g2_typ_override)
+    lap_time_typ_s, lt_n, _lt_source = _lookup_lap_time(model, track, car)
+    if lap_time_typ_override_s is not None:
+        lap_time_typ_s = float(lap_time_typ_override_s)
+    c_track, c_track_stderr, _c_from_prior = _lookup_c_track(model, track)
+    w_road = float(model["energy_balance"]["w_road"])
+    sun_factor = float(model["energy_balance"]["t_road_proxy"].get("sun_factor_default", 1.0))
+    delta_sun_max_c = float(model["energy_balance"]["t_road_proxy"].get("delta_sun_max_c", 10.0))
+
+    # T_road sourcing
+    if track_temp_c is not None:
+        t_road_c = float(track_temp_c)
+    else:
+        t_road_c = t_road_proxy_c(
+            t_air_c=ambient_temp_c,
+            cloud_cover_pct=cloud_cover_pct,
+            sun_factor=sun_factor,
+            delta_sun_max_c=delta_sun_max_c,
+        )
+    t_eff_c = t_effective_c(t_air_c=ambient_temp_c, t_road_c=t_road_c, w_road=w_road)
+
+    # Time at end of lap N
+    t_at_lap_n_s = float(lap_within_stint) * lap_time_typ_s
+
+    out: dict[str, Prediction] = {}
+    for corner in CORNERS:
+        if corner not in target_hot_pressure_bar:
+            raise KeyError(f"target_hot_pressure_bar missing corner {corner!r}")
+        target_hot = float(target_hot_pressure_bar[corner])
+        K, K_stderr, K_n, K_from_prior, K_src = _lookup_k(model, car, corner)
+        tau_sec, tau_stderr = _lookup_tau(model, car, corner)
+
+        warmup_frac = 1.0 - math.exp(-t_at_lap_n_s / tau_sec) if tau_sec > 0 else 0.0
+        delta_t_inf = K * c_track * g2_typ
+        t_hot_c = warmup_curve_c(
+            t_seconds=t_at_lap_n_s,
+            t_eff_c=t_eff_c,
+            k_kelvin_per_g2=K,
+            c_track=c_track,
+            g2_typ=g2_typ,
+            tau_sec=tau_sec,
+        )
+        cold = gay_lussac_cold_pressure_bar(
+            target_hot_pressure_bar=target_hot,
+            t_hot_c=t_hot_c,
+            t_cold_c=ambient_temp_c,  # cold uses T_air only
+            p_atm_bar=P_ATM_BAR,
+        )
+
+        out[corner] = Prediction(
+            corner=corner,
+            cold_pressure_bar=cold,
+            predicted_hot_temp_c=t_hot_c,
+            target_hot_pressure_bar=target_hot,
+            K_kelvin_per_g2=K,
+            tau_sec=tau_sec,
+            c_track=c_track,
+            g2_typ=g2_typ,
+            lap_time_typ_s=lap_time_typ_s,
+            t_at_lap_n_s=t_at_lap_n_s,
+            warmup_frac=warmup_frac,
+            delta_t_inf_kelvin=delta_t_inf,
+            t_eff_c=t_eff_c,
+            t_air_c=ambient_temp_c,
+            t_road_c=t_road_c,
+            K_source_bucket=K_src,
+            K_from_prior=K_from_prior,
+            K_n_samples=K_n,
+            K_stderr=K_stderr,
+            tau_stderr=tau_stderr,
+            c_track_stderr=c_track_stderr,
+        )
+    return out
+
+
+def predict_cold_pressure_symmetric(
+    *,
+    target_hot_pressure_bar: float,
+    **kwargs: Any,
+) -> dict[str, Prediction]:
+    """Convenience: broadcast one hot-pressure target across all four corners."""
+    per_corner = {c: float(target_hot_pressure_bar) for c in CORNERS}
+    return predict_cold_pressure(target_hot_pressure_bar=per_corner, **kwargs)

--- a/src/motorsports_data_notebook/tire_model/validate.py
+++ b/src/motorsports_data_notebook/tire_model/validate.py
@@ -1,0 +1,339 @@
+"""Validation utilities for the tire warmup model.
+
+Two distinct validations:
+
+- :func:`run_validation` — compares predicted cold pressures against
+  notes-recorded cold pressures. Uses the production (full-data) model,
+  so this is a *consistency* check, not a held-out test.
+- :func:`run_holdout_validation` — held-out test. Excludes a few sessions
+  from training, then predicts per-lap T_hot for those sessions and
+  reports per-corner per-lap residuals. This is the honest measure of
+  generalization.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+
+from ..tire_etl.paths import default_dataset_root, laps_dir, sessions_dir
+from .energy_balance import (
+    t_effective_c,
+    t_road_proxy_c,
+    warmup_curve_c,
+)
+from .predict import CORNERS, predict_cold_pressure
+from .warmup_table import (
+    CORNERS as _WT_CORNERS,
+    W_ROAD,
+    build_warmup_table,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_validation(dataset_root: Path | None = None) -> int:
+    root = Path(dataset_root) if dataset_root else default_dataset_root()
+    notes_path = root / "notes_matches.parquet"
+    if not notes_path.exists():
+        logger.error("No notes_matches.parquet at %s", notes_path)
+        return 1
+    notes = pq.read_table(notes_path).to_pandas()
+    sessions = pd.concat(
+        [pq.read_table(f).to_pandas() for f in sorted(sessions_dir(root).glob("*.parquet"))],
+        ignore_index=True,
+    )
+    laps = pd.concat(
+        [pq.read_table(f).to_pandas() for f in sorted(laps_dir(root).glob("*.parquet"))],
+        ignore_index=True,
+    )
+
+    # Merge notes -> sessions for track/car/ambient
+    merged = notes.merge(
+        sessions[["session_id", "track_canonical", "car", "status", "has_tpms"]],
+        on="session_id",
+        how="left",
+    )
+    merged = merged[
+        (merged["status"] == "ok") & merged["has_tpms"] & merged["track_canonical"].notna()
+    ]
+
+    # Pre-cache model
+    with (root / "tire_model.json").open() as f:
+        model = json.load(f)
+
+    rows: list[dict] = []
+    for _, row in merged.iterrows():
+        actual = {c: row.get(f"cold_pressure_bar_{c}") for c in CORNERS}
+        if any(pd.isna(v) for v in actual.values()):
+            continue
+        # Target hot pressure: median of tpms_press_{c}_mean over mid-stint laps of this session
+        sess_laps = laps[(laps["session_id"] == row["session_id"]) & laps["tire_usable"]]
+        if sess_laps.empty:
+            continue
+        hot_targets: dict[str, float] = {}
+        skip = False
+        for c in CORNERS:
+            col = f"tpms_press_{c}_mean"
+            vals = sess_laps[col].dropna()
+            if vals.empty:
+                skip = True
+                break
+            hot_targets[c] = float(vals.median())
+        if skip:
+            continue
+        # Use lap 5 within stint as the representative warm point (or the median lap_within_stint)
+        # Use ambient from notes if present; else weather-derived from laps
+        ambient = row.get("ambient_temp_c")
+        if pd.isna(ambient):
+            continue
+        try:
+            pred = predict_cold_pressure(
+                track=row["track_canonical"],
+                car=row["car"],
+                lap_within_stint=5,
+                target_hot_pressure_bar=hot_targets,
+                ambient_temp_c=float(ambient),
+                dataset_root=root,
+                _model=model,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Skipping session %s: %s", row["session_id"], e)
+            continue
+        record = {
+            "session_id": row["session_id"],
+            "track": row["track_canonical"],
+            "car": row["car"],
+            "ambient_c": float(ambient),
+        }
+        for c in CORNERS:
+            record[f"actual_{c}"] = float(actual[c])
+            record[f"pred_{c}"] = float(pred[c].cold_pressure_bar)
+            record[f"resid_{c}"] = float(pred[c].cold_pressure_bar - actual[c])
+        rows.append(record)
+
+    if not rows:
+        print("No validation rows produced (no notes had complete actual + hot-pressure data).")
+        return 0
+    df = pd.DataFrame(rows)
+    print(f"Validation set: {len(df)} sessions\n")
+    for c in CORNERS:
+        resid = df[f"resid_{c}"]
+        mae = float(resid.abs().mean())
+        mean_bias = float(resid.mean())
+        print(
+            f"  {c.upper():3}  MAE = {mae:.3f} bar    "
+            f"mean signed residual = {mean_bias:+.3f} bar    "
+            f"(n={len(resid)})"
+        )
+
+    print("\nPer-session breakdown (first 15):")
+    cols = ["session_id", "track", "car", "ambient_c"]
+    for c in CORNERS:
+        cols += [f"actual_{c}", f"pred_{c}", f"resid_{c}"]
+    pd.set_option("display.width", 200)
+    pd.set_option("display.max_columns", 30)
+    print(df[cols].head(15).to_string(index=False))
+    return 0
+
+
+# ---------- Held-out (true generalization) validation ----------
+
+
+def _pick_holdout_sessions(
+    sessions: pd.DataFrame, laps: pd.DataFrame, n_per_bucket: int = 2, min_bucket_size: int = 10
+) -> list[str]:
+    """Pick deterministic held-out session_ids from each (track, car) bucket
+    that has enough sessions to afford excluding ``n_per_bucket`` without
+    breaking the fit.
+
+    Sorted by session_id for stability; takes the first ``n_per_bucket`` from
+    each eligible bucket.
+    """
+    ok = sessions[(sessions["status"] == "ok") & sessions["has_tpms"]]
+    ok = ok[ok["track_canonical"].notna() & ok["car"].notna()]
+    # Restrict to sessions that have at least 3 usable laps with TPMS data
+    usable_per_session = (
+        laps[laps["tire_usable"]].groupby("session_id").size().rename("n_usable_laps").reset_index()
+    )
+    ok = ok.merge(usable_per_session, on="session_id", how="left")
+    ok = ok[ok["n_usable_laps"].fillna(0) >= 3]
+
+    held_out: list[str] = []
+    for (track, car), grp in ok.groupby(["track_canonical", "car"]):
+        if len(grp) < min_bucket_size:
+            continue
+        chosen = sorted(grp["session_id"].tolist())[:n_per_bucket]
+        held_out.extend(chosen)
+    return held_out
+
+
+def run_holdout_validation(
+    dataset_root: Path | None = None,
+    *,
+    n_per_bucket: int = 2,
+    min_bucket_size: int = 10,
+) -> int:
+    """Train on all-minus-held-out, predict per-lap T_hot for held-out sessions.
+
+    Reports per-corner MAE / RMSE per session and a pooled summary.
+    """
+    root = Path(dataset_root) if dataset_root else default_dataset_root()
+    sessions = pd.concat(
+        [pq.read_table(f).to_pandas() for f in sorted(sessions_dir(root).glob("*.parquet"))],
+        ignore_index=True,
+    )
+    laps = pd.concat(
+        [pq.read_table(f).to_pandas() for f in sorted(laps_dir(root).glob("*.parquet"))],
+        ignore_index=True,
+    )
+
+    holdout_ids = _pick_holdout_sessions(
+        sessions, laps, n_per_bucket=n_per_bucket, min_bucket_size=min_bucket_size
+    )
+    if not holdout_ids:
+        print("No (track, car) bucket has enough sessions to hold out cleanly.")
+        return 1
+
+    print(
+        f"Holding out {len(holdout_ids)} sessions "
+        f"({n_per_bucket} per bucket, min bucket size = {min_bucket_size})"
+    )
+
+    # Train a model with the holdouts excluded
+    model = build_warmup_table(root, exclude_session_ids=set(holdout_ids), write_artifacts=False)
+
+    # Build per-(track, car) lookups from the held-out model
+    g2_lookup = {
+        (d["track_canonical"], d["car"]): d["g2_typ"] for d in model["g2_typ_by_track_car"]
+    }
+    c_track_lookup = {d["track_canonical"]: d["value"] for d in model["c_track_by_track"]}
+    k_lookup = {
+        (d["key"]["car"], d["key"]["corner"]): d["value_kelvin_per_g2"] for d in model["K_buckets"]
+    }
+    tau_lookup = {
+        (d["car"], d["corner"]): d["value_seconds"] for d in model["tau_sec_by_car_corner"]
+    }
+
+    # Build (session_id → ambient_temp_c) from weather attached during training prep.
+    # Simpler: re-run the same weather lookup logic for held-out sessions only.
+    from .warmup_table import (
+        _apply_blacklist,
+        _attach_weather,
+        _compute_delta_t,
+        _compute_stint_clock,
+        _load_filtered_laps,
+        _load_weather,
+        load_sensor_blacklist,
+    )
+
+    all_laps = _load_filtered_laps(root)
+    all_laps = all_laps[all_laps["session_id"].isin(holdout_ids)].copy()
+    if all_laps.empty:
+        print("Held-out sessions have no laps passing filters — nothing to evaluate.")
+        return 0
+    weather = _load_weather(root)
+    all_laps = _attach_weather(all_laps, weather)
+    all_laps = _compute_stint_clock(all_laps)
+    # Apply the same blacklist used at training — don't grade predictions
+    # against channels we already know are broken. Held-out laps are a
+    # subset, so most blacklist entries won't match — silence that noise.
+    blacklist_pairs = load_sensor_blacklist(root)
+    all_laps, _ = _apply_blacklist(all_laps, blacklist_pairs, warn_on_unknown=False)
+    all_laps = _compute_delta_t(all_laps)
+    # Drop out-laps from evaluation (same convention as training)
+    all_laps = all_laps[all_laps["lap_within_stint"] > 0].reset_index(drop=True)
+
+    # Per-lap predictions
+    rows: list[dict] = []
+    for _, lap in all_laps.iterrows():
+        track = lap["track_canonical"]
+        car = lap["car"]
+        t_cum_s = float(lap["t_cum_s"])
+        t_eff = float(lap["t_eff_c"]) if pd.notna(lap["t_eff_c"]) else None
+        if t_eff is None:
+            continue
+        g2 = g2_lookup.get((track, car))
+        if g2 is None:
+            continue
+        c_track = c_track_lookup.get(track, 1.0)
+        for c in CORNERS:
+            K = k_lookup.get((car, c))
+            tau = tau_lookup.get((car, c))
+            if K is None or tau is None:
+                continue
+            obs = lap.get(f"tpms_temp_{c}_end")
+            if pd.isna(obs):
+                continue
+            t_hot_pred = warmup_curve_c(
+                t_seconds=t_cum_s,
+                t_eff_c=t_eff,
+                k_kelvin_per_g2=K,
+                c_track=c_track,
+                g2_typ=g2,
+                tau_sec=tau,
+            )
+            rows.append(
+                {
+                    "session_id": lap["session_id"],
+                    "track": track,
+                    "car": car,
+                    "lap_num": int(lap["lap_num"]),
+                    "stint_id": int(lap["stint_id"]),
+                    "lap_within_stint": int(lap["lap_within_stint"]),
+                    "t_cum_s": t_cum_s,
+                    "corner": c,
+                    "T_hot_pred_c": t_hot_pred,
+                    "T_hot_obs_c": float(obs),
+                    "resid_c": t_hot_pred - float(obs),
+                }
+            )
+
+    if not rows:
+        print("No predictable laps in held-out set.")
+        return 0
+    df = pd.DataFrame(rows)
+
+    def _print_corner_table(label: str, frame: pd.DataFrame) -> None:
+        if frame.empty:
+            return
+        print(f"\n=== {label} ({len(frame)} (lap × corner) points) ===")
+        for c in CORNERS:
+            sub = frame[frame["corner"] == c]
+            if sub.empty:
+                continue
+            mae = float(sub["resid_c"].abs().mean())
+            rmse = float(np.sqrt((sub["resid_c"] ** 2).mean()))
+            bias = float(sub["resid_c"].mean())
+            print(
+                f"  {c.upper():>3}   MAE = {mae:>5.2f} °C   RMSE = {rmse:>5.2f} °C   "
+                f"mean bias = {bias:+.2f} °C    n = {len(sub)}"
+            )
+
+    _print_corner_table("Held-out per-corner T_hot residuals — POOLED", df)
+    for car_name, car_frame in df.groupby("car"):
+        _print_corner_table(f"Held-out — {car_name}", car_frame)
+
+    # Per-(session, lap) table
+    print("\n=== Per-(session, lap) breakdown ===")
+    pivot = df.pivot_table(
+        index=["session_id", "track", "car", "lap_num", "lap_within_stint", "t_cum_s"],
+        columns="corner",
+        values=["T_hot_pred_c", "T_hot_obs_c", "resid_c"],
+    )
+    pivot.columns = [f"{tup[0]}_{tup[1]}" for tup in pivot.columns]
+    pivot = pivot.reset_index().sort_values(["session_id", "lap_num"])
+    pd.set_option("display.width", 240)
+    pd.set_option("display.max_columns", 30)
+    pd.set_option("display.float_format", lambda x: f"{x:.1f}")
+    cols = ["session_id", "track", "car", "lap_num", "lap_within_stint", "t_cum_s"]
+    for c in CORNERS:
+        cols += [f"T_hot_obs_c_{c}", f"T_hot_pred_c_{c}", f"resid_c_{c}"]
+    print(pivot[cols].to_string(index=False))
+    return 0

--- a/tests/tire_model/test_cli.py
+++ b/tests/tire_model/test_cli.py
@@ -1,0 +1,120 @@
+"""Unit tests for the tire-model CLI argument parsing and helpers.
+
+These tests cover the argparse surface and the pure helpers in cli.py —
+not the subcommands themselves, which require a built model artifact
+and are exercised end-to-end by `just tire-build-warmup-table` +
+`just tire-predict-holdout`.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from motorsports_data_notebook.tire_model.cli import (
+    _resolve_hot_pressures,
+    main,
+)
+
+
+def _args(**kw: float | None) -> argparse.Namespace:
+    """Build a tiny Namespace with the hot-pressure fields _resolve_hot_pressures reads."""
+    return argparse.Namespace(
+        hot_all=kw.get("hot_all"),
+        hot_fl=kw.get("hot_fl"),
+        hot_fr=kw.get("hot_fr"),
+        hot_rl=kw.get("hot_rl"),
+        hot_rr=kw.get("hot_rr"),
+    )
+
+
+# ---------- _resolve_hot_pressures ----------
+
+
+def test_resolve_hot_pressures_all_shorthand_broadcasts() -> None:
+    out = _resolve_hot_pressures(_args(hot_all=1.95))
+    assert out == {"fl": 1.95, "fr": 1.95, "rl": 1.95, "rr": 1.95}
+
+
+def test_resolve_hot_pressures_per_corner_values() -> None:
+    out = _resolve_hot_pressures(_args(hot_fl=1.95, hot_fr=1.95, hot_rl=1.90, hot_rr=1.92))
+    assert out == {"fl": 1.95, "fr": 1.95, "rl": 1.90, "rr": 1.92}
+
+
+def test_resolve_hot_pressures_all_overrides_per_corner() -> None:
+    out = _resolve_hot_pressures(_args(hot_all=2.0, hot_fl=1.5, hot_fr=1.5, hot_rl=1.5, hot_rr=1.5))
+    assert out == {"fl": 2.0, "fr": 2.0, "rl": 2.0, "rr": 2.0}
+
+
+def test_resolve_hot_pressures_missing_corner_raises_systemexit() -> None:
+    # Neither --hot-all nor a complete set of per-corner values
+    with pytest.raises(SystemExit) as exc:
+        _resolve_hot_pressures(_args(hot_fl=1.95, hot_fr=1.95))
+    msg = str(exc.value)
+    # Should mention which corners are missing
+    assert "rl" in msg and "rr" in msg
+
+
+# ---------- CLI parser ----------
+
+
+def test_cli_no_args_errors() -> None:
+    """Calling main() with no subcommand should exit non-zero (argparse: required=True)."""
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_cli_predict_requires_track_car_lap_and_ambient() -> None:
+    with pytest.raises(SystemExit):
+        main(["predict", "--track", "tsukuba_2000", "--car", "KK-SII", "--hot-all", "1.95"])
+        # Missing --lap and --ambient
+
+
+def test_cli_predict_parses_full_invocation_then_fails_loading_model(tmp_path) -> None:
+    """The CLI should parse cleanly even if the dataset_root has no
+    tire_model.json — failure should come from the predictor, not argparse."""
+    with pytest.raises(FileNotFoundError):
+        main(
+            [
+                "predict",
+                "--dataset-root",
+                str(tmp_path),
+                "--track",
+                "tsukuba_2000",
+                "--car",
+                "KK-SII",
+                "--lap",
+                "5",
+                "--ambient",
+                "18",
+                "--hot-all",
+                "1.95",
+            ]
+        )
+
+
+def test_cli_subcommands_are_registered() -> None:
+    """A regression guard so silently dropping a subcommand from main() trips."""
+    import argparse
+
+    # Build the same parser the CLI does, by introspecting main's argv handling
+    # via a dry-run with --help and confirming all subcommands appear in the
+    # parser. Easier: just confirm each subcommand's argparser doesn't error
+    # when given its minimal required args.
+    cases: list[list[str]] = [
+        ["build-warmup-table", "--dataset-root", "/nonexistent"],
+        ["audit-sensors", "--dataset-root", "/nonexistent"],
+        ["validate", "--dataset-root", "/nonexistent"],
+        ["holdout", "--dataset-root", "/nonexistent"],
+    ]
+    for argv in cases:
+        # Each subcommand should parse cleanly. Most will fail downstream
+        # because the dataset doesn't exist; that's fine — we're testing
+        # argparse here, not the I/O.
+        try:
+            main(argv)
+        except (FileNotFoundError, ValueError, SystemExit):
+            pass
+        except argparse.ArgumentError as e:
+            pytest.fail(f"argparse rejected subcommand {argv[0]!r}: {e}")

--- a/tests/tire_model/test_predict.py
+++ b/tests/tire_model/test_predict.py
@@ -1,0 +1,322 @@
+"""Unit tests for the predictor and its fallback chain."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from motorsports_data_notebook.tire_model.predict import (
+    CORNERS,
+    Prediction,
+    predict_cold_pressure,
+)
+
+
+def _minimal_model() -> dict:
+    """Build a synthetic in-memory model that exercises the fallback chain.
+
+    - Cars: "ToyCar" and "OtherCar"
+    - Tracks: "track_a" (anchor), "track_b"
+    - K_buckets cover every (ToyCar, corner) but only RR for OtherCar
+    - τ covers all 8 (ToyCar) + (OtherCar) entries
+    """
+    return {
+        "schema_version": 1,
+        "model_form": "T_hot - T_eff = K * c_track * g2_typ * (1 - exp(-t/tau_sec))",
+        "gay_lussac": {"p_atm_bar": 1.0, "t_zero_c_to_k": 273.15, "t_cold_uses": "T_air"},
+        "energy_balance": {
+            "w_road": 0.2,
+            "w_road_fitted": False,
+            "t_road_proxy": {
+                "formula": "T_air + delta_sun_max_c * (1 - cloud_cover/100) * sun_factor",
+                "delta_sun_max_c": 10.0,
+                "sun_factor_default": 1.0,
+            },
+        },
+        "corners": list(CORNERS),
+        "min_samples_per_bucket": 5,
+        "priors_when_no_fit": {
+            "tau_sec_seconds": 240.0,
+            "K_kelvin_per_g2": 60.0,
+            "c_track": 1.0,
+        },
+        "tau_sec_by_car_corner": [
+            {
+                "car": "ToyCar",
+                "corner": c,
+                "value_seconds": 200.0 + 10.0 * i,
+                "stderr_seconds": 5.0,
+                "n_samples_used": 100,
+                "from_prior": False,
+            }
+            for i, c in enumerate(CORNERS)
+        ]
+        + [
+            {
+                "car": "OtherCar",
+                "corner": c,
+                "value_seconds": 250.0,
+                "stderr_seconds": 8.0,
+                "n_samples_used": 50,
+                "from_prior": False,
+            }
+            for c in CORNERS
+        ],
+        "K_buckets": [
+            {
+                "key": {"car": "ToyCar", "corner": c},
+                "value_kelvin_per_g2": 50.0 + 5.0 * i,
+                "stderr_kelvin_per_g2": 2.0,
+                "n_samples": 100,
+                "from_prior": False,
+                "from_single_track": False,
+            }
+            for i, c in enumerate(CORNERS)
+        ]
+        + [
+            {
+                "key": {"car": "OtherCar", "corner": "rr"},
+                "value_kelvin_per_g2": 45.0,
+                "stderr_kelvin_per_g2": 3.0,
+                "n_samples": 50,
+                "from_prior": False,
+                "from_single_track": True,
+            },
+        ],
+        "c_track_by_track": [
+            {
+                "track_canonical": "track_a",
+                "value": 1.0,
+                "stderr": 0.0,
+                "n_buckets_used": 8,
+                "anchor": True,
+            },
+            {
+                "track_canonical": "track_b",
+                "value": 0.85,
+                "stderr": 0.04,
+                "n_buckets_used": 4,
+                "anchor": False,
+            },
+        ],
+        "g2_typ_by_track_car": [
+            {"track_canonical": "track_a", "car": "ToyCar", "g2_typ": 0.9, "n_laps_used": 100},
+            {"track_canonical": "track_b", "car": "ToyCar", "g2_typ": 0.7, "n_laps_used": 50},
+            {"track_canonical": "track_a", "car": "OtherCar", "g2_typ": 0.8, "n_laps_used": 30},
+        ],
+        "lap_time_typ_by_track_car": [
+            {
+                "track_canonical": "track_a",
+                "car": "ToyCar",
+                "lap_time_typ_s": 60.0,
+                "n_laps_used": 100,
+            },
+            {
+                "track_canonical": "track_b",
+                "car": "ToyCar",
+                "lap_time_typ_s": 100.0,
+                "n_laps_used": 50,
+            },
+            {
+                "track_canonical": "track_a",
+                "car": "OtherCar",
+                "lap_time_typ_s": 80.0,
+                "n_laps_used": 30,
+            },
+        ],
+        "fallback_order_for_K": [["car", "corner"], ["car"], []],
+    }
+
+
+def test_predict_exact_bucket_match() -> None:
+    model = _minimal_model()
+    result = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    fl = result["fl"]
+    assert isinstance(fl, Prediction)
+    assert fl.K_source_bucket == ("ToyCar", "fl")
+    assert not fl.K_from_prior
+    assert fl.c_track == pytest.approx(1.0)  # anchor track
+    assert fl.g2_typ == pytest.approx(0.9)
+    assert fl.predicted_hot_temp_c > 20.0  # warming up
+
+
+def test_predict_falls_back_to_car_level_when_corner_missing() -> None:
+    """OtherCar has only RR in K_buckets — FL/FR/RL should fall back to (car) mean."""
+    model = _minimal_model()
+    result = predict_cold_pressure(
+        track="track_a",
+        car="OtherCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    fl = result["fl"]
+    assert fl.K_source_bucket == ("OtherCar",)
+    assert fl.K_kelvin_per_g2 == pytest.approx(45.0)  # only RR exists → mean is RR
+
+
+def test_predict_falls_back_to_global_when_car_unknown() -> None:
+    model = _minimal_model()
+    result = predict_cold_pressure(
+        track="track_a",
+        car="UnknownCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        # No (car) data → falls back to prior K
+        # Also no (car, corner) τ_sec → prior τ
+        # ⟨g²⟩ fallback to (track) mean
+        # lap_time_typ fallback to (track) mean
+        _model=model,
+    )
+    fl = result["fl"]
+    assert fl.K_from_prior is True
+    assert fl.K_source_bucket == ()  # global fallback
+
+
+def test_predict_falls_back_to_c_track_one_when_track_unknown() -> None:
+    model = _minimal_model()
+    result = predict_cold_pressure(
+        track="unknown_track",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    fl = result["fl"]
+    assert fl.c_track == pytest.approx(1.0)  # prior
+
+
+def test_predict_g2_override_bypasses_lookup() -> None:
+    model = _minimal_model()
+    result = predict_cold_pressure(
+        track="unknown_track",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        g2_typ_override=1.2,
+        _model=model,
+    )
+    assert result["fl"].g2_typ == pytest.approx(1.2)
+
+
+def test_predict_uses_user_provided_track_temp_when_given() -> None:
+    model = _minimal_model()
+    # Without track_temp: T_road defaults to T_air (no cloud cover provided)
+    r_default = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    # With track_temp = 40 °C: T_eff blends up
+    r_with = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        track_temp_c=40.0,
+        _model=model,
+    )
+    assert r_default["fl"].t_eff_c == pytest.approx(20.0)  # T_road == T_air → T_eff == T_air
+    # T_eff = 0.8·20 + 0.2·40 = 24
+    assert r_with["fl"].t_eff_c == pytest.approx(24.0)
+    # T_hot prediction is higher with the hotter T_eff baseline
+    assert r_with["fl"].predicted_hot_temp_c > r_default["fl"].predicted_hot_temp_c
+
+
+def test_predict_cold_uses_t_air_not_t_eff_for_gay_lussac() -> None:
+    """Even when T_eff blends in road heat, the cold side of Gay-Lussac uses
+    T_air — cold tires equilibrate to pit air, not hot asphalt."""
+    model = _minimal_model()
+    r = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=15.0,
+        track_temp_c=50.0,
+        _model=model,
+    )
+    # T_cold for the Gay-Lussac inversion should be 15 °C, even though T_eff is higher
+    # We can verify by recomputing with the closed-form
+    p = r["fl"]
+    from motorsports_data_notebook.tire_model.energy_balance import (
+        gay_lussac_cold_pressure_bar,
+    )
+
+    expected_cold = gay_lussac_cold_pressure_bar(
+        target_hot_pressure_bar=1.95,
+        t_hot_c=p.predicted_hot_temp_c,
+        t_cold_c=15.0,  # T_air, not T_eff
+    )
+    assert p.cold_pressure_bar == pytest.approx(expected_cold)
+
+
+def test_predict_missing_corner_in_target_raises_keyerror() -> None:
+    model = _minimal_model()
+    with pytest.raises(KeyError):
+        predict_cold_pressure(
+            track="track_a",
+            car="ToyCar",
+            lap_within_stint=5,
+            target_hot_pressure_bar={"fl": 1.95, "fr": 1.95, "rl": 1.95},  # missing rr
+            ambient_temp_c=20.0,
+            _model=model,
+        )
+
+
+def test_predict_cross_track_uses_same_k_different_c_track() -> None:
+    """Whole point of the energy-balance design: track shouldn't change K."""
+    model = _minimal_model()
+    r_a = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    r_b = predict_cold_pressure(
+        track="track_b",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    # Same K, same τ
+    assert r_a["fl"].K_kelvin_per_g2 == r_b["fl"].K_kelvin_per_g2
+    assert r_a["fl"].tau_sec == r_b["fl"].tau_sec
+    # Different c_track
+    assert r_a["fl"].c_track != r_b["fl"].c_track
+
+
+def test_predict_loads_from_disk_when_no_model_kwarg(tmp_path: Path) -> None:
+    """End-to-end: predict_cold_pressure reads tire_model.json from dataset_root."""
+    model = _minimal_model()
+    (tmp_path / "tire_model.json").write_text(json.dumps(model))
+    result = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        dataset_root=tmp_path,
+    )
+    assert result["fl"].cold_pressure_bar > 0

--- a/tests/tire_model/test_validate.py
+++ b/tests/tire_model/test_validate.py
@@ -1,0 +1,129 @@
+"""Unit tests for the held-out validation helpers.
+
+The full end-to-end ``run_holdout_validation`` requires the committed
+dataset and is exercised by ``just tire-predict-holdout``. These tests
+cover the pure pandas logic in ``_pick_holdout_sessions``.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from motorsports_data_notebook.tire_model.validate import _pick_holdout_sessions
+
+
+def _make_sessions(rows: list[dict]) -> pd.DataFrame:
+    """Build a minimal sessions DataFrame matching the columns the picker reads."""
+    defaults = {"status": "ok", "has_tpms": True}
+    return pd.DataFrame([{**defaults, **r} for r in rows])
+
+
+def _make_laps_with_usable_per_session(counts: dict[str, int]) -> pd.DataFrame:
+    """Build a laps DataFrame where each session_id has ``counts[sid]`` usable laps."""
+    rows = []
+    for sid, n in counts.items():
+        for lap in range(n):
+            rows.append({"session_id": sid, "lap_num": lap, "tire_usable": True})
+    return pd.DataFrame(rows)
+
+
+def test_picker_returns_empty_when_no_bucket_meets_threshold() -> None:
+    sessions = _make_sessions(
+        [
+            {"session_id": "s1", "track_canonical": "tsukuba_2000", "car": "CarA"},
+            {"session_id": "s2", "track_canonical": "tsukuba_2000", "car": "CarA"},
+        ]
+    )
+    laps = _make_laps_with_usable_per_session({"s1": 5, "s2": 5})
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    assert out == []
+
+
+def test_picker_returns_first_n_session_ids_sorted_within_eligible_bucket() -> None:
+    # 12 sessions in one (track, car) bucket → eligible at min_bucket_size=10
+    sids = [f"sess_{i:02d}" for i in range(12)]
+    sessions = _make_sessions(
+        [{"session_id": sid, "track_canonical": "tsukuba_2000", "car": "CarA"} for sid in sids]
+    )
+    laps = _make_laps_with_usable_per_session({sid: 8 for sid in sids})
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    # Picks first 2 by sort order
+    assert out == sorted(sids)[:2]
+
+
+def test_picker_skips_sessions_with_too_few_usable_laps() -> None:
+    """A session needs at least 3 usable laps to be a valid held-out candidate."""
+    sids = [f"sess_{i:02d}" for i in range(15)]
+    sessions = _make_sessions(
+        [{"session_id": sid, "track_canonical": "tsukuba_2000", "car": "CarA"} for sid in sids]
+    )
+    # Most sessions have 8 usable laps; first 2 (by sort order) have only 2
+    counts = {sid: 8 for sid in sids}
+    counts["sess_00"] = 2  # would be picked first if usable, but only 2 laps
+    counts["sess_01"] = 2
+    laps = _make_laps_with_usable_per_session(counts)
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    # Picker skips sess_00 and sess_01, picks sess_02 and sess_03
+    assert out == ["sess_02", "sess_03"]
+
+
+def test_picker_picks_from_multiple_buckets_independently() -> None:
+    # Two eligible buckets: Tsukuba/CarA and Fuji/CarA
+    sids_tsukuba = [f"tsk_{i:02d}" for i in range(12)]
+    sids_fuji = [f"fji_{i:02d}" for i in range(11)]
+    sessions = _make_sessions(
+        [
+            {"session_id": sid, "track_canonical": "tsukuba_2000", "car": "CarA"}
+            for sid in sids_tsukuba
+        ]
+        + [{"session_id": sid, "track_canonical": "fuji", "car": "CarA"} for sid in sids_fuji]
+    )
+    laps = _make_laps_with_usable_per_session({sid: 8 for sid in sids_tsukuba + sids_fuji})
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    # 2 from each bucket = 4 total
+    assert len(out) == 4
+    assert sorted(sids_tsukuba)[:2] == [s for s in out if s.startswith("tsk")]
+    assert sorted(sids_fuji)[:2] == [s for s in out if s.startswith("fji")]
+
+
+def test_picker_drops_non_ok_or_no_tpms_sessions() -> None:
+    rows: list[dict] = [
+        {"session_id": "ok1", "track_canonical": "tsukuba_2000", "car": "CarA"},
+        {"session_id": "ok2", "track_canonical": "tsukuba_2000", "car": "CarA"},
+        {
+            "session_id": "err",
+            "track_canonical": "tsukuba_2000",
+            "car": "CarA",
+            "status": "error",
+        },
+        {
+            "session_id": "noTPMS",
+            "track_canonical": "tsukuba_2000",
+            "car": "CarA",
+            "has_tpms": False,
+        },
+    ]
+    rows.extend(
+        {"session_id": f"filler_{i}", "track_canonical": "tsukuba_2000", "car": "CarA"}
+        for i in range(10)
+    )
+    sessions = _make_sessions(rows)
+    laps = _make_laps_with_usable_per_session({sid: 8 for sid in sessions["session_id"].tolist()})
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    assert "err" not in out
+    assert "noTPMS" not in out
+
+
+def test_picker_skips_sessions_with_missing_track_or_car() -> None:
+    sessions = _make_sessions(
+        [{"session_id": "s_bad_track", "track_canonical": None, "car": "CarA"}]
+        + [{"session_id": "s_bad_car", "track_canonical": "tsukuba_2000", "car": None}]
+        + [
+            {"session_id": f"ok_{i}", "track_canonical": "tsukuba_2000", "car": "CarA"}
+            for i in range(12)
+        ]
+    )
+    laps = _make_laps_with_usable_per_session({sid: 8 for sid in sessions["session_id"].tolist()})
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    assert "s_bad_track" not in out
+    assert "s_bad_car" not in out


### PR DESCRIPTION

The user-facing surface on top of the fitted model. Three pieces:

- `predict.predict_cold_pressure(track, car, lap_within_stint, ...)`
  Reads tire_model.json, runs the fallback chain
  (K[car,corner] → K[car] → global; ⟨g²⟩[track,car] → ⟨g²⟩[track] → user
  override; c_track[track] → 1.0; τ_sec[car,corner] always present),
  sources T_road (user → logger-historical → cloud-cover proxy), evaluates
  the closed-form warmup curve, and inverts Gay-Lussac per corner.
  Returns dict[corner, Prediction] with full provenance (K_source_bucket,
  n_samples, stderrs, etc.).

- `cli` subcommands:
  - `build-warmup-table` — fits the model, writes both artifacts.
  - `audit-sensors` — surfaces (session, corner) candidates with evidence;
    no auto-masking — operator decides which to add to
    `sensor_blacklist.yaml`.
  - `predict` — per-corner prediction with verbose physical breakdown
    (K, τ_sec, warmup_frac, ΔT_∞, hot T, ±) so the user can sanity-check
    every step of the energy balance before trusting the cold pressure.
  - `validate` — predicted vs notes-recorded cold pressures (consistency
    check; not held out).
  - `holdout` — the honest generalization test: trains a model excluding
    N sessions per (track, car) bucket, predicts per-lap T_hot for those
    sessions, reports per-corner MAE/RMSE/bias both pooled and per car.

- justfile recipes: `tire-build-warmup-table`, `tire-sensor-audit`,
  `tire-predict`, `tire-predict-validate`, `tire-predict-holdout`.

- `scripts/tire_predict.py` thin wrapper mirroring scripts/tire_etl.py.

- `__init__.py` re-exports `Prediction` + `predict_cold_pressure`.

Tests cover: exact-bucket match, (car) fallback when a corner is missing,
global fallback when the whole car is unknown, c_track=1.0 fallback for
unseen tracks, ⟨g²⟩ override, cold uses T_air not T_eff (Gay-Lussac
correctness), missing corner raises KeyError, cross-track shrinkage uses
the same K with different c_track, and end-to-end load-from-disk.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/114).
* #122
* #121
* #120
* #119
* #118
* #117
* #116
* #115
* __->__ #114