### PR TITLE
tire-pressure-calculator: bundle tire_model.json + C# parser/lookups

### DIFF
--- a/src/motorsports_data_notebook/tire_model/cli.py
+++ b/src/motorsports_data_notebook/tire_model/cli.py
@@ -61,6 +61,14 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional measured track-surface temperature in °C.",
     )
     p_predict.add_argument(
+        "--cold-tire-temp",
+        type=float,
+        default=None,
+        help="Temperature the tire is at right now when you measure/set cold "
+        "pressure in °C. Defaults to --ambient. Use when the tire isn't at "
+        "current air temperature (sun-warmed garage, set the night before, etc.).",
+    )
+    p_predict.add_argument(
         "--cloud-cover",
         type=float,
         default=None,
@@ -192,6 +200,7 @@ def _cmd_predict(args: argparse.Namespace) -> int:
         lap_within_stint=args.lap,
         target_hot_pressure_bar=targets,
         ambient_temp_c=args.ambient,
+        cold_tire_temp_c=args.cold_tire_temp,
         track_condition=args.condition,
         track_temp_c=args.track_temp,
         cloud_cover_pct=args.cloud_cover,
@@ -219,6 +228,11 @@ def _print_prediction(result: dict[str, Prediction], args: argparse.Namespace) -
         f"T_air = {any_p.t_air_c:.1f} °C    T_road = {any_p.t_road_c:.1f} °C    "
         f"T_eff = {any_p.t_eff_c:.1f} °C (w_road=0.20)"
     )
