### PR TITLE
tire-model: design doc with methodology and v0 results

### DIFF
--- a/docs/tire_model.md
+++ b/docs/tire_model.md
@@ -1,0 +1,453 @@
+# Cold tire pressure model — v0
+
+A physically-based predictor that takes
+**(track, car, target lap within stint, target hot pressure per corner, expected ambient temp)**
+and returns the cold pressure to set, per corner.
+
+> Quickstart: `just tire-build-warmup-table && just tire-predict --track tsukuba_2000 --car KK-SII --lap 5 --ambient 18 --hot-all 1.95`
+
+## 1. Why this is the v0
+
+The plan was deliberately conservative: get a working end-to-end predictor with
+honest accuracy numbers we can iterate on, not a full Bayesian hierarchical
+model. The constraints we adopted:
+
+- **Physically based.** Every fitted parameter is a real thermal quantity the
+  user can sanity-check.
+- **Few free parameters.** ~20 across the whole dataset, not hundreds.
+- **Per-corner output.** Front/rear and left/right tires are different physical
+  objects, so per-corner cold pressures fall out naturally.
+- **Track-independent fit.** A car's thermal parameters are properties of the
+  car, not the venue. The track effect enters through data (⟨g²⟩, c_track),
+  not through track-specific fitted coefficients.
+- **Tire compound omitted.** Notes-derived compound coverage is only 49 of
+  142 ok sessions (34%) and strings are messy. Including it as a model
+  dimension makes K + c_track + compound mutually unidentifiable in the
+  current data. Deferred until coverage improves.
+
+## 2. Modeling approach
+
+### 2.1 Energy balance on a lumped tire mass
+
+The model is one ODE — heat flux balance on the tire treated as a single
+thermal mass:
+
+```
+                                              ┌──────────────┐   ┌──────────────┐
+   m·c · dT/dt   =   c_track · α · g²(t)   −   │ h_air · (T   │ + │ h_road ·     │
+                                               │  − T_air )   │   │ (T − T_road) │
+   ───────────       ──────────────────        └──────────────┘   └──────────────┘
+   energy stored     energy IN                       energy OUT
+   per second        per second                      per second
+   (W = J/s)         (friction work + hysteresis)    (convection to air at the
+                                                      tire's top/sides + conduction
+                                                      to the track at the patch)
+```
+
+**Energy IN.** Friction work at the contact patch scales with squared total
+acceleration `g²(t) = lat_g(t)² + long_g(t)²` (cornering + braking) times a
+per-track surface factor `c_track` (asphalt grip, roughness — what's left over
+after accounting for ⟨g²⟩) times a coefficient `α` that absorbs friction
+coefficient, contact-patch geometry, brake-disc-to-tire heat coupling, and
+compound hysteresis.
+
+**Energy OUT.** Two parallel paths — convection to ambient air at the tire's
+top/sides, and conduction to the track surface at the contact patch. These
+have different reference temperatures: hot asphalt cools the tire less than
+cold air does. We collect them into one effective ambient:
+
+```
+T_eff = (1 − w_road) · T_air + w_road · T_road
+```
+
+where `w_road = h_road / (h_air + h_road)` is the fraction of energy-OUT going
+to the track. **v0 fixes `w_road = 0.2`** based on the physical prior that
+convection-to-air dominates conduction-to-road at race speeds (fast airflow
+over the tire; small contact-patch area relative to tire surface area). Fitting
+`w_road` is deferred to v1 — at 34% c_track-known × ~5% T_road-measured, the
+joint identifiability is poor.
+
+**T_road sourcing** at inference (priority order): user-supplied → AIM logger
+channel (rare, <5%) → proxy `T_road = T_air + 10 · (1 − cloud_cover/100) ·
+sun_factor` from Open-Meteo cloud cover → fall back to `T_road = T_air`.
+
+### 2.2 Closed-form solution
+
+Approximating `g²(t)` by its session average `⟨g²⟩` (good within a stint for
+a consistent driver), the linear ODE has a closed-form solution starting
+from `T_0 = T_eff`:
+
+```
+T_hot(t) − T_eff  =  K · c_track · ⟨g²⟩ · (1 − exp(−t / τ_sec))
+```
+
+with:
+
+- `K = α / (h_air + h_road)` — units of K per G². The **warmup gain**:
+  steady-state Kelvin per unit of average G². Property of `(car, corner)`.
+- `τ_sec = m·c / (h_air + h_road)` — units of seconds. The **thermal time
+  constant**: how fast the tire approaches its steady state. Property of
+  `(car, corner)`.
+- `t` = on-track seconds since stint start.
+
+### 2.3 Why on-track seconds, not laps
+
+A Tsukuba lap takes ~60 s; a Fuji lap takes ~115 s. Fitting τ in laps would
+mix tire physics with circuit geometry — "3 laps to warm up" means different
+things at different tracks. **Fitting τ in seconds gives a quantity that is
+truly a property of the wheel/tire/hub system**, transferable across tracks.
+
+At inference time we convert lap N → seconds via the bucket's median lap
+time: `t_at_lap_N = N · lap_time_typ_s[track, car]`. Users can override with
+`--lap-time-s` (e.g. for race-pace estimates that differ from session
+median).
+
+### 2.4 Gay-Lussac inversion
+
+Given the predicted hot temperature, invert Gay-Lussac's Law at constant
+volume (P/T = const, absolute units):
+
+```
+T_cold_K  = T_air + 273.15          # cold tires equilibrate to AIR (not T_eff)
+T_hot_K   = T_hot + 273.15
+P_hot_abs = target_hot_pressure_bar + 1.0
+P_cold    = P_hot_abs · (T_cold_K / T_hot_K) − 1.0
+```
+
+Matches the C# tire-pressure calculator's convention exactly
+(`tire_pressure_calculator/Core/ViewModels/TireCornerViewModel.cs:77-89`)
+so round-trip is bit-identical within float rounding. **Note `T_cold` uses
+`T_air` only, not the road-blended `T_eff`** — cold tires sitting in the
+pits aren't being cooled by hot asphalt; they equilibrate to whatever air
+they're sitting in.
+
+### 2.5 Parameter pooling
+
+| Param            | Physics                                  | Pooled over                       | Count   | Notes |
+|------------------|------------------------------------------|-----------------------------------|---------|---|
+| `K`              | `α / (h_air + h_road)`                   | `(car, corner)`                   | 8       | Energy-IN / Energy-OUT gain |
+| `τ_sec`          | `m·c / (h_air + h_road)`                 | `(car, corner)`                   | 8       | Thermal time constant |
+| `c_track`        | per-track surface scalar                 | `(track)`                         | ~3–4    | Tsukuba anchored at 1.0 |
+| `w_road`         | `h_road / (h_air + h_road)`              | **fixed at 0.2 in v0**            | 0       | Deferred |
+| `⟨g²⟩`           | `median(heat_proxy / on_track_s)`        | `(track, car)` — lookup, not fit  | ~6      | From data |
+| `lap_time_typ_s` | `median(on_track_s)`                     | `(track, car)` — lookup, not fit  | ~6      | From data |
+| `T_road`         | logger / weather + sun proxy             | per-session                       | 0       | From data |
+
+**Total fitted: ~20 parameters** across the entire dataset (8 K + 8 τ_sec +
+~4 c_track). Compare to a per-(track, car, lap) regression approach which
+would have hundreds. The energy-balance framing means the **track-aggressiveness
+signal is captured by ⟨g²⟩ data, not by a fitted constant** — that's why the
+model is track-independent at fit time and only enters the prediction via
+data lookups.
+
+### 2.6 Fitting procedure
+
+Two-pass non-linear least squares using `scipy.optimize.curve_fit` against
+per-lap aggregates from `laps.parquet`:
+
+1. **Pass 1 — `τ_sec[car, corner]` + per-bucket gains.** For each (car, corner),
+   select that car's (track) buckets with ≥ 30 lap samples. Fit jointly across
+   them: `δT_i = gain_{bucket(i)} · (1 − exp(−t_i / τ_sec))` with a shared
+   `τ_sec[car, corner]` and bucket-specific `gain_b = K · c_track · ⟨g²⟩`.
+   KK-SII FL τ is fit jointly from Tsukuba (326 laps) + Fuji (71 laps) data —
+   precisely the cross-circuit shrinkage we want.
+
+2. **Pass 2 — factor `gain_b` into `K[car, corner] × c_track[track]`.** Divide
+   out ⟨g²⟩ (a lookup) and use alternating least squares in log-space, with
+   `c_track[tsukuba_2000] ≡ 1.0` anchored for identifiability. Standard errors
+   propagate from Pass 1's bucket-gain stderrs.
+
+If a (car, corner) bucket has fewer than `MIN_LAPS_FOR_TAU_FIT = 30` lap
+samples, the fit returns the prior `τ_sec = 240 s, K = 60 K/G²` with
+`from_prior: true` flagged in the artifact.
+
+### 2.7 Artifact: `tire_model.json`
+
+The model serializes to a versioned JSON committed under
+`data/tire_dataset/tire_model.json`. Six top-level tables, one per physical
+quantity in the energy balance:
+
+- `tau_sec_by_car_corner` — 8 entries with stderrs
+- `K_buckets` — 8 entries with stderrs and `from_single_track` flags
+- `c_track_by_track` — per-track surface scalars, Tsukuba marked as anchor
+- `g2_typ_by_track_car` — lookup
+- `lap_time_typ_by_track_car` — lookup
+- `energy_balance` — the `w_road` config + T_road proxy formula
+- `sensor_blacklist_applied` — audit trail of masked (session, corner) pairs
+- `fallback_order_for_K` — declarative fallback chain
+
+Typical file size: 6–12 KB. Diff-friendly — when new sessions land, the
+artifact updates in lockstep and the JSON diff shows reviewers exactly which
+buckets gained samples or changed coefficients. The C# calculator (future
+plan) reads the same file.
+
+### 2.8 Sensor blacklist (human-curated)
+
+`just tire-sensor-audit` auto-detects (session, corner) channels whose TPMS
+temperature has std < 1.0 °C across ≥ 4 usable laps (i.e. the sensor looks
+stuck) and presents them for human review. **No auto-masking.** Confirmed
+broken entries get added to a committed YAML file
+(`data/tire_dataset/sensor_blacklist.yaml`); the build pipeline reads that
+file and masks those channels from training and held-out evaluation alike.
+
+The v0 dataset has 8 stuck-at-X channels confirmed via this workflow:
+
+| session | car | track | date | corner | stuck at |
+|---|---|---|---|---|---|
+| `01811fbc44ee4dcb` | Inferno 86 | fuji | 2025-07-07 | RL | 28 °C |
+| `1cd906c9ecf27b24` | KK-SII | fuji | 2026-02-25 | RR | 12 °C |
+| `034b6b78a440fe3a` | KK-SII | fuji | 2026-02-26 | RR | 13 °C |
+| `1efdf17c42265ba9` | KK-SII | fuji | 2026-02-26 | RR | 13 °C |
+| `bbe7b51bd428f5a0` | KK-SII | fuji | 2026-02-26 | RR | 13 °C |
+| `d3bf612415fb31ba` | KK-SII | fuji | 2026-02-26 | RR | 14 °C |
+| `42a95638e6bd528b` | KK-SII | tsukuba | 2026-03-22 | RL | 41 °C |
+| `cd9aaae0b59ff389` | KK-SII | tsukuba | 2026-03-22 | RL | 41 °C |
+
+KK-SII RR appears to have had **a single bad sensor that ran across 5
+consecutive Fuji sessions on 2026-02-25/26**, and KK-SII RL had a similar
+recurring failure across **2 Tsukuba sessions on 2026-03-22**.
+
+## 3. Test methodology
+
+### 3.1 Two distinct validations
+
+- **`tire-predict-validate`** — compares predicted cold pressures against
+  notes-recorded cold pressures from `notes_matches.parquet` (79 sessions
+  with logged cold pressures from run notes). Uses the production
+  (full-data) model. This is a **consistency check**, not a held-out test —
+  the model was trained on these sessions too.
+- **`tire-predict-holdout`** — the honest generalization measure. Excludes
+  N=2 sessions per (track, car) bucket from training, predicts per-lap
+  T_hot for those sessions, reports per-corner residuals. **No training on
+  the test set.**
+
+### 3.2 Held-out test design
+
+- **Bucket selection.** Only (track, car) buckets with ≥ 10 sessions are
+  eligible (Tsukuba KK-SII: 34, Sodegaura Inferno 86: 30, Fuji Inferno 86:
+  21, Fuji KK-SII: 11). Tsukuba Inferno 86 (7 sessions) and Motegi Inferno
+  86 (4 sessions) are too sparse to safely exclude from.
+- **Session picking.** For each eligible bucket, the first 2 session_ids
+  in sort order are held out. Deterministic, reproducible.
+- **Lap filtering.** Out-laps (`lap_within_stint == 0`) are excluded since
+  they're cold-start points, not warmup-curve observations. Same convention
+  as training.
+- **Blacklist applied.** Confirmed broken sensors are masked in both
+  training and evaluation — we don't grade the model against channels we
+  already know are broken.
+- **Metric.** Per-corner per-lap **T_hot residual** (predicted minus
+  observed end-of-lap TPMS temperature). MAE, RMSE, and mean signed bias
+  reported per corner. T_hot is the right metric because everything
+  downstream (Gay-Lussac, cold pressure) is a deterministic transform of
+  it — predict T_hot well and the cold pressure is right.
+
+### 3.3 What MAE in T_hot translates to in cold pressure
+
+For target hot 1.9 bar (gauge), air 18 °C, T_hot ≈ 50–60 °C, the Gay-Lussac
+inversion has
+
+```
+|∂P_cold / ∂T_hot|  ≈  (P_hot + 1) · T_cold_K / T_hot_K²  ≈  0.025 bar / °C
+```
+
+so an MAE of 2 °C in T_hot → roughly 0.05 bar in cold pressure (~0.7 psi).
+An MAE of 4 °C → ~0.10 bar (~1.5 psi).
+
+## 4. Results
+
+### 4.1 Headline (held-out, pooled, 236 (lap × corner) points)
+
+| Corner | MAE | RMSE | mean bias | n |
+|---|---|---|---|---|
+| FL | 3.01 °C | 3.72 °C | +0.09 °C | 61 |
+| FR | 2.99 °C | 3.71 °C | +0.19 °C | 61 |
+| RL | 2.77 °C | 3.98 °C | −0.51 °C | 53 |
+| RR | 2.65 °C | 3.49 °C | −0.84 °C | 61 |
+
+Pooled MAE ~3 °C ↔ ~±0.075 bar cold-pressure precision per corner.
+
+### 4.2 Per-car breakdown — the cars are in very different regimes
+
+#### KK-SII (excellent)
+
+| Corner | MAE | RMSE | mean bias | n |
+|---|---|---|---|---|
+| FL | **1.48 °C** | 1.81 °C | +1.18 °C | 30 |
+| FR | **1.94 °C** | 2.31 °C | +1.92 °C | 30 |
+| RL | **0.90 °C** | 1.30 °C | +0.53 °C | 30 |
+| RR | **1.07 °C** | 1.36 °C | +0.07 °C | 30 |
+
+MAE 0.9–1.9 °C ↔ ~±0.03 bar cold-pressure precision. The model is
+essentially right for this car. Small positive bias (+0.07 to +1.92 °C)
+means we slightly under-predict warmup — likely the 2026-02-25 cold-day
+session whose three borderline corners survived the blacklist as
+"plausibly real" pulled mean K down a touch.
+
+#### Inferno 86 (acceptable but markedly worse)
+
+| Corner | MAE | RMSE | mean bias | n |
+|---|---|---|---|---|
+| FL | 4.49 °C | 4.91 °C | −0.97 °C | 31 |
+| FR | 4.00 °C | 4.69 °C | −1.48 °C | 31 |
+| RL | 5.20 °C | 5.86 °C | −1.86 °C | 23 |
+| RR | 4.17 °C | 4.71 °C | −1.72 °C | 31 |
+
+MAE 4–5 °C ↔ ~±0.10 bar cold-pressure precision. The systematic **negative
+bias on every corner (−1.0 to −1.9 °C)** is the telling signal: we're
+consistently over-predicting T_hot for held-out Inferno 86 sessions.
+Hypothesized causes:
+
+- Inferno 86 trains on data from 4 tracks vs KK-SII's 2 — wider variance
+  across driving styles + track surfaces, more for c_track to absorb.
+- Several Inferno 86 sessions have very short stint counts; the K · c_track
+  decomposition is poorly constrained in those buckets.
+
+### 4.3 Fitted parameter values (sanity check against physics)
+
+```
+=== τ_sec by (car, corner) ===                  === K by (car, corner) ===
+     Inferno 86 fl  τ=249 ± 14 s                     Inferno 86 fl  K=70.4 ± 2.85
+     Inferno 86 fr  τ=229 ± 12 s                     Inferno 86 fr  K=61.7 ± 1.10
+     Inferno 86 rl  τ=300 ± 19 s                     Inferno 86 rl  K=64.3 ± 1.71
+     Inferno 86 rr  τ=275 ± 16 s                     Inferno 86 rr  K=58.5 ± 1.60
+         KK-SII fl  τ=211 ± 14 s                         KK-SII fl  K=29.2 ± 0.04
+         KK-SII fr  τ=187 ± 14 s                         KK-SII fr  K=23.0 ± 1.11
+         KK-SII rl  τ=220 ± 20 s                         KK-SII rl  K=24.9 ± 0.08
+         KK-SII rr  τ=231 ± 16 s                         KK-SII rr  K=25.6 ± 0.00
+
+=== c_track ===
+         tsukuba_2000  c=1.000 (anchor)
+             sodegaura c=0.968 ± 0.019
+                  fuji c=1.273 ± 0.037
+```
+
+- **τ in 187–300 s** range — literature-typical for racing tires; rears
+  consistently longer than fronts (more thermal mass, less brake heat),
+  which matches physical intuition.
+- **K in 23–70 K/G²** — Inferno 86 generates roughly 2.5× the steady-state
+  ΔT per unit G² as KK-SII. Makes sense given the Inferno 86 is heavier
+  with more downforce and runs slicks; KK-SII is a lighter formula car
+  with a different compound family.
+- **c_track[fuji] = 1.27** — Fuji's faster, wider corners generate more
+  load per unit of measured G² (sustained high-G sweepers vs Tsukuba's
+  short heavy hits). The model is capturing this.
+
+### 4.4 Effect of the sensor blacklist
+
+Before applying the 8-entry blacklist, the held-out validation produced:
+
+| Corner | MAE pre-blacklist | MAE post-blacklist | Improvement |
+|---|---|---|---|
+| FL | 4.00 °C | 3.01 °C | 25% |
+| FR | 4.21 °C | 2.99 °C | 29% |
+| RL | **7.57 °C** | **2.77 °C** | **63%** |
+| RR | **7.72 °C** | **2.65 °C** | **66%** |
+
+The dramatic 60+% improvement on RL/RR came from removing the stuck-at-X
+training data that was pulling K down. Most starkly: **KK-SII RR went from
+`K = 13 ± 8.77` (fit on broken stuck-at-13 data) to `K = 25.6` (sensible,
+matching the other corners)**.
+
+## 5. Limitations + ideas for next steps
+
+In rough priority order:
+
+### v0.1 — same architecture, better data hygiene
+
+1. **Tighten the borderline blacklist.** The audit surfaced 6 borderline
+   candidates (std 0.4–0.9 °C) we left in. Some, like the 2026-02-25
+   cold-day FL/FR/RL on `1cd906c9ecf27b24`, might genuinely be valid
+   short-warmup data; others might be intermittent sensor issues. Manual
+   inspection of the per-lap traces would settle it.
+2. **Track-canonical cleanup.** 46 Inferno 86 sessions have
+   `track_canonical = None` because the filename track string didn't
+   normalize. Recovering even half of those would meaningfully shrink the
+   Inferno 86 held-out variance.
+3. **Per-(track, car) breakdown of the held-out report.** Right now we see
+   per-car residuals; splitting further by track would tell us whether
+   Inferno 86's worse fit is uniformly bad or concentrated at one venue
+   (e.g., Sodegaura has 232 usable laps but might be biasing).
+
+### v0.2 — model refinements that don't change the architecture
+
+4. **Validate against notes-recorded cold pressures.** `tire-predict-validate`
+   exists but I haven't reported its number in this v0 — it would tell us
+   whether the T_hot fit translates to real-world cold-pressure accuracy as
+   the Gay-Lussac sensitivity analysis predicts.
+5. **Fit `w_road`.** Currently fixed at 0.2 from a physical prior. Even with
+   sparse logger-T_road coverage, a single global `w_road` could be fit
+   jointly with K + c_track + τ — the worst that happens is the optimizer
+   stays close to 0.2 and we learn nothing, but we get an honest standard
+   error on it.
+6. **T_road sun-factor refinement.** Currently 1.0 globally. A
+   latitude/time-of-day-aware factor would matter for Japan summer/winter
+   contrast — a simple lookup by month + venue lat would do it.
+
+### v1 — bigger architecture changes
+
+7. **Within-lap fitting.** Use the per-sample `timeseries/*.parquet` data
+   (already committed) to fit the discretized ODE step-by-step instead of
+   the per-lap aggregate closed-form. The same K and τ values come out but
+   with much smaller stderr because we use ~thousands of samples per
+   session instead of one number per lap. Also opens the door to within-lap
+   T_hot predictions ("what's my FL temp at t=180 s into lap 3?"). The
+   discretized recurrence is already implemented and tested in
+   `energy_balance.py`.
+8. **Hierarchical / Bayesian partial pooling.** Sparse (car, corner) buckets
+   would benefit from shrinking toward a global mean — Motegi Inferno 86
+   has only 18 usable laps. NumPyro Stage-2 partial pooling over scipy
+   Stage-1 per-bucket fits is the canonical move. Probably worth doing
+   once we have ≥ 3 cars in the dataset; with 2 cars, the Stage-2 prior is
+   too narrow to learn much.
+9. **Re-introduce tire compound.** When notes have ≥ 80% compound coverage
+   with consistent normalization (or AIM logger reads compound RFID
+   directly), and we have multiple compounds at the same (car, track) for
+   identifiability, compound can come back as a `K[car, compound, corner]`
+   dimension. v0 explicitly omits it.
+
+### v2 — calculator integration
+
+10. **C# calculator integration.** The committed `tire_model.json` is the
+    integration hand-off. A follow-up plan adds:
+    1. A versioned JSON loader on the C# side, sanity-checking
+       `schema_version` and the Gay-Lussac block matches the calculator's
+       own constants.
+    2. UI inputs for track + car + lap + cloud cover.
+    3. Auto-fill of the per-corner cold-pressure fields from the model
+       prediction (still overridable).
+
+## 6. CLI reference
+
+```bash
+# Detect candidate broken TPMS sensors (low-variance channels). Human-curated.
+just tire-sensor-audit
+
+# Fit the energy-balance model and write both artifacts
+just tire-build-warmup-table
+
+# Predict per-corner cold pressures for a target lap
+just tire-predict --track tsukuba_2000 --car KK-SII --lap 5 --ambient 18 --hot-all 1.95
+# (per-corner: --hot-fl 1.95 --hot-fr 1.95 --hot-rl 1.90 --hot-rr 1.90)
+# (optional: --track-temp 35 --cloud-cover 30 --g2-typ 0.85 --lap-time-s 70)
+
+# Held-out validation (train without N sessions per bucket, report per-corner T_hot residuals)
+just tire-predict-holdout
+# (--n-per-bucket 2 --min-bucket-size 10)
+
+# Validate against notes-recorded cold pressures (consistency check, not held-out)
+just tire-predict-validate
+```
+
+## 7. Files of interest
+
+| Path | What |
+|---|---|
+| `src/motorsports_data_notebook/tire_model/energy_balance.py` | Pure physics functions (T_eff, warmup_curve, Gay-Lussac, T_road proxy, discretized recurrence) |
+| `src/motorsports_data_notebook/tire_model/warmup_table.py` | Data prep + two-pass scipy fit + JSON serializer + sensor audit + blacklist |
+| `src/motorsports_data_notebook/tire_model/predict.py` | `predict_cold_pressure(...)` and the fallback chain for K / τ / c_track / ⟨g²⟩ |
+| `src/motorsports_data_notebook/tire_model/validate.py` | `tire-predict-validate` (notes-recorded ground truth) and `tire-predict-holdout` (held-out generalization test) |
+| `data/tire_dataset/tire_model.json` | The committed fitted artifact (~6–12 KB, diff-friendly) |
+| `data/tire_dataset/sensor_blacklist.yaml` | Human-curated list of broken (session, corner) channels |
+| `tests/tire_model/test_energy_balance.py` | Physics functions in isolation |
+| `tests/tire_model/test_warmup_table.py` | Synthetic-data round-trip: known K, τ, c_track → fit → recover |
+| `tests/tire_model/test_predict.py` | Fallback chain hits every level with mocked artifacts |

