### PR TITLE
tire-model: --cold-tire-temp lets caller separate T_cold from T_air

### DIFF
--- a/src/motorsports_data_notebook/tire_model/cli.py
+++ b/src/motorsports_data_notebook/tire_model/cli.py
@@ -61,6 +61,14 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional measured track-surface temperature in °C.",
     )
     p_predict.add_argument(
+        "--cold-tire-temp",
+        type=float,
+        default=None,
+        help="Temperature the tire is at right now when you measure/set cold "
+        "pressure in °C. Defaults to --ambient. Use when the tire isn't at "
+        "current air temperature (sun-warmed garage, set the night before, etc.).",
+    )
+    p_predict.add_argument(
         "--cloud-cover",
         type=float,
         default=None,
@@ -192,6 +200,7 @@ def _cmd_predict(args: argparse.Namespace) -> int:
         lap_within_stint=args.lap,
         target_hot_pressure_bar=targets,
         ambient_temp_c=args.ambient,
+        cold_tire_temp_c=args.cold_tire_temp,
         track_condition=args.condition,
         track_temp_c=args.track_temp,
         cloud_cover_pct=args.cloud_cover,
@@ -219,6 +228,11 @@ def _print_prediction(result: dict[str, Prediction], args: argparse.Namespace) -
         f"T_air = {any_p.t_air_c:.1f} °C    T_road = {any_p.t_road_c:.1f} °C    "
         f"T_eff = {any_p.t_eff_c:.1f} °C (w_road=0.20)"
     )