+    if abs(any_p.t_cold_c - any_p.t_air_c) > 1e-6:
+        print(
+            f"T_cold (Gay-Lussac cold side) = {any_p.t_cold_c:.1f} °C  "
+            f"[override — tire temp at pressure-set time differs from T_air]"
+        )
     print()
     header = (
         f"{'Corner':6} {'K(K/G²)':>9} {'τ_sec(s)':>9} {'warmup':>7} {'ΔT∞(K)':>8} "

--- a/src/motorsports_data_notebook/tire_model/predict.py
+++ b/src/motorsports_data_notebook/tire_model/predict.py
@@ -44,6 +44,7 @@ class Prediction:
     t_eff_c: float
     t_air_c: float
     t_road_c: float
+    t_cold_c: float  # temperature the tire is at when you measure/set cold pressure
     K_source_bucket: tuple[str, ...]
     K_from_prior: bool
     K_n_samples: int
@@ -215,6 +216,7 @@ def predict_cold_pressure(
     lap_within_stint: int,
     target_hot_pressure_bar: dict[str, float],
     ambient_temp_c: float,
+    cold_tire_temp_c: float | None = None,
     track_condition: str = "dry",
     track_temp_c: float | None = None,
     cloud_cover_pct: float | None = None,
@@ -227,6 +229,15 @@ def predict_cold_pressure(
 
     Parameters
     ----------
+    ambient_temp_c
+        Air temperature for the upcoming session. Drives the T_road sun-proxy
+        and the T_eff baseline used in the warmup curve.
+    cold_tire_temp_c
+        Optional temperature the tire is at right *now* when you'll measure
+        or set cold pressure. Defaults to ``ambient_temp_c`` when omitted.
+        Use this when the tire isn't at air temperature — e.g., sitting in
+        a sun-warmed garage, set the night before in cooler air, or pre-heated.
+        Affects the Gay-Lussac inversion only, not the warmup-curve target.
     track_condition
         One of ``"dry"`` (default), ``"damp"`` (light drizzle, 0.1–1 mm/hr),
         or ``"wet"`` (≥ 1 mm/hr). Picks the condition-specific K, τ_sec,
@@ -263,6 +274,11 @@ def predict_cold_pressure(
         )
     t_eff_c = t_effective_c(t_air_c=ambient_temp_c, t_road_c=t_road_c, w_road=w_road)
 
+    # Cold-side temperature for the Gay-Lussac inversion: defaults to T_air
+    # but lets the caller pin a different "what's the tire currently at?"
+    # value (e.g., garage temp ≠ track ambient).
+    t_cold_c = float(cold_tire_temp_c) if cold_tire_temp_c is not None else ambient_temp_c
+
     # Time at end of lap N
     t_at_lap_n_s = float(lap_within_stint) * lap_time_typ_s
 
@@ -287,7 +303,7 @@ def predict_cold_pressure(
         cold = gay_lussac_cold_pressure_bar(
             target_hot_pressure_bar=target_hot,
             t_hot_c=t_hot_c,
-            t_cold_c=ambient_temp_c,  # cold uses T_air only
+            t_cold_c=t_cold_c,  # tire's actual current temp (default: T_air)
             p_atm_bar=P_ATM_BAR,
         )
 
@@ -307,6 +323,7 @@ def predict_cold_pressure(
             t_eff_c=t_eff_c,
             t_air_c=ambient_temp_c,
             t_road_c=t_road_c,
+            t_cold_c=t_cold_c,
             K_source_bucket=K_src,
             K_from_prior=K_from_prior,
             K_n_samples=K_n,

--- a/tests/tire_model/test_predict.py
+++ b/tests/tire_model/test_predict.py
@@ -411,6 +411,43 @@ def test_predict_cold_uses_t_air_not_t_eff_for_gay_lussac() -> None:
     assert p.cold_pressure_bar == pytest.approx(expected_cold)
 
 
+def test_predict_cold_tire_temp_overrides_ambient_in_gay_lussac_only() -> None:
+    """When the tire isn't at air temperature (e.g., warm garage), the user
+    can pin T_cold separately. It MUST only affect the Gay-Lussac inversion
+    — the warmup-curve target T_eff is still computed from ambient_temp_c."""
+    model = _minimal_model()
+    base = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=15.0,
+        _model=model,
+    )
+    # Tire is 10 °C warmer than air (sat in a heated garage). Cold side of
+    # Gay-Lussac uses 25 °C; T_eff and predicted hot temp are unchanged.
+    warm_tire = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.95 for c in CORNERS},
+        ambient_temp_c=15.0,
+        cold_tire_temp_c=25.0,
+        _model=model,
+    )
+    p_base = base["fl"]
+    p_warm = warm_tire["fl"]
+    # T_eff and predicted hot temp unchanged
+    assert p_base.t_eff_c == pytest.approx(p_warm.t_eff_c)
+    assert p_base.predicted_hot_temp_c == pytest.approx(p_warm.predicted_hot_temp_c)
+    # T_cold differs
+    assert p_base.t_cold_c == pytest.approx(15.0)
+    assert p_warm.t_cold_c == pytest.approx(25.0)
+    # Cold pressure HIGHER for a warmer cold-side (P/T constant ⇒ larger
+    # T_cold ⇒ larger P_cold for the same P_hot/T_hot)
+    assert p_warm.cold_pressure_bar > p_base.cold_pressure_bar
+
+
 def test_predict_missing_corner_in_target_raises_keyerror() -> None:
     model = _minimal_model()
     with pytest.raises(KeyError):

--- a/tire_pressure_calculator/Core/Services/Modeling/TireModel.cs
+++ b/tire_pressure_calculator/Core/Services/Modeling/TireModel.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TirePressureCalculator.Services.Modeling;
+
+/// <summary>
+/// In-memory wrapper around a parsed <see cref="TireModelDto"/>. Adds
+/// lookup helpers + the condition fallback chain that mirrors the Python
+/// predictor at <c>src/motorsports_data_notebook/tire_model/predict.py</c>.
+/// </summary>
+public sealed class TireModel
+{
+    public const int SupportedSchemaVersion = 2;
+
+    public TireModelDto Dto { get; }
+
+    public TireModel(TireModelDto dto)
+    {
+        if (dto.SchemaVersion != SupportedSchemaVersion)
+        {
+            throw new InvalidOperationException(
+                $"Unsupported tire_model.json schema_version {dto.SchemaVersion}; expected {SupportedSchemaVersion}. " +
+                "Rebuild the artifact with `just tire-build-warmup-table`.");
+        }
+        Dto = dto;
+    }
+
+    public IReadOnlyList<string> AvailableCars => Dto.TauSecByCarCornerCond
+        .Select(r => r.Car).Distinct().OrderBy(s => s).ToList();
+
+    public IReadOnlyList<string> AvailableTracks => Dto.CTrackByTrack
+        .Select(r => r.TrackCanonical).OrderBy(s => s).ToList();
+
+    public IReadOnlyList<string> AvailableConditions => Dto.Conditions.Values;
+
+    public string DefaultCondition => Dto.Conditions.Default;
+
+    public double WRoad => Dto.EnergyBalance.WRoad;
+
+    public double SunFactorDefault => Dto.EnergyBalance.TRoadProxy.SunFactorDefault;
+
+    public double DeltaSunMaxC => Dto.EnergyBalance.TRoadProxy.DeltaSunMaxC;
+
+    public double PAtmBar => Dto.GayLussac.PAtmBar;
+
+    public double TZeroCToK => Dto.GayLussac.TZeroCToK;
+
+    // ---- Condition fallback chain (mirrors predict.py:_CONDITION_FALLBACK) ----
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> _conditionChain =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["dry"] = new[] { "dry" },
+            ["damp"] = new[] { "damp", "dry" },
+            ["wet"] = new[] { "wet", "damp", "dry" },
+        };
+
+    internal static IReadOnlyList<string> ConditionChain(string condition) =>
+        _conditionChain.TryGetValue(condition, out var chain)
+            ? chain
+            : new[] { condition, "dry" };
+
+    // ---- Lookups ----
+
+    public TauLookup LookupTau(string car, string corner, string condition)
+    {
+        foreach (var cond in ConditionChain(condition))
+        {
+            var hit = Dto.TauSecByCarCornerCond.FirstOrDefault(
+                r => r.Car == car && r.Corner == corner && r.Condition == cond);
+            if (hit is not null)
+            {
+                return new TauLookup(hit.ValueSeconds, hit.StderrSeconds,
+                    SourceBucket: $"({car}, {corner}, {cond})", FromPrior: hit.FromPrior);
+            }
+        }
+        // (car, corner) mean across conditions
+        var sameCC = Dto.TauSecByCarCornerCond.Where(r => r.Car == car && r.Corner == corner).ToList();
+        if (sameCC.Count > 0)
+        {
+            return new TauLookup(sameCC.Average(r => r.ValueSeconds), 0.0,
+                SourceBucket: $"({car}, {corner})", FromPrior: false);
+        }
+        // (car) mean across all corners + conditions
+        var sameCar = Dto.TauSecByCarCornerCond.Where(r => r.Car == car).ToList();
+        if (sameCar.Count > 0)
+        {
+            return new TauLookup(sameCar.Average(r => r.ValueSeconds), 0.0,
+                SourceBucket: $"({car})", FromPrior: false);
+        }
+        return new TauLookup(Dto.PriorsWhenNoFit.TauSecSeconds, 0.0,
+            SourceBucket: "(prior)", FromPrior: true);
+    }
+
+    public KLookup LookupK(string car, string corner, string condition)
+    {
+        foreach (var cond in ConditionChain(condition))
+        {
+            var hit = Dto.KBuckets.FirstOrDefault(
+                r => r.Key.Car == car && r.Key.Corner == corner && r.Key.Condition == cond);
+            if (hit is not null)
+            {
+                return new KLookup(hit.ValueKelvinPerG2, hit.StderrKelvinPerG2, hit.NSamples,
+                    SourceBucket: $"({car}, {corner}, {cond})", FromPrior: hit.FromPrior);
+            }
+        }
+        var sameCC = Dto.KBuckets.Where(r => r.Key.Car == car && r.Key.Corner == corner).ToList();
+        if (sameCC.Count > 0)
+        {
+            return new KLookup(sameCC.Average(r => r.ValueKelvinPerG2), 0.0,
+                sameCC.Sum(r => r.NSamples),
+                SourceBucket: $"({car}, {corner})", FromPrior: false);
+        }
+        var sameCar = Dto.KBuckets.Where(r => r.Key.Car == car).ToList();
+        if (sameCar.Count > 0)
+        {
+            return new KLookup(sameCar.Average(r => r.ValueKelvinPerG2), 0.0,
+                sameCar.Sum(r => r.NSamples),
+                SourceBucket: $"({car})", FromPrior: false);
+        }
+        return new KLookup(Dto.PriorsWhenNoFit.KKelvinPerG2, 0.0, 0,
+            SourceBucket: "(prior)", FromPrior: true);
+    }
+
+    public CTrackLookup LookupCTrack(string track)
+    {
+        var hit = Dto.CTrackByTrack.FirstOrDefault(r => r.TrackCanonical == track);
+        if (hit is not null)
+            return new CTrackLookup(hit.Value, hit.Stderr, FromPrior: false);
+        return new CTrackLookup(Dto.PriorsWhenNoFit.CTrack, 0.0, FromPrior: true);
+    }
+
+    public G2Lookup LookupG2(string track, string car, string condition)
+    {
+        foreach (var cond in ConditionChain(condition))
+        {
+            var hit = Dto.G2TypByTrackCarCond.FirstOrDefault(
+                r => r.TrackCanonical == track && r.Car == car && r.Condition == cond);
+            if (hit is not null)
+            {
+                var tag = cond == condition ? "exact" : $"fallback({cond})";
+                return new G2Lookup(hit.G2Typ, hit.NLapsUsed, tag);
+            }
+        }
+        var sameTC = Dto.G2TypByTrackCarCond.Where(
+            r => r.TrackCanonical == track && r.Car == car).ToList();
+        if (sameTC.Count > 0)
+        {
+            return new G2Lookup(sameTC.Average(r => r.G2Typ),
+                sameTC.Sum(r => r.NLapsUsed), "track_car_pooled");
+        }
+        var sameT = Dto.G2TypByTrackCarCond.Where(r => r.TrackCanonical == track).ToList();
+        if (sameT.Count > 0)
+        {
+            return new G2Lookup(sameT.Average(r => r.G2Typ),
+                sameT.Sum(r => r.NLapsUsed), "track_pooled");
+        }
+        if (Dto.G2TypByTrackCarCond.Count > 0)
+        {
+            return new G2Lookup(Dto.G2TypByTrackCarCond.Average(r => r.G2Typ), 0, "global");
+        }
+        return new G2Lookup(0.7, 0, "global");
+    }
+
+    public LapTimeLookup LookupLapTime(string track, string car, string condition)
+    {
+        foreach (var cond in ConditionChain(condition))
+        {
+            var hit = Dto.LapTimeTypByTrackCarCond.FirstOrDefault(
+                r => r.TrackCanonical == track && r.Car == car && r.Condition == cond);
+            if (hit is not null)
+            {
+                var tag = cond == condition ? "exact" : $"fallback({cond})";
+                return new LapTimeLookup(hit.LapTimeTypS, hit.NLapsUsed, tag);
+            }
+        }
+        var sameTC = Dto.LapTimeTypByTrackCarCond.Where(
+            r => r.TrackCanonical == track && r.Car == car).ToList();
+        if (sameTC.Count > 0)
+        {
+            return new LapTimeLookup(sameTC.Average(r => r.LapTimeTypS),
+                sameTC.Sum(r => r.NLapsUsed), "track_car_pooled");
+        }
+        var sameT = Dto.LapTimeTypByTrackCarCond.Where(r => r.TrackCanonical == track).ToList();
+        if (sameT.Count > 0)
+        {
+            return new LapTimeLookup(sameT.Average(r => r.LapTimeTypS),
+                sameT.Sum(r => r.NLapsUsed), "track_pooled");
+        }
+        return new LapTimeLookup(90.0, 0, "global");
+    }
+}
+
+public readonly record struct TauLookup(
+    double ValueSeconds, double StderrSeconds, string SourceBucket, bool FromPrior);
+
+public readonly record struct KLookup(
+    double ValueKelvinPerG2, double StderrKelvinPerG2, int NSamples, string SourceBucket, bool FromPrior);
+
+public readonly record struct CTrackLookup(
+    double Value, double Stderr, bool FromPrior);
+
+public readonly record struct G2Lookup(
+    double Value, int NLapsUsed, string Source);
+
+public readonly record struct LapTimeLookup(
+    double ValueSeconds, int NLapsUsed, string Source);

--- a/tire_pressure_calculator/Core/Services/Modeling/TireModelDtos.cs
+++ b/tire_pressure_calculator/Core/Services/Modeling/TireModelDtos.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace TirePressureCalculator.Services.Modeling;
+
+// DTOs mirroring data/tire_dataset/tire_model.json (schema v2).
+// See docs/tire_model.md §2.7 for the schema reference.
+
+public sealed record TireModelDto(
+    [property: JsonPropertyName("schema_version")] int SchemaVersion,
+    [property: JsonPropertyName("fit_at_utc")] string FitAtUtc,
+    [property: JsonPropertyName("model_form")] string ModelForm,
+    [property: JsonPropertyName("gay_lussac")] GayLussacConfigDto GayLussac,
+    [property: JsonPropertyName("energy_balance")] EnergyBalanceConfigDto EnergyBalance,
+    [property: JsonPropertyName("conditions")] ConditionsConfigDto Conditions,
+    [property: JsonPropertyName("corners")] IReadOnlyList<string> Corners,
+    [property: JsonPropertyName("min_samples_per_bucket")] int MinSamplesPerBucket,
+    [property: JsonPropertyName("priors_when_no_fit")] PriorsDto PriorsWhenNoFit,
+    [property: JsonPropertyName("tau_sec_by_car_corner_cond")] IReadOnlyList<TauEntryDto> TauSecByCarCornerCond,
+    [property: JsonPropertyName("K_buckets")] IReadOnlyList<KBucketEntryDto> KBuckets,
+    [property: JsonPropertyName("c_track_by_track")] IReadOnlyList<CTrackEntryDto> CTrackByTrack,
+    [property: JsonPropertyName("g2_typ_by_track_car_cond")] IReadOnlyList<G2EntryDto> G2TypByTrackCarCond,
+    [property: JsonPropertyName("lap_time_typ_by_track_car_cond")] IReadOnlyList<LapTimeEntryDto> LapTimeTypByTrackCarCond
+);
+
+public sealed record GayLussacConfigDto(
+    [property: JsonPropertyName("p_atm_bar")] double PAtmBar,
+    [property: JsonPropertyName("t_zero_c_to_k")] double TZeroCToK,
+    [property: JsonPropertyName("t_cold_uses")] string TColdUses
+);
+
+public sealed record EnergyBalanceConfigDto(
+    [property: JsonPropertyName("w_road")] double WRoad,
+    [property: JsonPropertyName("w_road_fitted")] bool WRoadFitted,
+    [property: JsonPropertyName("t_road_proxy")] TRoadProxyConfigDto TRoadProxy
+);
+
+public sealed record TRoadProxyConfigDto(
+    [property: JsonPropertyName("formula")] string Formula,
+    [property: JsonPropertyName("delta_sun_max_c")] double DeltaSunMaxC,
+    [property: JsonPropertyName("sun_factor_default")] double SunFactorDefault
+);
+
+public sealed record ConditionsConfigDto(
+    [property: JsonPropertyName("values")] IReadOnlyList<string> Values,
+    [property: JsonPropertyName("default")] string Default
+);
+
+public sealed record PriorsDto(
+    [property: JsonPropertyName("tau_sec_seconds")] double TauSecSeconds,
+    [property: JsonPropertyName("K_kelvin_per_g2")] double KKelvinPerG2,
+    [property: JsonPropertyName("c_track")] double CTrack
+);
+
+public sealed record TauEntryDto(
+    [property: JsonPropertyName("car")] string Car,
+    [property: JsonPropertyName("corner")] string Corner,
+    [property: JsonPropertyName("condition")] string Condition,
+    [property: JsonPropertyName("value_seconds")] double ValueSeconds,
+    [property: JsonPropertyName("stderr_seconds")] double StderrSeconds,
+    [property: JsonPropertyName("n_samples_used")] int NSamplesUsed,
+    [property: JsonPropertyName("from_prior")] bool FromPrior
+);
+
+public sealed record KBucketEntryDto(
+    [property: JsonPropertyName("key")] KBucketKeyDto Key,
+    [property: JsonPropertyName("value_kelvin_per_g2")] double ValueKelvinPerG2,
+    [property: JsonPropertyName("stderr_kelvin_per_g2")] double StderrKelvinPerG2,
+    [property: JsonPropertyName("n_samples")] int NSamples,
+    [property: JsonPropertyName("from_prior")] bool FromPrior,
+    [property: JsonPropertyName("from_single_track")] bool FromSingleTrack
+);
+
+public sealed record KBucketKeyDto(
+    [property: JsonPropertyName("car")] string Car,
+    [property: JsonPropertyName("corner")] string Corner,
+    [property: JsonPropertyName("condition")] string Condition
+);
+
+public sealed record CTrackEntryDto(
+    [property: JsonPropertyName("track_canonical")] string TrackCanonical,
+    [property: JsonPropertyName("value")] double Value,
+    [property: JsonPropertyName("stderr")] double Stderr,
+    [property: JsonPropertyName("n_buckets_used")] int NBucketsUsed,
+    [property: JsonPropertyName("anchor")] bool Anchor
+);
+
+public sealed record G2EntryDto(
+    [property: JsonPropertyName("track_canonical")] string TrackCanonical,
+    [property: JsonPropertyName("car")] string Car,
+    [property: JsonPropertyName("condition")] string Condition,
+    [property: JsonPropertyName("g2_typ")] double G2Typ,
+    [property: JsonPropertyName("n_laps_used")] int NLapsUsed
+);
+
+public sealed record LapTimeEntryDto(
+    [property: JsonPropertyName("track_canonical")] string TrackCanonical,
+    [property: JsonPropertyName("car")] string Car,
+    [property: JsonPropertyName("condition")] string Condition,
+    [property: JsonPropertyName("lap_time_typ_s")] double LapTimeTypS,
+    [property: JsonPropertyName("n_laps_used")] int NLapsUsed
+);
+
+// Source-gen context — AOT-friendly. Single entry point lets us deserialize
+// the full root DTO without runtime reflection.
+[JsonSerializable(typeof(TireModelDto))]
+public partial class TireModelJsonContext : JsonSerializerContext { }

--- a/tire_pressure_calculator/Core/Services/Modeling/TireModelLoader.cs
+++ b/tire_pressure_calculator/Core/Services/Modeling/TireModelLoader.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+
+namespace TirePressureCalculator.Services.Modeling;
+
+/// <summary>
+/// Loads the bundled <c>tire_model.json</c> embedded resource (see the
+/// MSBuild <c>EmbeddedResource</c> entry in <c>TirePressureCalculator.Core.csproj</c>).
+/// </summary>
+public static class TireModelLoader
+{
+    private const string EmbeddedName = "tire_model.json";
+
+    public static TireModel LoadEmbedded()
+    {
+        var asm = typeof(TireModelLoader).Assembly;
+        return LoadEmbedded(asm);
+    }
+
+    internal static TireModel LoadEmbedded(Assembly assembly)
+    {
+        using var stream = assembly.GetManifestResourceStream(EmbeddedName)
+            ?? throw new InvalidOperationException(
+                $"Embedded tire model resource '{EmbeddedName}' not found in {assembly.FullName}. " +
+                "Check the EmbeddedResource entry in TirePressureCalculator.Core.csproj.");
+        return LoadFromStream(stream);
+    }
+
+    public static TireModel LoadFromFile(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return LoadFromStream(stream);
+    }
+
+    public static TireModel LoadFromStream(Stream stream)
+    {
+        var dto = JsonSerializer.Deserialize(stream, TireModelJsonContext.Default.TireModelDto)
+            ?? throw new InvalidDataException("tire_model.json deserialized to null.");
+        return new TireModel(dto);
+    }
+}

--- a/tire_pressure_calculator/Core/TirePressureCalculator.Core.csproj
+++ b/tire_pressure_calculator/Core/TirePressureCalculator.Core.csproj
@@ -16,4 +16,14 @@
     <InternalsVisibleTo Include="TirePressureCalculator.Tests" />
   </ItemGroup>
 
+  <!--
+    Bundle the fitted tire model artifact directly from the repo dataset.
+    Refit (`just tire-build-warmup-table`) + rebuild (`dotnet build`) =
+    updated app. The LogicalName fixes the resource key regardless of the
+    source path, so loader code just asks for "tire_model.json".
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\data\tire_dataset\tire_model.json" LogicalName="tire_model.json" />
+  </ItemGroup>
+
 </Project>

--- a/tire_pressure_calculator/Tests/TireModelTests.cs
+++ b/tire_pressure_calculator/Tests/TireModelTests.cs
@@ -1,0 +1,200 @@
+using System.IO;
+using System.Reflection;
+using TirePressureCalculator.Services.Modeling;
+
+namespace TirePressureCalculator.Tests;
+
+public class TireModelTests
+{
+    private static TireModel LoadBundled() =>
+        TireModelLoader.LoadEmbedded(typeof(TireModel).Assembly);
+
+    // ---------- Loader / schema-version gate ----------
+
+    [Fact]
+    public void LoadEmbedded_ParsesBundledArtifact()
+    {
+        var model = LoadBundled();
+        Assert.Equal(TireModel.SupportedSchemaVersion, model.Dto.SchemaVersion);
+        Assert.NotNull(model.Dto.FitAtUtc);
+        Assert.True(model.Dto.KBuckets.Count > 0, "expected at least one K bucket");
+    }
+
+    [Fact]
+    public void Loader_RefusesUnsupportedSchemaVersion()
+    {
+        // Craft a minimal valid-shaped JSON with schema_version=1 and ensure the
+        // wrapper throws. We bypass the embedded path and feed a stream directly.
+        const string oldSchema = """
+            {
+              "schema_version": 1,
+              "fit_at_utc": "2026-01-01T00:00:00Z",
+              "model_form": "old",
+              "gay_lussac": {"p_atm_bar": 1.0, "t_zero_c_to_k": 273.15, "t_cold_uses": "T_air"},
+              "energy_balance": {"w_road": 0.2, "w_road_fitted": false,
+                "t_road_proxy": {"formula": "x", "delta_sun_max_c": 10.0, "sun_factor_default": 1.0}},
+              "conditions": {"values": ["dry"], "default": "dry"},
+              "corners": ["fl", "fr", "rl", "rr"],
+              "min_samples_per_bucket": 5,
+              "priors_when_no_fit": {"tau_sec_seconds": 240.0, "K_kelvin_per_g2": 60.0, "c_track": 1.0},
+              "tau_sec_by_car_corner_cond": [],
+              "K_buckets": [],
+              "c_track_by_track": [],
+              "g2_typ_by_track_car_cond": [],
+              "lap_time_typ_by_track_car_cond": []
+            }
+            """;
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(oldSchema));
+        Assert.Throws<InvalidOperationException>(() => TireModelLoader.LoadFromStream(stream));
+    }
+
+    // ---------- Available cars / tracks / conditions ----------
+
+    [Fact]
+    public void AvailableCars_IncludesBothExpectedCars()
+    {
+        var model = LoadBundled();
+        Assert.Contains("Inferno 86", model.AvailableCars);
+        Assert.Contains("KK-SII", model.AvailableCars);
+    }
+
+    [Fact]
+    public void AvailableTracks_IncludesTsukubaAsAnchor()
+    {
+        var model = LoadBundled();
+        Assert.Contains("tsukuba_2000", model.AvailableTracks);
+        var anchor = model.Dto.CTrackByTrack.Single(r => r.TrackCanonical == "tsukuba_2000");
+        Assert.True(anchor.Anchor, "tsukuba_2000 must be the c_track anchor (value == 1.0)");
+        Assert.Equal(1.0, anchor.Value, precision: 9);
+    }
+
+    [Fact]
+    public void AvailableConditions_ContainsDryDampWet()
+    {
+        var model = LoadBundled();
+        Assert.Equal(new[] { "dry", "damp", "wet" }, model.AvailableConditions);
+        Assert.Equal("dry", model.DefaultCondition);
+    }
+
+    [Fact]
+    public void GayLussac_TColdUses_MatchesPythonConvention()
+    {
+        // Pinning this prevents accidental schema drift: the manual calculator
+        // and the predictor must agree that the Gay-Lussac cold side uses T_air.
+        var model = LoadBundled();
+        Assert.Equal("T_air", model.Dto.GayLussac.TColdUses);
+    }
+
+    // ---------- Condition fallback chain ----------
+
+    [Fact]
+    public void ConditionChain_Dry_ReturnsDryOnly()
+    {
+        Assert.Equal(new[] { "dry" }, TireModel.ConditionChain("dry"));
+    }
+
+    [Fact]
+    public void ConditionChain_Damp_FallsBackToDry()
+    {
+        Assert.Equal(new[] { "damp", "dry" }, TireModel.ConditionChain("damp"));
+    }
+
+    [Fact]
+    public void ConditionChain_Wet_PrefersDampOverDry()
+    {
+        Assert.Equal(new[] { "wet", "damp", "dry" }, TireModel.ConditionChain("wet"));
+    }
+
+    // ---------- Lookup helpers ----------
+
+    [Fact]
+    public void LookupK_KKSII_FL_Dry_HitsExactBucket()
+    {
+        var model = LoadBundled();
+        var k = model.LookupK("KK-SII", "fl", "dry");
+        Assert.False(k.FromPrior);
+        Assert.Contains("KK-SII, fl, dry", k.SourceBucket);
+        Assert.True(k.ValueKelvinPerG2 > 0);
+    }
+
+    [Fact]
+    public void LookupK_KKSII_Wet_FallsBackToDampOrDry()
+    {
+        // KK-SII has no wet K bucket in the current artifact (Fuji wet samples
+        // didn't meet the τ-fit threshold). Wet should fall through the chain
+        // and produce a (KK-SII, *, damp) or (KK-SII, *, dry) source bucket.
+        var model = LoadBundled();
+        var k = model.LookupK("KK-SII", "fl", "wet");
+        Assert.False(k.FromPrior);
+        Assert.True(k.SourceBucket.Contains("damp") || k.SourceBucket.Contains("dry"),
+            $"Expected damp/dry fallback for KK-SII wet; got {k.SourceBucket}");
+    }
+
+    [Fact]
+    public void LookupK_UnknownCar_ReturnsPrior()
+    {
+        var model = LoadBundled();
+        var k = model.LookupK("Fictional Car", "fl", "dry");
+        Assert.True(k.FromPrior);
+        Assert.Equal(model.Dto.PriorsWhenNoFit.KKelvinPerG2, k.ValueKelvinPerG2);
+    }
+
+    [Fact]
+    public void LookupTau_KKSII_FL_Dry_IsInPhysicalRange()
+    {
+        var model = LoadBundled();
+        var tau = model.LookupTau("KK-SII", "fl", "dry");
+        Assert.False(tau.FromPrior);
+        // Plan says racing-tire τ is typically 150–350 s.
+        Assert.InRange(tau.ValueSeconds, 100.0, 500.0);
+    }
+
+    [Fact]
+    public void LookupCTrack_Tsukuba_IsExactlyOne()
+    {
+        var model = LoadBundled();
+        var c = model.LookupCTrack("tsukuba_2000");
+        Assert.Equal(1.0, c.Value, precision: 9);
+        Assert.False(c.FromPrior);
+    }
+
+    [Fact]
+    public void LookupCTrack_UnknownTrack_ReturnsPrior()
+    {
+        var model = LoadBundled();
+        var c = model.LookupCTrack("zandvoort");
+        Assert.True(c.FromPrior);
+        Assert.Equal(model.Dto.PriorsWhenNoFit.CTrack, c.Value);
+    }
+
+    [Fact]
+    public void LookupG2_Tsukuba_KKSII_Dry_IsInPhysicalRange()
+    {
+        var model = LoadBundled();
+        var g2 = model.LookupG2("tsukuba_2000", "KK-SII", "dry");
+        // KK-SII at Tsukuba on dry runs ~1.0 G² per plan
+        Assert.InRange(g2.Value, 0.5, 1.5);
+        Assert.Equal("exact", g2.Source);
+    }
+
+    [Fact]
+    public void LookupG2_NewTrack_FallsBackToGlobalMean()
+    {
+        var model = LoadBundled();
+        var g2 = model.LookupG2("zandvoort", "KK-SII", "dry");
+        // No data for zandvoort at all → no track-car, no track-only,
+        // chain falls all the way to global.
+        Assert.Equal("global", g2.Source);
+        Assert.InRange(g2.Value, 0.3, 1.5);
+    }
+
+    [Fact]
+    public void LookupLapTime_Tsukuba_KKSII_Dry_IsInPhysicalRange()
+    {
+        var model = LoadBundled();
+        var lt = model.LookupLapTime("tsukuba_2000", "KK-SII", "dry");
+        // Tsukuba KK-SII typical lap ~ 60-70 s
+        Assert.InRange(lt.ValueSeconds, 40.0, 90.0);
+        Assert.Equal("exact", lt.Source);
+    }
+}