--- a/justfile
+++ b/justfile
@@ -58,6 +58,26 @@ tire-query SQL:
 # Run all three phases in order (full refresh)
 tire-refresh: tire-etl tire-notes tire-weather
 
+# Detect candidate broken TPMS sensors (low-variance channels) for human review
+tire-sensor-audit *ARGS:
+    uv run python -m motorsports_data_notebook.tire_model.cli audit-sensors {{ARGS}}
+
+# Fit the energy-balance tire warmup model from the committed dataset
+tire-build-warmup-table *ARGS:
+    uv run python -m motorsports_data_notebook.tire_model.cli build-warmup-table {{ARGS}}
+
+# Predict per-corner cold pressures (see `tire-predict --help`)
+tire-predict *ARGS:
+    uv run python -m motorsports_data_notebook.tire_model.cli predict {{ARGS}}
+
+# Per-corner MAE report vs. notes-recorded cold pressures (uses production model)
+tire-predict-validate *ARGS:
+    uv run python -m motorsports_data_notebook.tire_model.cli validate {{ARGS}}
+
+# Held-out validation: train without N sessions, predict per-lap T_hot, report residuals
+tire-predict-holdout *ARGS:
+    uv run python -m motorsports_data_notebook.tire_model.cli holdout {{ARGS}}
+
 # Emscripten SDK setup (one-time, needed for building libxrk Pyodide wheel)
 setup-emsdk:
     #!/usr/bin/env bash