+    if abs(any_p.t_cold_c - any_p.t_air_c) > 1e-6:
+        print(
+            f"T_cold (Gay-Lussac cold side) = {any_p.t_cold_c:.1f} °C  "
+            f"[override — tire temp at pressure-set time differs from T_air]"
+        )
     print()
     header = (
         f"{'Corner':6} {'K(K/G²)':>9} {'τ_sec(s)':>9} {'warmup':>7} {'ΔT∞(K)':>8} "

--- a/src/motorsports_data_notebook/tire_model/predict.py
+++ b/src/motorsports_data_notebook/tire_model/predict.py
@@ -44,6 +44,7 @@ class Prediction:
     t_eff_c: float
     t_air_c: float
     t_road_c: float
+    t_cold_c: float  # temperature the tire is at when you measure/set cold pressure
     K_source_bucket: tuple[str, ...]
     K_from_prior: bool
     K_n_samples: int
@@ -215,6 +216,7 @@ def predict_cold_pressure(
     lap_within_stint: int,
     target_hot_pressure_bar: dict[str, float],
     ambient_temp_c: float,
+    cold_tire_temp_c: float | None = None,
     track_condition: str = "dry",
     track_temp_c: float | None = None,
     cloud_cover_pct: float | None = None,
@@ -227,6 +229,15 @@ def predict_cold_pressure(
 
     Parameters
     ----------
+    ambient_temp_c
+        Air temperature for the upcoming session. Drives the T_road sun-proxy
+        and the T_eff baseline used in the warmup curve.
+    cold_tire_temp_c
+        Optional temperature the tire is at right *now* when you'll measure
+        or set cold pressure. Defaults to ``ambient_temp_c`` when omitted.
+        Use this when the tire isn't at air temperature — e.g., sitting in
+        a sun-warmed garage, set the night before in cooler air, or pre-heated.
+        Affects the Gay-Lussac inversion only, not the warmup-curve target.
     track_condition
         One of ``"dry"`` (default), ``"damp"`` (light drizzle, 0.1–1 mm/hr),
         or ``"wet"`` (≥ 1 mm/hr). Picks the condition-specific K, τ_sec,
@@ -263,6 +274,11 @@ def predict_cold_pressure(
         )
     t_eff_c = t_effective_c(t_air_c=ambient_temp_c, t_road_c=t_road_c, w_road=w_road)
 
+    # Cold-side temperature for the Gay-Lussac inversion: defaults to T_air
+    # but lets the caller pin a different "what's the tire currently at?"
+    # value (e.g., garage temp ≠ track ambient).
+    t_cold_c = float(cold_tire_temp_c) if cold_tire_temp_c is not None else ambient_temp_c
+
     # Time at end of lap N
     t_at_lap_n_s = float(lap_within_stint) * lap_time_typ_s
 
@@ -287,7 +303,7 @@ def predict_cold_pressure(
         cold = gay_lussac_cold_pressure_bar(
             target_hot_pressure_bar=target_hot,
             t_hot_c=t_hot_c,
-            t_cold_c=ambient_temp_c,  # cold uses T_air only
+            t_cold_c=t_cold_c,  # tire's actual current temp (default: T_air)
             p_atm_bar=P_ATM_BAR,
         )
 
@@ -307,6 +323,7 @@ def predict_cold_pressure(
             t_eff_c=t_eff_c,
             t_air_c=ambient_temp_c,
             t_road_c=t_road_c,
+            t_cold_c=t_cold_c,
             K_source_bucket=K_src,
             K_from_prior=K_from_prior,
             K_n_samples=K_n,

--- a/tests/tire_model/test_predict.py
+++ b/tests/tire_model/test_predict.py
@@ -411,6 +411,43 @@ def test_predict_cold_uses_t_air_not_t_eff_for_gay_lussac() -> None:
     assert p.cold_pressure_bar == pytest.approx(expected_cold)
 
 
+def test_predict_cold_tire_temp_overrides_ambient_in_gay_lussac_only() -> None:
+    """When the tire isn't at air temperature (e.g., warm garage), the user
+    can pin T_cold separately. It MUST only affect the Gay-Lussac inversion
+    — the warmup-curve target T_eff is still computed from ambient_temp_c."""
+    model = _minimal_model()
+    base = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=15.0,
+        _model=model,
+    )
+    # Tire is 10 °C warmer than air (sat in a heated garage). Cold side of
+    # Gay-Lussac uses 25 °C; T_eff and predicted hot temp are unchanged.
+    warm_tire = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=15.0,
+        cold_tire_temp_c=25.0,
+        _model=model,
+    )
+    p_base = base["fl"]
+    p_warm = warm_tire["fl"]
+    # T_eff and predicted hot temp unchanged
+    assert p_base.t_eff_c == pytest.approx(p_warm.t_eff_c)
+    assert p_base.predicted_hot_temp_c == pytest.approx(p_warm.predicted_hot_temp_c)
+    # T_cold differs
+    assert p_base.t_cold_c == pytest.approx(15.0)
+    assert p_warm.t_cold_c == pytest.approx(25.0)
+    # Cold pressure HIGHER for a warmer cold-side (P/T constant ⇒ larger
+    # T_cold ⇒ larger P_cold for the same P_hot/T_hot)
+    assert p_warm.cold_pressure_bar > p_base.cold_pressure_bar
+
+
 def test_predict_missing_corner_in_target_raises_keyerror() -> None:
     model = _minimal_model()
     with pytest.raises(KeyError):


### PR DESCRIPTION

Adds an optional ``cold_tire_temp_c`` parameter to ``predict_cold_pressure``
(and ``--cold-tire-temp`` to the CLI). Defaults to ``ambient_temp_c`` so
existing callers are unaffected.

Use case: the tire's current temperature when you measure/set cold
pressure isn't always the same as the air temperature at the upcoming
session. Common scenarios:

- Tire sat in a heated/sun-warmed garage → warmer than ambient → cold
  measurement reads higher than it would outside → set a higher cold
  number to land on the same hot pressure.
- Tire was pressure-set the night before in cooler air → set a lower
  cold number.
- Tire's been pre-heated with warmers (skipped here — warmers also
  pressurize the gas above ambient, which is a slightly different
  physical regime).

The override only affects the Gay-Lussac inversion (the cold side).
T_eff (the warmup-curve target) still uses ``ambient_temp_c`` because
the tire equilibrates to the *track* air during driving, not to its
pre-session storage temperature.

Worked example (Tsukuba KK-SII, target hot 1.7 bar, lap 10, 15 °C air):

  Cold-tire 15 °C (= ambient)  →  FL 1.45 / FR 1.50 / RL 1.48 / RR 1.47
  Cold-tire 22 °C (warm garage) →  FL 1.51 / FR 1.56 / RL 1.54 / RR 1.53
  Cold-tire  8 °C (set last nt) →  FL 1.39 / FR 1.44 / RL 1.42 / RR 1.41

~0.06 bar shift per 7 °C of cold-side temperature change, matching the
P/T ratio in the energy-balance prediction (P_cold = P_hot_abs · T_cold_K
/ T_hot_K — only T_cold_K moves with this override).

CLI surface:
- New flag ``--cold-tire-temp`` (default: same as ``--ambient``).
- The header now prints ``T_cold (Gay-Lussac cold side) = X °C`` when
  the override is in effect, so users can see the distinction without
  hunting through the math.

Tests:
- New: ``test_predict_cold_tire_temp_overrides_ambient_in_gay_lussac_only``
  asserts T_eff and predicted_hot_temp_c are unchanged when the override
  fires (the warmup curve uses ambient, not the override), but
  cold_pressure_bar moves in the right direction (warmer T_cold → higher
  cold pressure for the same target hot).

``Prediction`` dataclass gains a ``t_cold_c`` field so the provenance
is visible in code and in the artifact-derived reports.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/118).
* #122
* #121
* #120
* #119
* __->__ #118