### PR DESCRIPTION

First commit of the C# integration of the Python tire-warmup model
(PRs #112-#118). Adds the model artifact bundling and a typed parser
that can load it, but no predictor or UI yet.

- `Core/TirePressureCalculator.Core.csproj`: embeds the committed
  `data/tire_dataset/tire_model.json` as a resource with LogicalName
  `tire_model.json` so refits (`just tire-build-warmup-table`) +
  rebuilds (`dotnet build`) ship together.
- `Core/Services/Modeling/TireModelDtos.cs`: System.Text.Json
  source-gen DTOs (`TireModelJsonContext`) mirroring schema v2 — refuses
  v1, which prevents accidentally loading a pre-rain artifact.
- `Core/Services/Modeling/TireModel.cs`: in-memory wrapper with
  lookups + the condition fallback chain (wet → damp → dry, damp → dry,
  dry → dry) that mirrors `predict.py:_CONDITION_FALLBACK` exactly.
  Lookups: `LookupK`, `LookupTau`, `LookupCTrack`, `LookupG2`,
  `LookupLapTime`. Each carries (value, stderr, n_samples, SourceBucket)
  so downstream callers can surface provenance.
- `Core/Services/Modeling/TireModelLoader.cs`: reads the embedded
  resource (`LoadEmbedded()`) or an arbitrary file/stream for tests.

Tests cover parsing the bundled artifact (asserts schema_version=2,
expected cars/tracks/conditions present, `gay_lussac.t_cold_uses=T_air`),
the condition fallback chain, and each lookup's exact-match + fallback
behavior. 18 new tests; 54 total in the project pass after this commit.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/119).
* #122
* #121
* #120
* __->__ #119
* #118