--- a/scripts/tire_predict.py
+++ b/scripts/tire_predict.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Thin wrapper around motorsports_data_notebook.tire_model.cli for scripting."""
+
+from __future__ import annotations
+
+import sys
+
+from motorsports_data_notebook.tire_model.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/motorsports_data_notebook/tire_model/__init__.py
+++ b/src/motorsports_data_notebook/tire_model/__init__.py
@@ -12,11 +12,14 @@ from .energy_balance import (
     t_road_proxy_c,
     warmup_curve_c,
 )
+from .predict import Prediction, predict_cold_pressure
 from .warmup_table import build_warmup_table
 
 __all__ = [
+    "Prediction",
     "build_warmup_table",
     "gay_lussac_cold_pressure_bar",
+    "predict_cold_pressure",
     "t_effective_c",
     "t_road_proxy_c",
     "warmup_curve_c",

--- a/src/motorsports_data_notebook/tire_model/cli.py
+++ b/src/motorsports_data_notebook/tire_model/cli.py
@@ -1,0 +1,332 @@
+"""CLI for the tire warmup model: build-warmup-table, predict, validate."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from ..tire_etl.paths import default_dataset_root
+from .predict import CORNERS, Prediction, predict_cold_pressure
+from .warmup_table import build_warmup_table
+
+logger = logging.getLogger(__name__)
+
+
+def _add_dataset_root_arg(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--dataset-root",
+        type=Path,
+        default=None,
+        help="Override the dataset root (defaults to repo data/tire_dataset).",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="tire-model", description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_build = sub.add_parser(
+        "build-warmup-table",
+        help="Fit the energy-balance model and write tire_model.json + warmup_table.parquet.",
+    )
+    _add_dataset_root_arg(p_build)
+    p_build.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="Force rebuild (currently always rebuilds; flag reserved for future)",
+    )
+
+    p_predict = sub.add_parser(
+        "predict",
+        help="Predict per-corner cold pressures for a target lap.",
+    )
+    _add_dataset_root_arg(p_predict)
+    p_predict.add_argument("--track", required=True)
+    p_predict.add_argument("--car", required=True)
+    p_predict.add_argument(
+        "--lap",
+        type=int,
+        required=True,
+        help="Target lap_within_stint (0 = out-lap; 5 = 5 laps in).",
+    )
+    p_predict.add_argument(
+        "--ambient", type=float, required=True, help="Ambient air temperature in °C."
+    )
+    p_predict.add_argument(
+        "--track-temp",
+        type=float,
+        default=None,
+        help="Optional measured track-surface temperature in °C.",
+    )
+    p_predict.add_argument(
+        "--cloud-cover",
+        type=float,
+        default=None,
+        help="0..100; used only if --track-temp is omitted.",
+    )
+    p_predict.add_argument(
+        "--g2-typ",
+        type=float,
+        default=None,
+        help="Override the looked-up <g²> for this (track, car).",
+    )
+    p_predict.add_argument(
+        "--lap-time-s",
+        type=float,
+        default=None,
+        help="Override the looked-up median lap time in seconds.",
+    )
+    group = p_predict.add_argument_group("Target hot pressures (bar gauge)")
+    group.add_argument(
+        "--hot-all", type=float, default=None, help="Shorthand: same target for all 4 corners."
+    )
+    group.add_argument("--hot-fl", type=float, default=None)
+    group.add_argument("--hot-fr", type=float, default=None)
+    group.add_argument("--hot-rl", type=float, default=None)
+    group.add_argument("--hot-rr", type=float, default=None)
+
+    p_validate = sub.add_parser(
+        "validate",
+        help="MAE report vs. notes-recorded cold pressures (uses production model).",
+    )
+    _add_dataset_root_arg(p_validate)
+
+    p_audit = sub.add_parser(
+        "audit-sensors",
+        help=(
+            "Detect (session, corner) channels that look stuck/broken (low std). "
+            "Lists candidates with evidence; you decide which to add to sensor_blacklist.yaml."
+        ),
+    )
+    _add_dataset_root_arg(p_audit)
+
+    p_holdout = sub.add_parser(
+        "holdout",
+        help="Held-out validation: exclude sessions from training, predict per-lap T_hot, report residuals.",
+    )
+    _add_dataset_root_arg(p_holdout)
+    p_holdout.add_argument(
+        "--n-per-bucket",
+        type=int,
+        default=2,
+        help="Number of held-out sessions per (track, car) bucket.",
+    )
+    p_holdout.add_argument(
+        "--min-bucket-size",
+        type=int,
+        default=10,
+        help="Only hold out from buckets with at least this many sessions.",
+    )
+
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.cmd == "build-warmup-table":
+        return _cmd_build(args)
+    if args.cmd == "predict":
+        return _cmd_predict(args)
+    if args.cmd == "validate":
+        return _cmd_validate(args)
+    if args.cmd == "holdout":
+        return _cmd_holdout(args)
+    if args.cmd == "audit-sensors":
+        return _cmd_audit_sensors(args)
+    parser.print_help()
+    return 2
+
+
+def _cmd_build(args: argparse.Namespace) -> int:
+    root = args.dataset_root or default_dataset_root()
+    logger.info("Building tire model artifacts at %s", root)
+    model = build_warmup_table(root, rebuild=args.rebuild)
+    n_k = len(model["K_buckets"])
+    n_tau = len(model["tau_sec_by_car_corner"])
+    n_c = len(model["c_track_by_track"])
+    logger.info(
+        "Wrote tire_model.json + warmup_table.parquet: %d K, %d τ, %d c_track entries",
+        n_k,
+        n_tau,
+        n_c,
+    )
+    return 0
+
+
+def _resolve_hot_pressures(args: argparse.Namespace) -> dict[str, float]:
+    if args.hot_all is not None:
+        return {c: float(args.hot_all) for c in CORNERS}
+    by_corner = {
+        "fl": args.hot_fl,
+        "fr": args.hot_fr,
+        "rl": args.hot_rl,
+        "rr": args.hot_rr,
+    }
+    missing = [c for c, v in by_corner.items() if v is None]
+    if missing:
+        raise SystemExit(
+            f"Must provide --hot-all OR all of --hot-fl/--hot-fr/--hot-rl/--hot-rr; missing: {missing}"
+        )
+    return {c: float(v) for c, v in by_corner.items()}
+
+
+def _cmd_predict(args: argparse.Namespace) -> int:
+    targets = _resolve_hot_pressures(args)
+    result = predict_cold_pressure(
+        track=args.track,
+        car=args.car,
+        lap_within_stint=args.lap,
+        target_hot_pressure_bar=targets,
+        ambient_temp_c=args.ambient,
+        track_temp_c=args.track_temp,
+        cloud_cover_pct=args.cloud_cover,
+        g2_typ_override=args.g2_typ,
+        lap_time_typ_override_s=args.lap_time_s,
+        dataset_root=args.dataset_root,
+    )
+    _print_prediction(result, args)
+    return 0
+
+
+def _print_prediction(result: dict[str, Prediction], args: argparse.Namespace) -> None:
+    # Header from the first corner (all share track-level lookups)
+    any_p = next(iter(result.values()))
+    print(
+        f"Track:        {args.track:<20} c_track = {any_p.c_track:.2f}"
+        f" ± {any_p.c_track_stderr:.3f}     ⟨g²⟩ = {any_p.g2_typ:.2f} G²"
+    )
+    print(f"Car:          {args.car:<20} lap_time_typ = {any_p.lap_time_typ_s:.1f} s")
+    print(f"                                  t at lap {args.lap} = {any_p.t_at_lap_n_s:.1f} s")
+    print(
+        f"T_air = {any_p.t_air_c:.1f} °C    T_road = {any_p.t_road_c:.1f} °C    "
+        f"T_eff = {any_p.t_eff_c:.1f} °C (w_road=0.20)"
+    )
+    print()
+    header = (
+        f"{'Corner':6} {'K(K/G²)':>9} {'τ_sec(s)':>9} {'warmup':>7} {'ΔT∞(K)':>8} "
+        f"{'HotT(°C)':>9} {'HotIn(bar)':>11} {'Cold(bar)':>10} {'±(bar)':>7} "
+        f"{'K source':<18} {'n':>4}"
+    )
+    print(header)
+    for c in CORNERS:
+        p = result[c]
+        # Propagate uncertainty: dominant term is K stderr × c_track × g²
+        dT_inf_stderr = p.K_stderr * p.c_track * p.g2_typ
+        # Roughly: |dCold/dT_hot| · stderr of T_hot
+        t_hot_k = p.predicted_hot_temp_c + 273.15
+        t_cold_k = p.t_air_c + 273.15
+        # P_cold = (HotIn+1) · T_cold_K / T_hot_K  →  ∂/∂T_hot = -(HotIn+1) · T_cold_K / T_hot_K²
+        d_cold_d_thot = -(p.target_hot_pressure_bar + 1.0) * t_cold_k / (t_hot_k**2)
+        cold_stderr = abs(d_cold_d_thot) * (dT_inf_stderr * p.warmup_frac)
+        src = ",".join(p.K_source_bucket) if p.K_source_bucket else "prior"
+        print(
+            f"{c.upper():6} {p.K_kelvin_per_g2:>9.1f} {p.tau_sec:>9.0f} {p.warmup_frac:>7.2f} "
+            f"{p.delta_t_inf_kelvin:>8.1f} {p.predicted_hot_temp_c:>9.1f} "
+            f"{p.target_hot_pressure_bar:>11.3f} {p.cold_pressure_bar:>10.3f} "
+            f"{cold_stderr:>7.3f} ({src})".ljust(0) + f"{'':<4}{p.K_n_samples:>4}"
+        )
+    print()
+    print("ΔT_∞ = K · c_track · ⟨g²⟩       Hot T = T_eff + ΔT_∞ · warmup_frac")
+    print("Cold  = (HotIn + 1)·(T_air+273)/(HotT+273) − 1")
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    from .validate import run_validation  # local import keeps CLI cold-load fast
+
+    return run_validation(dataset_root=args.dataset_root)
+
+
+def _cmd_holdout(args: argparse.Namespace) -> int:
+    from .validate import run_holdout_validation
+
+    return run_holdout_validation(
+        dataset_root=args.dataset_root,
+        n_per_bucket=args.n_per_bucket,
+        min_bucket_size=args.min_bucket_size,
+    )
+
+
+def _cmd_audit_sensors(args: argparse.Namespace) -> int:
+    """Detect candidate broken sensors and print them for human review."""
+    from .warmup_table import (
+        _attach_weather,
+        _compute_stint_clock,
+        _load_filtered_laps,
+        _load_weather,
+        detect_suspect_corners,
+        load_sensor_blacklist,
+    )
+
+    root = args.dataset_root or default_dataset_root()
+    laps = _load_filtered_laps(root)
+    laps = _attach_weather(laps, _load_weather(root))
+    laps = _compute_stint_clock(laps)
+    candidates = detect_suspect_corners(laps)
+
+    blacklisted = load_sensor_blacklist(root)
+
+    if candidates.empty:
+        print("No suspect (session, corner) channels detected.")
+        return 0
+
+    print(f"=== Sensor audit: {len(candidates)} candidate (session, corner) channels ===")
+    print(
+        "Heuristic: tpms_temp_{c}_end has std < 1.0 °C across ≥ 4 tire-usable laps "
+        "(channel looks stuck)."
+    )
+    print(
+        "Review each entry; add confirmed broken ones to "
+        "`data/tire_dataset/sensor_blacklist.yaml` to exclude from training."
+    )
+    print()
+    candidates = candidates.sort_values(["car", "track_canonical", "date", "session_id", "corner"])
+
+    import pandas as _pd
+
+    _pd.set_option("display.width", 240)
+    _pd.set_option("display.max_columns", 30)
+    _pd.set_option("display.max_colwidth", 80)
+    # Show whether each candidate is already in the blacklist
+    candidates = candidates.copy()
+    candidates["already_blacklisted"] = [
+        (sid, c) in blacklisted for sid, c in zip(candidates["session_id"], candidates["corner"])
+    ]
+    cols = [
+        "session_id",
+        "car",
+        "track_canonical",
+        "date",
+        "corner",
+        "n_laps",
+        "std_c",
+        "min_c",
+        "max_c",
+        "mean_c",
+        "first_5_values",
+        "already_blacklisted",
+    ]
+    print(candidates[cols].to_string(index=False))
+    print()
+    n_new = int((~candidates["already_blacklisted"]).sum())
+    n_known = int(candidates["already_blacklisted"].sum())
+    print(f"  {n_new} not yet in sensor_blacklist.yaml    {n_known} already blacklisted")
+    print()
+    if n_new > 0:
+        print("Suggested YAML entries (copy into data/tire_dataset/sensor_blacklist.yaml):")
+        print()
+        for _, row in candidates[~candidates["already_blacklisted"]].iterrows():
+            print(f"  - session_id: {row['session_id']}")
+            print(f"    corner: {row['corner']}")
+            print(
+                f"    reason: \"std={row['std_c']:.2f} °C across {row['n_laps']} laps "
+                f"(min={row['min_c']:.1f}, max={row['max_c']:.1f})\""
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/motorsports_data_notebook/tire_model/predict.py
+++ b/src/motorsports_data_notebook/tire_model/predict.py
@@ -1,0 +1,270 @@
+"""Inference: turn (track, car, lap, ambient, target hot pressures) → cold pressures.
+
+Reads the JSON artifact written by :func:`build_warmup_table`, applies the
+fallback chain documented in the plan (K[car, corner] → K[car] → global; track
+falls back to ``c_track = 1.0``; ⟨g²⟩ falls back to (track) mean → global), and
+returns per-corner :class:`Prediction` records with full provenance.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from ..tire_etl.paths import default_dataset_root
+from .energy_balance import (
+    P_ATM_BAR,
+    T_ZERO_C_TO_K,
+    gay_lussac_cold_pressure_bar,
+    t_effective_c,
+    t_road_proxy_c,
+    warmup_curve_c,
+)
+
+CORNERS = ("fl", "fr", "rl", "rr")
+
+
+@dataclass(frozen=True)
+class Prediction:
+    corner: str
+    cold_pressure_bar: float
+    predicted_hot_temp_c: float
+    target_hot_pressure_bar: float
+    K_kelvin_per_g2: float
+    tau_sec: float
+    c_track: float
+    g2_typ: float
+    lap_time_typ_s: float
+    t_at_lap_n_s: float
+    warmup_frac: float
+    delta_t_inf_kelvin: float
+    t_eff_c: float
+    t_air_c: float
+    t_road_c: float
+    K_source_bucket: tuple[str, ...]
+    K_from_prior: bool
+    K_n_samples: int
+    K_stderr: float
+    tau_stderr: float
+    c_track_stderr: float
+
+
+def _load_model(dataset_root: Path | None) -> dict[str, Any]:
+    root = Path(dataset_root) if dataset_root else default_dataset_root()
+    artifact = root / "tire_model.json"
+    if not artifact.exists():
+        raise FileNotFoundError(
+            f"No tire_model.json at {artifact}. Run `just tire-build-warmup-table` first."
+        )
+    with artifact.open() as f:
+        model: dict[str, Any] = json.load(f)
+    return model
+
+
+def _lookup_tau(model: dict[str, Any], car: str, corner: str) -> tuple[float, float]:
+    for r in model["tau_sec_by_car_corner"]:
+        if r["car"] == car and r["corner"] == corner:
+            return float(r["value_seconds"]), float(r["stderr_seconds"])
+    # fallback to mean over (car) if any
+    same_car = [r for r in model["tau_sec_by_car_corner"] if r["car"] == car]
+    if same_car:
+        vals = [r["value_seconds"] for r in same_car]
+        return float(sum(vals) / len(vals)), 0.0
+    return float(model["priors_when_no_fit"]["tau_sec_seconds"]), 0.0
+
+
+def _lookup_k(
+    model: dict[str, Any], car: str, corner: str
+) -> tuple[float, float, int, bool, tuple[str, ...]]:
+    """Return (K, stderr, n_samples, from_prior, source_bucket_tuple)."""
+    for r in model["K_buckets"]:
+        if r["key"]["car"] == car and r["key"]["corner"] == corner:
+            return (
+                float(r["value_kelvin_per_g2"]),
+                float(r["stderr_kelvin_per_g2"]),
+                int(r["n_samples"]),
+                bool(r["from_prior"]),
+                (car, corner),
+            )
+    # (car) fallback: average K over corners
+    same_car = [r for r in model["K_buckets"] if r["key"]["car"] == car]
+    if same_car:
+        vals = [r["value_kelvin_per_g2"] for r in same_car]
+        n = sum(int(r["n_samples"]) for r in same_car)
+        return float(sum(vals) / len(vals)), 0.0, n, False, (car,)
+    # global fallback
+    prior_k = float(model["priors_when_no_fit"]["K_kelvin_per_g2"])
+    return prior_k, 0.0, 0, True, ()
+
+
+def _lookup_c_track(model: dict[str, Any], track: str) -> tuple[float, float, bool]:
+    """Return (c_track, stderr, from_prior)."""
+    for r in model["c_track_by_track"]:
+        if r["track_canonical"] == track:
+            return float(r["value"]), float(r["stderr"]), False
+    prior_c = float(model["priors_when_no_fit"]["c_track"])
+    return prior_c, 0.0, True
+
+
+def _lookup_g2(model: dict[str, Any], track: str, car: str) -> tuple[float, int, str]:
+    """Return (g2_typ, n_laps_used, source). Source is one of 'exact', 'track', 'global', 'override'."""
+    for r in model["g2_typ_by_track_car"]:
+        if r["track_canonical"] == track and r["car"] == car:
+            return float(r["g2_typ"]), int(r["n_laps_used"]), "exact"
+    same_track = [r for r in model["g2_typ_by_track_car"] if r["track_canonical"] == track]
+    if same_track:
+        vals = [r["g2_typ"] for r in same_track]
+        n = sum(int(r["n_laps_used"]) for r in same_track)
+        return float(sum(vals) / len(vals)), n, "track"
+    all_g2 = [r["g2_typ"] for r in model["g2_typ_by_track_car"]]
+    if all_g2:
+        return float(sum(all_g2) / len(all_g2)), 0, "global"
+    return 0.7, 0, "global"
+
+
+def _lookup_lap_time(model: dict[str, Any], track: str, car: str) -> tuple[float, int, str]:
+    for r in model["lap_time_typ_by_track_car"]:
+        if r["track_canonical"] == track and r["car"] == car:
+            return float(r["lap_time_typ_s"]), int(r["n_laps_used"]), "exact"
+    same_track = [r for r in model["lap_time_typ_by_track_car"] if r["track_canonical"] == track]
+    if same_track:
+        vals = [r["lap_time_typ_s"] for r in same_track]
+        n = sum(int(r["n_laps_used"]) for r in same_track)
+        return float(sum(vals) / len(vals)), n, "track"
+    return 90.0, 0, "global"
+
+
+def predict_cold_pressure(
+    *,
+    track: str,
+    car: str,
+    lap_within_stint: int,
+    target_hot_pressure_bar: dict[str, float],
+    ambient_temp_c: float,
+    track_temp_c: float | None = None,
+    cloud_cover_pct: float | None = None,
+    g2_typ_override: float | None = None,
+    lap_time_typ_override_s: float | None = None,
+    dataset_root: Path | None = None,
+    _model: dict[str, Any] | None = None,
+) -> dict[str, Prediction]:
+    """Predict per-corner cold pressure for a target lap.
+
+    Parameters
+    ----------
+    track
+        ``track_canonical`` string (e.g. ``"tsukuba_2000"``).
+    car
+        Car string as it appears in ``sessions/*.parquet`` (e.g. ``"KK-SII"``).
+    lap_within_stint
+        0-indexed lap number within a stint. ``5`` means "5 laps in" — the
+        prediction is at the END of that lap.
+    target_hot_pressure_bar
+        Dict keyed by corner ``{"fl", "fr", "rl", "rr"}``, values in bar gauge.
+    ambient_temp_c
+        Outside air temperature in °C (T_air for Gay-Lussac).
+    track_temp_c
+        Optional measured track surface temperature in °C. If ``None``, the
+        proxy ``T_air + Δ_sun · (1 - cloud_cover/100)`` is used (see
+        :func:`energy_balance.t_road_proxy_c`).
+    cloud_cover_pct
+        0..100, used only if ``track_temp_c is None``. ``None`` ⇒ no sun
+        offset (T_road = T_air).
+    g2_typ_override
+        Override the looked-up ⟨g²⟩ for the (track, car) bucket. Useful for
+        brand-new tracks.
+    lap_time_typ_override_s
+        Override the looked-up median lap time. Useful when the user wants a
+        race-pace prediction that differs from session median.
+    """
+    model = _model if _model is not None else _load_model(dataset_root)
+
+    # Lookups
+    g2_typ, g2_n, _g2_source = _lookup_g2(model, track, car)
+    if g2_typ_override is not None:
+        g2_typ = float(g2_typ_override)
+    lap_time_typ_s, lt_n, _lt_source = _lookup_lap_time(model, track, car)
+    if lap_time_typ_override_s is not None:
+        lap_time_typ_s = float(lap_time_typ_override_s)
+    c_track, c_track_stderr, _c_from_prior = _lookup_c_track(model, track)
+    w_road = float(model["energy_balance"]["w_road"])
+    sun_factor = float(model["energy_balance"]["t_road_proxy"].get("sun_factor_default", 1.0))
+    delta_sun_max_c = float(model["energy_balance"]["t_road_proxy"].get("delta_sun_max_c", 10.0))
+
+    # T_road sourcing
+    if track_temp_c is not None:
+        t_road_c = float(track_temp_c)
+    else:
+        t_road_c = t_road_proxy_c(
+            t_air_c=ambient_temp_c,
+            cloud_cover_pct=cloud_cover_pct,
+            sun_factor=sun_factor,
+            delta_sun_max_c=delta_sun_max_c,
+        )
+    t_eff_c = t_effective_c(t_air_c=ambient_temp_c, t_road_c=t_road_c, w_road=w_road)
+
+    # Time at end of lap N
+    t_at_lap_n_s = float(lap_within_stint) * lap_time_typ_s
+
+    out: dict[str, Prediction] = {}
+    for corner in CORNERS:
+        if corner not in target_hot_pressure_bar:
+            raise KeyError(f"target_hot_pressure_bar missing corner {corner!r}")
+        target_hot = float(target_hot_pressure_bar[corner])
+        K, K_stderr, K_n, K_from_prior, K_src = _lookup_k(model, car, corner)
+        tau_sec, tau_stderr = _lookup_tau(model, car, corner)
+
+        warmup_frac = 1.0 - math.exp(-t_at_lap_n_s / tau_sec) if tau_sec > 0 else 0.0
+        delta_t_inf = K * c_track * g2_typ
+        t_hot_c = warmup_curve_c(
+            t_seconds=t_at_lap_n_s,
+            t_eff_c=t_eff_c,
+            k_kelvin_per_g2=K,
+            c_track=c_track,
+            g2_typ=g2_typ,
+            tau_sec=tau_sec,
+        )
+        cold = gay_lussac_cold_pressure_bar(
+            target_hot_pressure_bar=target_hot,
+            t_hot_c=t_hot_c,
+            t_cold_c=ambient_temp_c,  # cold uses T_air only
+            p_atm_bar=P_ATM_BAR,
+        )
+
+        out[corner] = Prediction(
+            corner=corner,
+            cold_pressure_bar=cold,
+            predicted_hot_temp_c=t_hot_c,
+            target_hot_pressure_bar=target_hot,
+            K_kelvin_per_g2=K,
+            tau_sec=tau_sec,
+            c_track=c_track,
+            g2_typ=g2_typ,
+            lap_time_typ_s=lap_time_typ_s,
+            t_at_lap_n_s=t_at_lap_n_s,
+            warmup_frac=warmup_frac,
+            delta_t_inf_kelvin=delta_t_inf,
+            t_eff_c=t_eff_c,
+            t_air_c=ambient_temp_c,
+            t_road_c=t_road_c,
+            K_source_bucket=K_src,
+            K_from_prior=K_from_prior,
+            K_n_samples=K_n,
+            K_stderr=K_stderr,
+            tau_stderr=tau_stderr,
+            c_track_stderr=c_track_stderr,
+        )
+    return out
+
+
+def predict_cold_pressure_symmetric(
+    *,
+    target_hot_pressure_bar: float,
+    **kwargs: Any,
+) -> dict[str, Prediction]:
+    """Convenience: broadcast one hot-pressure target across all four corners."""
+    per_corner = {c: float(target_hot_pressure_bar) for c in CORNERS}
+    return predict_cold_pressure(target_hot_pressure_bar=per_corner, **kwargs)

--- a/src/motorsports_data_notebook/tire_model/validate.py
+++ b/src/motorsports_data_notebook/tire_model/validate.py
@@ -1,0 +1,339 @@
+"""Validation utilities for the tire warmup model.
+
+Two distinct validations:
+
+- :func:`run_validation` — compares predicted cold pressures against
+  notes-recorded cold pressures. Uses the production (full-data) model,
+  so this is a *consistency* check, not a held-out test.
+- :func:`run_holdout_validation` — held-out test. Excludes a few sessions
+  from training, then predicts per-lap T_hot for those sessions and
+  reports per-corner per-lap residuals. This is the honest measure of
+  generalization.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+
+from ..tire_etl.paths import default_dataset_root, laps_dir, sessions_dir
+from .energy_balance import (
+    t_effective_c,
+    t_road_proxy_c,
+    warmup_curve_c,
+)
+from .predict import CORNERS, predict_cold_pressure
+from .warmup_table import (
+    CORNERS as _WT_CORNERS,
+    W_ROAD,
+    build_warmup_table,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_validation(dataset_root: Path | None = None) -> int:
+    root = Path(dataset_root) if dataset_root else default_dataset_root()
+    notes_path = root / "notes_matches.parquet"
+    if not notes_path.exists():
+        logger.error("No notes_matches.parquet at %s", notes_path)
+        return 1
+    notes = pq.read_table(notes_path).to_pandas()
+    sessions = pd.concat(
+        [pq.read_table(f).to_pandas() for f in sorted(sessions_dir(root).glob("*.parquet"))],
+        ignore_index=True,
+    )
+    laps = pd.concat(
+        [pq.read_table(f).to_pandas() for f in sorted(laps_dir(root).glob("*.parquet"))],
+        ignore_index=True,
+    )
+
+    # Merge notes -> sessions for track/car/ambient
+    merged = notes.merge(
+        sessions[["session_id", "track_canonical", "car", "status", "has_tpms"]],
+        on="session_id",
+        how="left",
+    )
+    merged = merged[
+        (merged["status"] == "ok") & merged["has_tpms"] & merged["track_canonical"].notna()
+    ]
+
+    # Pre-cache model
+    with (root / "tire_model.json").open() as f:
+        model = json.load(f)
+
+    rows: list[dict] = []
+    for _, row in merged.iterrows():
+        actual = {c: row.get(f"cold_pressure_bar_{c}") for c in CORNERS}
+        if any(pd.isna(v) for v in actual.values()):
+            continue
+        # Target hot pressure: median of tpms_press_{c}_mean over mid-stint laps of this session
+        sess_laps = laps[(laps["session_id"] == row["session_id"]) & laps["tire_usable"]]
+        if sess_laps.empty:
+            continue
+        hot_targets: dict[str, float] = {}
+        skip = False
+        for c in CORNERS:
+            col = f"tpms_press_{c}_mean"
+            vals = sess_laps[col].dropna()
+            if vals.empty:
+                skip = True
+                break
+            hot_targets[c] = float(vals.median())
+        if skip:
+            continue
+        # Use lap 5 within stint as the representative warm point (or the median lap_within_stint)
+        # Use ambient from notes if present; else weather-derived from laps
+        ambient = row.get("ambient_temp_c")
+        if pd.isna(ambient):
+            continue
+        try:
+            pred = predict_cold_pressure(
+                track=row["track_canonical"],
+                car=row["car"],
+                lap_within_stint=5,
+                target_hot_pressure_bar=hot_targets,
+                ambient_temp_c=float(ambient),
+                dataset_root=root,
+                _model=model,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Skipping session %s: %s", row["session_id"], e)
+            continue
+        record = {
+            "session_id": row["session_id"],
+            "track": row["track_canonical"],
+            "car": row["car"],
+            "ambient_c": float(ambient),
+        }
+        for c in CORNERS:
+            record[f"actual_{c}"] = float(actual[c])
+            record[f"pred_{c}"] = float(pred[c].cold_pressure_bar)
+            record[f"resid_{c}"] = float(pred[c].cold_pressure_bar - actual[c])
+        rows.append(record)
+
+    if not rows:
+        print("No validation rows produced (no notes had complete actual + hot-pressure data).")
+        return 0
+    df = pd.DataFrame(rows)
+    print(f"Validation set: {len(df)} sessions\n")
+    for c in CORNERS:
+        resid = df[f"resid_{c}"]
+        mae = float(resid.abs().mean())
+        mean_bias = float(resid.mean())
+        print(
+            f"  {c.upper():3}  MAE = {mae:.3f} bar    "
+            f"mean signed residual = {mean_bias:+.3f} bar    "
+            f"(n={len(resid)})"
+        )
+
+    print("\nPer-session breakdown (first 15):")
+    cols = ["session_id", "track", "car", "ambient_c"]
+    for c in CORNERS:
+        cols += [f"actual_{c}", f"pred_{c}", f"resid_{c}"]
+    pd.set_option("display.width", 200)
+    pd.set_option("display.max_columns", 30)
+    print(df[cols].head(15).to_string(index=False))
+    return 0
+
+
+# ---------- Held-out (true generalization) validation ----------
+
+
+def _pick_holdout_sessions(
+    sessions: pd.DataFrame, laps: pd.DataFrame, n_per_bucket: int = 2, min_bucket_size: int = 10
+) -> list[str]:
+    """Pick deterministic held-out session_ids from each (track, car) bucket
+    that has enough sessions to afford excluding ``n_per_bucket`` without
+    breaking the fit.
+
+    Sorted by session_id for stability; takes the first ``n_per_bucket`` from
+    each eligible bucket.
+    """
+    ok = sessions[(sessions["status"] == "ok") & sessions["has_tpms"]]
+    ok = ok[ok["track_canonical"].notna() & ok["car"].notna()]
+    # Restrict to sessions that have at least 3 usable laps with TPMS data
+    usable_per_session = (
+        laps[laps["tire_usable"]].groupby("session_id").size().rename("n_usable_laps").reset_index()
+    )
+    ok = ok.merge(usable_per_session, on="session_id", how="left")
+    ok = ok[ok["n_usable_laps"].fillna(0) >= 3]
+
+    held_out: list[str] = []
+    for (track, car), grp in ok.groupby(["track_canonical", "car"]):
+        if len(grp) < min_bucket_size:
+            continue
+        chosen = sorted(grp["session_id"].tolist())[:n_per_bucket]
+        held_out.extend(chosen)
+    return held_out
+
+
+def run_holdout_validation(
+    dataset_root: Path | None = None,
+    *,
+    n_per_bucket: int = 2,
+    min_bucket_size: int = 10,
+) -> int:
+    """Train on all-minus-held-out, predict per-lap T_hot for held-out sessions.
+
+    Reports per-corner MAE / RMSE per session and a pooled summary.
+    """
+    root = Path(dataset_root) if dataset_root else default_dataset_root()
+    sessions = pd.concat(
+        [pq.read_table(f).to_pandas() for f in sorted(sessions_dir(root).glob("*.parquet"))],
+        ignore_index=True,
+    )
+    laps = pd.concat(
+        [pq.read_table(f).to_pandas() for f in sorted(laps_dir(root).glob("*.parquet"))],
+        ignore_index=True,
+    )
+
+    holdout_ids = _pick_holdout_sessions(
+        sessions, laps, n_per_bucket=n_per_bucket, min_bucket_size=min_bucket_size
+    )
+    if not holdout_ids:
+        print("No (track, car) bucket has enough sessions to hold out cleanly.")
+        return 1
+
+    print(
+        f"Holding out {len(holdout_ids)} sessions "
+        f"({n_per_bucket} per bucket, min bucket size = {min_bucket_size})"
+    )
+
+    # Train a model with the holdouts excluded
+    model = build_warmup_table(root, exclude_session_ids=set(holdout_ids), write_artifacts=False)
+
+    # Build per-(track, car) lookups from the held-out model
+    g2_lookup = {
+        (d["track_canonical"], d["car"]): d["g2_typ"] for d in model["g2_typ_by_track_car"]
+    }
+    c_track_lookup = {d["track_canonical"]: d["value"] for d in model["c_track_by_track"]}
+    k_lookup = {
+        (d["key"]["car"], d["key"]["corner"]): d["value_kelvin_per_g2"] for d in model["K_buckets"]
+    }
+    tau_lookup = {
+        (d["car"], d["corner"]): d["value_seconds"] for d in model["tau_sec_by_car_corner"]
+    }
+
+    # Build (session_id → ambient_temp_c) from weather attached during training prep.
+    # Simpler: re-run the same weather lookup logic for held-out sessions only.
+    from .warmup_table import (
+        _apply_blacklist,
+        _attach_weather,
+        _compute_delta_t,
+        _compute_stint_clock,
+        _load_filtered_laps,
+        _load_weather,
+        load_sensor_blacklist,
+    )
+
+    all_laps = _load_filtered_laps(root)
+    all_laps = all_laps[all_laps["session_id"].isin(holdout_ids)].copy()
+    if all_laps.empty:
+        print("Held-out sessions have no laps passing filters — nothing to evaluate.")
+        return 0
+    weather = _load_weather(root)
+    all_laps = _attach_weather(all_laps, weather)
+    all_laps = _compute_stint_clock(all_laps)
+    # Apply the same blacklist used at training — don't grade predictions
+    # against channels we already know are broken. Held-out laps are a
+    # subset, so most blacklist entries won't match — silence that noise.
+    blacklist_pairs = load_sensor_blacklist(root)
+    all_laps, _ = _apply_blacklist(all_laps, blacklist_pairs, warn_on_unknown=False)
+    all_laps = _compute_delta_t(all_laps)
+    # Drop out-laps from evaluation (same convention as training)
+    all_laps = all_laps[all_laps["lap_within_stint"] > 0].reset_index(drop=True)
+
+    # Per-lap predictions
+    rows: list[dict] = []
+    for _, lap in all_laps.iterrows():
+        track = lap["track_canonical"]
+        car = lap["car"]
+        t_cum_s = float(lap["t_cum_s"])
+        t_eff = float(lap["t_eff_c"]) if pd.notna(lap["t_eff_c"]) else None
+        if t_eff is None:
+            continue
+        g2 = g2_lookup.get((track, car))
+        if g2 is None:
+            continue
+        c_track = c_track_lookup.get(track, 1.0)
+        for c in CORNERS:
+            K = k_lookup.get((car, c))
+            tau = tau_lookup.get((car, c))
+            if K is None or tau is None:
+                continue
+            obs = lap.get(f"tpms_temp_{c}_end")
+            if pd.isna(obs):
+                continue
+            t_hot_pred = warmup_curve_c(
+                t_seconds=t_cum_s,
+                t_eff_c=t_eff,
+                k_kelvin_per_g2=K,
+                c_track=c_track,
+                g2_typ=g2,
+                tau_sec=tau,
+            )
+            rows.append(
+                {
+                    "session_id": lap["session_id"],
+                    "track": track,
+                    "car": car,
+                    "lap_num": int(lap["lap_num"]),
+                    "stint_id": int(lap["stint_id"]),
+                    "lap_within_stint": int(lap["lap_within_stint"]),
+                    "t_cum_s": t_cum_s,
+                    "corner": c,
+                    "T_hot_pred_c": t_hot_pred,
+                    "T_hot_obs_c": float(obs),
+                    "resid_c": t_hot_pred - float(obs),
+                }
+            )
+
+    if not rows:
+        print("No predictable laps in held-out set.")
+        return 0
+    df = pd.DataFrame(rows)
+
+    def _print_corner_table(label: str, frame: pd.DataFrame) -> None:
+        if frame.empty:
+            return
+        print(f"\n=== {label} ({len(frame)} (lap × corner) points) ===")
+        for c in CORNERS:
+            sub = frame[frame["corner"] == c]
+            if sub.empty:
+                continue
+            mae = float(sub["resid_c"].abs().mean())
+            rmse = float(np.sqrt((sub["resid_c"] ** 2).mean()))
+            bias = float(sub["resid_c"].mean())
+            print(
+                f"  {c.upper():>3}   MAE = {mae:>5.2f} °C   RMSE = {rmse:>5.2f} °C   "
+                f"mean bias = {bias:+.2f} °C    n = {len(sub)}"
+            )
+
+    _print_corner_table("Held-out per-corner T_hot residuals — POOLED", df)
+    for car_name, car_frame in df.groupby("car"):
+        _print_corner_table(f"Held-out — {car_name}", car_frame)
+
+    # Per-(session, lap) table
+    print("\n=== Per-(session, lap) breakdown ===")
+    pivot = df.pivot_table(
+        index=["session_id", "track", "car", "lap_num", "lap_within_stint", "t_cum_s"],
+        columns="corner",
+        values=["T_hot_pred_c", "T_hot_obs_c", "resid_c"],
+    )
+    pivot.columns = [f"{tup[0]}_{tup[1]}" for tup in pivot.columns]
+    pivot = pivot.reset_index().sort_values(["session_id", "lap_num"])
+    pd.set_option("display.width", 240)
+    pd.set_option("display.max_columns", 30)
+    pd.set_option("display.float_format", lambda x: f"{x:.1f}")
+    cols = ["session_id", "track", "car", "lap_num", "lap_within_stint", "t_cum_s"]
+    for c in CORNERS:
+        cols += [f"T_hot_obs_c_{c}", f"T_hot_pred_c_{c}", f"resid_c_{c}"]
+    print(pivot[cols].to_string(index=False))
+    return 0

--- a/tests/tire_model/test_cli.py
+++ b/tests/tire_model/test_cli.py
@@ -1,0 +1,120 @@
+"""Unit tests for the tire-model CLI argument parsing and helpers.
+
+These tests cover the argparse surface and the pure helpers in cli.py —
+not the subcommands themselves, which require a built model artifact
+and are exercised end-to-end by `just tire-build-warmup-table` +
+`just tire-predict-holdout`.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from motorsports_data_notebook.tire_model.cli import (
+    _resolve_hot_pressures,
+    main,
+)
+
+
+def _args(**kw: float | None) -> argparse.Namespace:
+    """Build a tiny Namespace with the hot-pressure fields _resolve_hot_pressures reads."""
+    return argparse.Namespace(
+        hot_all=kw.get("hot_all"),
+        hot_fl=kw.get("hot_fl"),
+        hot_fr=kw.get("hot_fr"),
+        hot_rl=kw.get("hot_rl"),
+        hot_rr=kw.get("hot_rr"),
+    )
+
+
+# ---------- _resolve_hot_pressures ----------
+
+
+def test_resolve_hot_pressures_all_shorthand_broadcasts() -> None:
+    out = _resolve_hot_pressures(_args(hot_all=1.95))
+    assert out == {"fl": 1.95, "fr": 1.95, "rl": 1.95, "rr": 1.95}
+
+
+def test_resolve_hot_pressures_per_corner_values() -> None:
+    out = _resolve_hot_pressures(_args(hot_fl=1.95, hot_fr=1.95, hot_rl=1.90, hot_rr=1.92))
+    assert out == {"fl": 1.95, "fr": 1.95, "rl": 1.90, "rr": 1.92}
+
+
+def test_resolve_hot_pressures_all_overrides_per_corner() -> None:
+    out = _resolve_hot_pressures(_args(hot_all=2.0, hot_fl=1.5, hot_fr=1.5, hot_rl=1.5, hot_rr=1.5))
+    assert out == {"fl": 2.0, "fr": 2.0, "rl": 2.0, "rr": 2.0}
+
+
+def test_resolve_hot_pressures_missing_corner_raises_systemexit() -> None:
+    # Neither --hot-all nor a complete set of per-corner values
+    with pytest.raises(SystemExit) as exc:
+        _resolve_hot_pressures(_args(hot_fl=1.95, hot_fr=1.95))
+    msg = str(exc.value)
+    # Should mention which corners are missing
+    assert "rl" in msg and "rr" in msg
+
+
+# ---------- CLI parser ----------
+
+
+def test_cli_no_args_errors() -> None:
+    """Calling main() with no subcommand should exit non-zero (argparse: required=True)."""
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_cli_predict_requires_track_car_lap_and_ambient() -> None:
+    with pytest.raises(SystemExit):
+        main(["predict", "--track", "tsukuba_2000", "--car", "KK-SII", "--hot-all", "1.95"])
+        # Missing --lap and --ambient
+
+
+def test_cli_predict_parses_full_invocation_then_fails_loading_model(tmp_path) -> None:
+    """The CLI should parse cleanly even if the dataset_root has no
+    tire_model.json — failure should come from the predictor, not argparse."""
+    with pytest.raises(FileNotFoundError):
+        main(
+            [
+                "predict",
+                "--dataset-root",
+                str(tmp_path),
+                "--track",
+                "tsukuba_2000",
+                "--car",
+                "KK-SII",
+                "--lap",
+                "5",
+                "--ambient",
+                "18",
+                "--hot-all",
+                "1.95",
+            ]
+        )
+
+
+def test_cli_subcommands_are_registered() -> None:
+    """A regression guard so silently dropping a subcommand from main() trips."""
+    import argparse
+
+    # Build the same parser the CLI does, by introspecting main's argv handling
+    # via a dry-run with --help and confirming all subcommands appear in the
+    # parser. Easier: just confirm each subcommand's argparser doesn't error
+    # when given its minimal required args.
+    cases: list[list[str]] = [
+        ["build-warmup-table", "--dataset-root", "/nonexistent"],
+        ["audit-sensors", "--dataset-root", "/nonexistent"],
+        ["validate", "--dataset-root", "/nonexistent"],
+        ["holdout", "--dataset-root", "/nonexistent"],
+    ]
+    for argv in cases:
+        # Each subcommand should parse cleanly. Most will fail downstream
+        # because the dataset doesn't exist; that's fine — we're testing
+        # argparse here, not the I/O.
+        try:
+            main(argv)
+        except (FileNotFoundError, ValueError, SystemExit):
+            pass
+        except argparse.ArgumentError as e:
+            pytest.fail(f"argparse rejected subcommand {argv[0]!r}: {e}")

--- a/tests/tire_model/test_predict.py
+++ b/tests/tire_model/test_predict.py
@@ -1,0 +1,322 @@
+"""Unit tests for the predictor and its fallback chain."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from motorsports_data_notebook.tire_model.predict import (
+    CORNERS,
+    Prediction,
+    predict_cold_pressure,
+)
+
+
+def _minimal_model() -> dict:
+    """Build a synthetic in-memory model that exercises the fallback chain.
+
+    - Cars: "ToyCar" and "OtherCar"
+    - Tracks: "track_a" (anchor), "track_b"
+    - K_buckets cover every (ToyCar, corner) but only RR for OtherCar
+    - τ covers all 8 (ToyCar) + (OtherCar) entries
+    """
+    return {
+        "schema_version": 1,
+        "model_form": "T_hot - T_eff = K * c_track * g2_typ * (1 - exp(-t/tau_sec))",
+        "gay_lussac": {"p_atm_bar": 1.0, "t_zero_c_to_k": 273.15, "t_cold_uses": "T_air"},
+        "energy_balance": {
+            "w_road": 0.2,
+            "w_road_fitted": False,
+            "t_road_proxy": {
+                "formula": "T_air + delta_sun_max_c * (1 - cloud_cover/100) * sun_factor",
+                "delta_sun_max_c": 10.0,
+                "sun_factor_default": 1.0,
+            },
+        },
+        "corners": list(CORNERS),
+        "min_samples_per_bucket": 5,
+        "priors_when_no_fit": {
+            "tau_sec_seconds": 240.0,
+            "K_kelvin_per_g2": 60.0,
+            "c_track": 1.0,
+        },
+        "tau_sec_by_car_corner": [
+            {
+                "car": "ToyCar",
+                "corner": c,
+                "value_seconds": 200.0 + 10.0 * i,
+                "stderr_seconds": 5.0,
+                "n_samples_used": 100,
+                "from_prior": False,
+            }
+            for i, c in enumerate(CORNERS)
+        ]
+        + [
+            {
+                "car": "OtherCar",
+                "corner": c,
+                "value_seconds": 250.0,
+                "stderr_seconds": 8.0,
+                "n_samples_used": 50,
+                "from_prior": False,
+            }
+            for c in CORNERS
+        ],
+        "K_buckets": [
+            {
+                "key": {"car": "ToyCar", "corner": c},
+                "value_kelvin_per_g2": 50.0 + 5.0 * i,
+                "stderr_kelvin_per_g2": 2.0,
+                "n_samples": 100,
+                "from_prior": False,
+                "from_single_track": False,
+            }
+            for i, c in enumerate(CORNERS)
+        ]
+        + [
+            {
+                "key": {"car": "OtherCar", "corner": "rr"},
+                "value_kelvin_per_g2": 45.0,
+                "stderr_kelvin_per_g2": 3.0,
+                "n_samples": 50,
+                "from_prior": False,
+                "from_single_track": True,
+            },
+        ],
+        "c_track_by_track": [
+            {
+                "track_canonical": "track_a",
+                "value": 1.0,
+                "stderr": 0.0,
+                "n_buckets_used": 8,
+                "anchor": True,
+            },
+            {
+                "track_canonical": "track_b",
+                "value": 0.85,
+                "stderr": 0.04,
+                "n_buckets_used": 4,
+                "anchor": False,
+            },
+        ],
+        "g2_typ_by_track_car": [
+            {"track_canonical": "track_a", "car": "ToyCar", "g2_typ": 0.9, "n_laps_used": 100},
+            {"track_canonical": "track_b", "car": "ToyCar", "g2_typ": 0.7, "n_laps_used": 50},
+            {"track_canonical": "track_a", "car": "OtherCar", "g2_typ": 0.8, "n_laps_used": 30},
+        ],
+        "lap_time_typ_by_track_car": [
+            {
+                "track_canonical": "track_a",
+                "car": "ToyCar",
+                "lap_time_typ_s": 60.0,
+                "n_laps_used": 100,
+            },
+            {
+                "track_canonical": "track_b",
+                "car": "ToyCar",
+                "lap_time_typ_s": 100.0,
+                "n_laps_used": 50,
+            },
+            {
+                "track_canonical": "track_a",
+                "car": "OtherCar",
+                "lap_time_typ_s": 80.0,
+                "n_laps_used": 30,
+            },
+        ],
+        "fallback_order_for_K": [["car", "corner"], ["car"], []],
+    }
+
+
+def test_predict_exact_bucket_match() -> None:
+    model = _minimal_model()
+    result = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    fl = result["fl"]
+    assert isinstance(fl, Prediction)
+    assert fl.K_source_bucket == ("ToyCar", "fl")
+    assert not fl.K_from_prior
+    assert fl.c_track == pytest.approx(1.0)  # anchor track
+    assert fl.g2_typ == pytest.approx(0.9)
+    assert fl.predicted_hot_temp_c > 20.0  # warming up
+
+
+def test_predict_falls_back_to_car_level_when_corner_missing() -> None:
+    """OtherCar has only RR in K_buckets — FL/FR/RL should fall back to (car) mean."""
+    model = _minimal_model()
+    result = predict_cold_pressure(
+        track="track_a",
+        car="OtherCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    fl = result["fl"]
+    assert fl.K_source_bucket == ("OtherCar",)
+    assert fl.K_kelvin_per_g2 == pytest.approx(45.0)  # only RR exists → mean is RR
+
+
+def test_predict_falls_back_to_global_when_car_unknown() -> None:
+    model = _minimal_model()
+    result = predict_cold_pressure(
+        track="track_a",
+        car="UnknownCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        # No (car) data → falls back to prior K
+        # Also no (car, corner) τ_sec → prior τ
+        # ⟨g²⟩ fallback to (track) mean
+        # lap_time_typ fallback to (track) mean
+        _model=model,
+    )
+    fl = result["fl"]
+    assert fl.K_from_prior is True
+    assert fl.K_source_bucket == ()  # global fallback
+
+
+def test_predict_falls_back_to_c_track_one_when_track_unknown() -> None:
+    model = _minimal_model()
+    result = predict_cold_pressure(
+        track="unknown_track",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    fl = result["fl"]
+    assert fl.c_track == pytest.approx(1.0)  # prior
+
+
+def test_predict_g2_override_bypasses_lookup() -> None:
+    model = _minimal_model()
+    result = predict_cold_pressure(
+        track="unknown_track",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        g2_typ_override=1.2,
+        _model=model,
+    )
+    assert result["fl"].g2_typ == pytest.approx(1.2)
+
+
+def test_predict_uses_user_provided_track_temp_when_given() -> None:
+    model = _minimal_model()
+    # Without track_temp: T_road defaults to T_air (no cloud cover provided)
+    r_default = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    # With track_temp = 40 °C: T_eff blends up
+    r_with = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        track_temp_c=40.0,
+        _model=model,
+    )
+    assert r_default["fl"].t_eff_c == pytest.approx(20.0)  # T_road == T_air → T_eff == T_air
+    # T_eff = 0.8·20 + 0.2·40 = 24
+    assert r_with["fl"].t_eff_c == pytest.approx(24.0)
+    # T_hot prediction is higher with the hotter T_eff baseline
+    assert r_with["fl"].predicted_hot_temp_c > r_default["fl"].predicted_hot_temp_c
+
+
+def test_predict_cold_uses_t_air_not_t_eff_for_gay_lussac() -> None:
+    """Even when T_eff blends in road heat, the cold side of Gay-Lussac uses
+    T_air — cold tires equilibrate to pit air, not hot asphalt."""
+    model = _minimal_model()
+    r = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=15.0,
+        track_temp_c=50.0,
+        _model=model,
+    )
+    # T_cold for the Gay-Lussac inversion should be 15 °C, even though T_eff is higher
+    # We can verify by recomputing with the closed-form
+    p = r["fl"]
+    from motorsports_data_notebook.tire_model.energy_balance import (
+        gay_lussac_cold_pressure_bar,
+    )
+
+    expected_cold = gay_lussac_cold_pressure_bar(
+        target_hot_pressure_bar=1.95,
+        t_hot_c=p.predicted_hot_temp_c,
+        t_cold_c=15.0,  # T_air, not T_eff
+    )
+    assert p.cold_pressure_bar == pytest.approx(expected_cold)
+
+
+def test_predict_missing_corner_in_target_raises_keyerror() -> None:
+    model = _minimal_model()
+    with pytest.raises(KeyError):
+        predict_cold_pressure(
+            track="track_a",
+            car="ToyCar",
+            lap_within_stint=5,
+            target_hot_pressure_bar={"fl": 1.95, "fr": 1.95, "rl": 1.95},  # missing rr
+            ambient_temp_c=20.0,
+            _model=model,
+        )
+
+
+def test_predict_cross_track_uses_same_k_different_c_track() -> None:
+    """Whole point of the energy-balance design: track shouldn't change K."""
+    model = _minimal_model()
+    r_a = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    r_b = predict_cold_pressure(
+        track="track_b",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    # Same K, same τ
+    assert r_a["fl"].K_kelvin_per_g2 == r_b["fl"].K_kelvin_per_g2
+    assert r_a["fl"].tau_sec == r_b["fl"].tau_sec
+    # Different c_track
+    assert r_a["fl"].c_track != r_b["fl"].c_track
+
+
+def test_predict_loads_from_disk_when_no_model_kwarg(tmp_path: Path) -> None:
+    """End-to-end: predict_cold_pressure reads tire_model.json from dataset_root."""
+    model = _minimal_model()
+    (tmp_path / "tire_model.json").write_text(json.dumps(model))
+    result = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=20.0,
+        dataset_root=tmp_path,
+    )
+    assert result["fl"].cold_pressure_bar > 0

--- a/tests/tire_model/test_validate.py
+++ b/tests/tire_model/test_validate.py
@@ -1,0 +1,129 @@
+"""Unit tests for the held-out validation helpers.
+
+The full end-to-end ``run_holdout_validation`` requires the committed
+dataset and is exercised by ``just tire-predict-holdout``. These tests
+cover the pure pandas logic in ``_pick_holdout_sessions``.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from motorsports_data_notebook.tire_model.validate import _pick_holdout_sessions
+
+
+def _make_sessions(rows: list[dict]) -> pd.DataFrame:
+    """Build a minimal sessions DataFrame matching the columns the picker reads."""
+    defaults = {"status": "ok", "has_tpms": True}
+    return pd.DataFrame([{**defaults, **r} for r in rows])
+
+
+def _make_laps_with_usable_per_session(counts: dict[str, int]) -> pd.DataFrame:
+    """Build a laps DataFrame where each session_id has ``counts[sid]`` usable laps."""
+    rows = []
+    for sid, n in counts.items():
+        for lap in range(n):
+            rows.append({"session_id": sid, "lap_num": lap, "tire_usable": True})
+    return pd.DataFrame(rows)
+
+
+def test_picker_returns_empty_when_no_bucket_meets_threshold() -> None:
+    sessions = _make_sessions(
+        [
+            {"session_id": "s1", "track_canonical": "tsukuba_2000", "car": "CarA"},
+            {"session_id": "s2", "track_canonical": "tsukuba_2000", "car": "CarA"},
+        ]
+    )
+    laps = _make_laps_with_usable_per_session({"s1": 5, "s2": 5})
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    assert out == []
+
+
+def test_picker_returns_first_n_session_ids_sorted_within_eligible_bucket() -> None:
+    # 12 sessions in one (track, car) bucket → eligible at min_bucket_size=10
+    sids = [f"sess_{i:02d}" for i in range(12)]
+    sessions = _make_sessions(
+        [{"session_id": sid, "track_canonical": "tsukuba_2000", "car": "CarA"} for sid in sids]
+    )
+    laps = _make_laps_with_usable_per_session({sid: 8 for sid in sids})
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    # Picks first 2 by sort order
+    assert out == sorted(sids)[:2]
+
+
+def test_picker_skips_sessions_with_too_few_usable_laps() -> None:
+    """A session needs at least 3 usable laps to be a valid held-out candidate."""
+    sids = [f"sess_{i:02d}" for i in range(15)]
+    sessions = _make_sessions(
+        [{"session_id": sid, "track_canonical": "tsukuba_2000", "car": "CarA"} for sid in sids]
+    )
+    # Most sessions have 8 usable laps; first 2 (by sort order) have only 2
+    counts = {sid: 8 for sid in sids}
+    counts["sess_00"] = 2  # would be picked first if usable, but only 2 laps
+    counts["sess_01"] = 2
+    laps = _make_laps_with_usable_per_session(counts)
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    # Picker skips sess_00 and sess_01, picks sess_02 and sess_03
+    assert out == ["sess_02", "sess_03"]
+
+
+def test_picker_picks_from_multiple_buckets_independently() -> None:
+    # Two eligible buckets: Tsukuba/CarA and Fuji/CarA
+    sids_tsukuba = [f"tsk_{i:02d}" for i in range(12)]
+    sids_fuji = [f"fji_{i:02d}" for i in range(11)]
+    sessions = _make_sessions(
+        [
+            {"session_id": sid, "track_canonical": "tsukuba_2000", "car": "CarA"}
+            for sid in sids_tsukuba
+        ]
+        + [{"session_id": sid, "track_canonical": "fuji", "car": "CarA"} for sid in sids_fuji]
+    )
+    laps = _make_laps_with_usable_per_session({sid: 8 for sid in sids_tsukuba + sids_fuji})
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    # 2 from each bucket = 4 total
+    assert len(out) == 4
+    assert sorted(sids_tsukuba)[:2] == [s for s in out if s.startswith("tsk")]
+    assert sorted(sids_fuji)[:2] == [s for s in out if s.startswith("fji")]
+
+
+def test_picker_drops_non_ok_or_no_tpms_sessions() -> None:
+    rows: list[dict] = [
+        {"session_id": "ok1", "track_canonical": "tsukuba_2000", "car": "CarA"},
+        {"session_id": "ok2", "track_canonical": "tsukuba_2000", "car": "CarA"},
+        {
+            "session_id": "err",
+            "track_canonical": "tsukuba_2000",
+            "car": "CarA",
+            "status": "error",
+        },
+        {
+            "session_id": "noTPMS",
+            "track_canonical": "tsukuba_2000",
+            "car": "CarA",
+            "has_tpms": False,
+        },
+    ]
+    rows.extend(
+        {"session_id": f"filler_{i}", "track_canonical": "tsukuba_2000", "car": "CarA"}
+        for i in range(10)
+    )
+    sessions = _make_sessions(rows)
+    laps = _make_laps_with_usable_per_session({sid: 8 for sid in sessions["session_id"].tolist()})
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    assert "err" not in out
+    assert "noTPMS" not in out
+
+
+def test_picker_skips_sessions_with_missing_track_or_car() -> None:
+    sessions = _make_sessions(
+        [{"session_id": "s_bad_track", "track_canonical": None, "car": "CarA"}]
+        + [{"session_id": "s_bad_car", "track_canonical": "tsukuba_2000", "car": None}]
+        + [
+            {"session_id": f"ok_{i}", "track_canonical": "tsukuba_2000", "car": "CarA"}
+            for i in range(12)
+        ]
+    )
+    laps = _make_laps_with_usable_per_session({sid: 8 for sid in sessions["session_id"].tolist()})
+    out = _pick_holdout_sessions(sessions, laps, n_per_bucket=2, min_bucket_size=10)
+    assert "s_bad_track" not in out
+    assert "s_bad_car" not in out


### PR DESCRIPTION

Adds docs/tire_model.md covering the v0 cold-pressure predictor:
- Modeling approach: the lumped-capacity energy balance, why on-track
  seconds (not laps), why per-corner τ and K, why track-independent K
  with track effects entering via ⟨g²⟩ + c_track from data, why tire
  compound is omitted in v0, why w_road is fixed at 0.2.
- Two-pass fitting procedure and parameter table (~20 fitted params total).
- Sensor blacklist workflow (auto-detect → human review → committed YAML).
- Test methodology: distinction between consistency check
  (notes-recorded cold pressures, model trained on same sessions) and the
  honest held-out generalization test (N=2 sessions per (track, car)
  bucket excluded from training).
- Results: pooled and per-car residual tables, fitted parameter sanity
  ranges, the dramatic 60+% MAE improvement on RL/RR from masking the
  stuck-sensor training data.
- Ideas for next steps in three tiers — v0.1 data hygiene (tighter
  blacklist, track-canonical cleanup, per-(track, car) breakdown);
  v0.2 model refinements that don't change the architecture (fit w_road,
  validate against notes, sun-factor refinement); v1 architecture changes
  (within-lap fitting, NumPyro partial pooling, re-introduce compound);
  v2 C# calculator integration.
- CLI reference and a pointer-table to the relevant source files.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/115).
* #122
* #121
* #120
* #119
* #118
* #117
* #116
* __->__ #115
* #114