### PR TITLE
Bump version 0.15.0 → 0.16.0 (release prep)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motorsports-data-notebook"
-version = "0.15.0"
+version = "0.16.0"
 description = ""
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/tire_pressure_calculator/Core/Settings.cs
+++ b/tire_pressure_calculator/Core/Settings.cs
@@ -18,6 +18,23 @@ public interface ISettingsStorage
     void Write(string contents);
 }
 
+public enum AppMode
+{
+    Manual = 0,
+    CircuitPrediction = 1,
+}
+
+public class PredictionSettings
+{
+    public string? Track { get; set; }
+    public string? Car { get; set; }
+    public string Condition { get; set; } = "dry";
+    public int LapWithinStint { get; set; } = 5;
+    public double AmbientTempC { get; set; } = 20.0;
+    public double? TrackTempC { get; set; }
+    public double? CloudCoverPct { get; set; }
+}
+
 public class AppSettings
 {
     public CornerSettings FrontLeft { get; set; } = new();
@@ -25,6 +42,8 @@ public class AppSettings
     public CornerSettings RearLeft { get; set; } = new();
     public CornerSettings RearRight { get; set; } = new();
     public double TempAdjustPercent { get; set; }
+    public AppMode Mode { get; set; } = AppMode.Manual;
+    public PredictionSettings Prediction { get; set; } = new();
 
     public static ISettingsStorage Storage { get; set; } = new FileSettingsStorage();
 

--- a/tire_pressure_calculator/Core/ViewModels/MainViewModel.cs
+++ b/tire_pressure_calculator/Core/ViewModels/MainViewModel.cs
@@ -1,6 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
+using TirePressureCalculator.Services;
+using TirePressureCalculator.Services.Modeling;
 
 namespace TirePressureCalculator.ViewModels;
 
@@ -13,7 +20,146 @@ public class MainViewModel : INotifyPropertyChanged
     public ICommand ResetCommand { get; }
 
     private readonly AppSettings _settings;
+    private readonly TireModel? _tireModel;
+    private readonly CircuitPredictor? _predictor;
     private double _tempAdjustPercent;
+
+    // ---- Mode + prediction inputs ----
+
+    private AppMode _mode;
+    private string? _selectedTrack;
+    private string? _selectedCar;
+    private string _selectedCondition = "dry";
+    private int _lapWithinStint = 5;
+    private double _ambientTempC = 20.0;
+    private double? _trackTempC;
+    private double? _cloudCoverPct;
+
+    public AppMode Mode
+    {
+        get => _mode;
+        set
+        {
+            if (_mode == value) return;
+            _mode = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsManualMode));
+            OnPropertyChanged(nameof(IsPredictionMode));
+            _settings.Mode = value;
+            _settings.Save();
+            RefreshPredictions();
+        }
+    }
+
+    public bool IsManualMode => _mode == AppMode.Manual;
+    public bool IsPredictionMode => _mode == AppMode.CircuitPrediction;
+
+    public ObservableCollection<string> AvailableTracks { get; } = new();
+    public ObservableCollection<string> AvailableCars { get; } = new();
+    public IReadOnlyList<string> AvailableConditions { get; } =
+        new[] { "dry", "damp", "wet" };
+
+    public string? SelectedTrack
+    {
+        get => _selectedTrack;
+        set
+        {
+            if (_selectedTrack == value) return;
+            _selectedTrack = value;
+            OnPropertyChanged();
+            _settings.Prediction.Track = value;
+            _settings.Save();
+            RefreshPredictions();
+        }
+    }
+
+    public string? SelectedCar
+    {
+        get => _selectedCar;
+        set
+        {
+            if (_selectedCar == value) return;
+            _selectedCar = value;
+            OnPropertyChanged();
+            _settings.Prediction.Car = value;
+            _settings.Save();
+            RefreshPredictions();
+        }
+    }
+
+    public string SelectedCondition
+    {
+        get => _selectedCondition;
+        set
+        {
+            if (_selectedCondition == value) return;
+            _selectedCondition = value;
+            OnPropertyChanged();
+            _settings.Prediction.Condition = value;
+            _settings.Save();
+            RefreshPredictions();
+        }
+    }
+
+    public int LapWithinStint
+    {
+        get => _lapWithinStint;
+        set
+        {
+            if (_lapWithinStint == value) return;
+            _lapWithinStint = value;
+            OnPropertyChanged();
+            _settings.Prediction.LapWithinStint = value;
+            _settings.Save();
+            RefreshPredictions();
+        }
+    }
+
+    public double AmbientTempC
+    {
+        get => _ambientTempC;
+        set
+        {
+            if (_ambientTempC == value) return;
+            _ambientTempC = value;
+            OnPropertyChanged();
+            _settings.Prediction.AmbientTempC = value;
+            _settings.Save();
+            RefreshPredictions();
+        }
+    }
+
+    public double? TrackTempC
+    {
+        get => _trackTempC;
+        set
+        {
+            if (_trackTempC == value) return;
+            _trackTempC = value;
+            OnPropertyChanged();
+            _settings.Prediction.TrackTempC = value;
+            _settings.Save();
+            RefreshPredictions();
+        }
+    }
+
+    public double? CloudCoverPct
+    {
+        get => _cloudCoverPct;
+        set
+        {
+            if (_cloudCoverPct == value) return;
+            _cloudCoverPct = value;
+            OnPropertyChanged();
+            _settings.Prediction.CloudCoverPct = value;
+            _settings.Save();
+            RefreshPredictions();
+        }
+    }
+
+    public bool TireModelAvailable => _tireModel is not null;
+
+    // ---- TempAdjust (existing) ----
 
     public double TempAdjustPercent
     {
@@ -37,15 +183,45 @@ public class MainViewModel : INotifyPropertyChanged
         ? "Temp adjust: 0%"
         : $"Temp adjust: {_tempAdjustPercent:+0.0;-0.0}%";
 
+    // ---- Construction ----
+
     public MainViewModel()
+        : this(LoadEmbeddedModelSafely())
+    {
+    }
+
+    /// <summary>
+    /// Test-friendly ctor that accepts an explicit model (or null to disable prediction).
+    /// </summary>
+    public MainViewModel(TireModel? tireModel)
     {
         _settings = AppSettings.Load();
         _tempAdjustPercent = _settings.TempAdjustPercent;
+        _tireModel = tireModel;
+        _predictor = tireModel is not null ? new CircuitPredictor(tireModel) : null;
 
         FrontLeft = CreateCorner("FL", _settings.FrontLeft);
         FrontRight = CreateCorner("FR", _settings.FrontRight);
         RearLeft = CreateCorner("RL", _settings.RearLeft);
         RearRight = CreateCorner("RR", _settings.RearRight);
+
+        if (_tireModel is not null)
+        {
+            foreach (var t in _tireModel.AvailableTracks) AvailableTracks.Add(t);
+            foreach (var c in _tireModel.AvailableCars) AvailableCars.Add(c);
+        }
+
+        // Restore persisted mode + prediction inputs.
+        _mode = _tireModel is null ? AppMode.Manual : _settings.Mode;
+        _selectedTrack = _settings.Prediction.Track is string t1 && AvailableTracks.Contains(t1) ? t1
+            : AvailableTracks.FirstOrDefault();
+        _selectedCar = _settings.Prediction.Car is string c1 && AvailableCars.Contains(c1) ? c1
+            : AvailableCars.FirstOrDefault();
+        _selectedCondition = _settings.Prediction.Condition;
+        _lapWithinStint = _settings.Prediction.LapWithinStint;
+        _ambientTempC = _settings.Prediction.AmbientTempC;
+        _trackTempC = _settings.Prediction.TrackTempC;
+        _cloudCoverPct = _settings.Prediction.CloudCoverPct;
 
         ResetCommand = new RelayCommand(() =>
         {
@@ -55,6 +231,22 @@ public class MainViewModel : INotifyPropertyChanged
             RearLeft.ResetToDefaults();
             RearRight.ResetToDefaults();
         });
+
+        RefreshPredictions();
+    }
+
+    private static TireModel? LoadEmbeddedModelSafely()
+    {
+        try
+        {
+            return TireModelLoader.LoadEmbedded(typeof(MainViewModel).Assembly);
+        }
+        catch (Exception)
+        {
+            // Mobile/browser heads may not have the embedded model wired up,
+            // and we still want Manual mode to work without it.
+            return null;
+        }
     }
 
     private TireCornerViewModel CreateCorner(string label, CornerSettings s)
@@ -67,14 +259,67 @@ public class MainViewModel : INotifyPropertyChanged
             TargetHotPressure = s.TargetHotPressure,
             TempAdjustPercent = _tempAdjustPercent
         };
-        vm.PropertyChanged += (_, _) =>
+        vm.PropertyChanged += (_, e) =>
         {
             s.CurrentTemp = vm.CurrentTemp;
             s.TargetHotTemp = vm.TargetHotTemp;
             s.TargetHotPressure = vm.TargetHotPressure;
             _settings.Save();
+            // Per-corner target hot pressure change should refresh predictions
+            // (the predicted T_hot is independent of target hot pressure, but
+            // the cold pressure displayed is a function of it — covered by the
+            // corner VM's own ColdPressure recompute).
+            if (e.PropertyName == nameof(TireCornerViewModel.TargetHotPressure)
+                && IsPredictionMode)
+            {
+                // Nothing extra to do — the corner already re-renders cold pressure
+                // because PredictedHotTempC is unchanged.
+            }
         };
         return vm;
+    }
+
+    /// <summary>
+    /// Recompute per-corner predicted hot temps + push into each corner VM
+    /// (or clear them in Manual mode so the corner falls back to AdjustedHotTemp).
+    /// </summary>
+    private void RefreshPredictions()
+    {
+        if (!IsPredictionMode || _predictor is null
+            || _selectedTrack is null || _selectedCar is null)
+        {
+            FrontLeft.PredictedHotTempC = null;
+            FrontRight.PredictedHotTempC = null;
+            RearLeft.PredictedHotTempC = null;
+            RearRight.PredictedHotTempC = null;
+            return;
+        }
+        foreach (var (corner, vm) in new[]
+                 {
+                     ("fl", FrontLeft), ("fr", FrontRight),
+                     ("rl", RearLeft), ("rr", RearRight),
+                 })
+        {
+            try
+            {
+                var prediction = _predictor.Predict(
+                    track: _selectedTrack,
+                    car: _selectedCar,
+                    condition: _selectedCondition,
+                    lapWithinStint: _lapWithinStint,
+                    ambientTempC: _ambientTempC,
+                    trackTempC: _trackTempC,
+                    cloudCoverPct: _cloudCoverPct,
+                    corner: corner,
+                    targetHotPressureBar: vm.TargetHotPressure,
+                    coldTireTempC: vm.CurrentTemp);
+                vm.PredictedHotTempC = prediction.PredictedHotTempC;
+            }
+            catch (Exception)
+            {
+                vm.PredictedHotTempC = null;
+            }
+        }
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/tire_pressure_calculator/Core/ViewModels/TireCornerViewModel.cs
+++ b/tire_pressure_calculator/Core/ViewModels/TireCornerViewModel.cs
@@ -11,6 +11,38 @@ public class TireCornerViewModel : INotifyPropertyChanged
     private double _targetHotTemp = 80.0;
     private double _targetHotPressure = 1.80;
     private double _tempAdjustPercent;
+    private double? _predictedHotTempC;
+
+    /// <summary>
+    /// When non-null, <see cref="ColdPressure"/> uses this value as T_hot
+    /// instead of <see cref="AdjustedHotTemp"/>. Set by MainViewModel when
+    /// in Circuit Prediction mode; null in Manual mode (preserves existing
+    /// behavior).
+    /// </summary>
+    public double? PredictedHotTempC
+    {
+        get => _predictedHotTempC;
+        set
+        {
+            if (_predictedHotTempC == value) return;
+            _predictedHotTempC = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(EffectiveHotTempC));
+            OnPropertyChanged(nameof(PredictedHotTempDisplay));
+            OnPropertyChanged(nameof(HasPrediction));
+            OnPropertyChanged(nameof(ColdPressure));
+        }
+    }
+
+    public bool HasPrediction => _predictedHotTempC is not null;
+
+    /// <summary>Hot temperature used by the Gay-Lussac inversion. Equals
+    /// <see cref="PredictedHotTempC"/> when set; otherwise <see cref="AdjustedHotTemp"/>.</summary>
+    public double EffectiveHotTempC => _predictedHotTempC ?? AdjustedHotTemp;
+
+    public string PredictedHotTempDisplay => _predictedHotTempC is double t
+        ? $"Predicted hot: {t:F1} °C"
+        : "";
 
     public string Label
     {
@@ -79,7 +111,7 @@ public class TireCornerViewModel : INotifyPropertyChanged
     {
         get
         {
-            double tHotC = AdjustedHotTemp;
+            double tHotC = EffectiveHotTempC;
             if (tHotC + EnergyBalance.TZeroCToK <= 0) return 0;
             return Math.Round(
                 EnergyBalance.GayLussacColdPressureBar(

--- a/tire_pressure_calculator/Core/Views/MainView.axaml
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml
@@ -30,10 +30,13 @@
                              HorizontalContentAlignment="Center" />
             </Border>
 
+            <!-- Manual mode: Target °C input -->
             <TextBlock Grid.Row="0" Grid.Column="2" Text="Target °C (Corr. °C)"
-                       FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+                       FontSize="11" HorizontalAlignment="Center" Margin="0,2"
+                       IsVisible="{Binding IsManualMode, RelativeSource={RelativeSource AncestorType=views:MainView}}" />
             <Border Grid.Row="1" Grid.Column="2"
-                    BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
+                    BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4"
+                    IsVisible="{Binding IsManualMode, RelativeSource={RelativeSource AncestorType=views:MainView}}">
               <Panel>
                 <NumericUpDown Value="{Binding TargetHotTemp}"
                                Minimum="0" Maximum="200"
@@ -54,6 +57,18 @@
                 </Panel.Styles>
               </Panel>
             </Border>
+
+            <!-- Prediction mode: read-only predicted hot temp -->
+            <TextBlock Grid.Row="0" Grid.Column="2" Text="Predicted hot °C"
+                       FontSize="11" HorizontalAlignment="Center" Margin="0,2"
+                       IsVisible="{Binding IsPredictionMode, RelativeSource={RelativeSource AncestorType=views:MainView}}" />
+            <Border Grid.Row="1" Grid.Column="2"
+                    BorderBrush="#4090C090" BorderThickness="1.5" CornerRadius="4"
+                    IsVisible="{Binding IsPredictionMode, RelativeSource={RelativeSource AncestorType=views:MainView}}">
+              <TextBlock Text="{Binding PredictedHotTempC, StringFormat='{}{0:F1}', FallbackValue='—'}"
+                         HorizontalAlignment="Center" VerticalAlignment="Center"
+                         Padding="6,2" />
+            </Border>
           </Grid>
 
           <StackPanel HorizontalAlignment="Center" Margin="0,4,0,0">
@@ -71,7 +86,7 @@
           </StackPanel>
         </StackPanel>
 
-        <!-- Wide layout: all three fields in a single row -->
+        <!-- Wide layout: all fields in a single row -->
         <Grid ColumnDefinitions="*,8,*,8,*" RowDefinitions="Auto,Auto"
               IsVisible="{Binding IsWide, RelativeSource={RelativeSource AncestorType=views:MainView}}">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Current °C"
@@ -85,10 +100,13 @@
                            HorizontalContentAlignment="Center" />
           </Border>
 
+          <!-- Manual mode: Target °C input -->
           <TextBlock Grid.Row="0" Grid.Column="2" Text="Target °C (Corr. °C)"
-                     FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+                     FontSize="11" HorizontalAlignment="Center" Margin="0,2"
+                     IsVisible="{Binding IsManualMode, RelativeSource={RelativeSource AncestorType=views:MainView}}" />
           <Border Grid.Row="1" Grid.Column="2"
-                  BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
+                  BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4"
+                  IsVisible="{Binding IsManualMode, RelativeSource={RelativeSource AncestorType=views:MainView}}">
             <Panel>
               <NumericUpDown Value="{Binding TargetHotTemp}"
                              Minimum="0" Maximum="200"
@@ -108,6 +126,18 @@
                 </Style>
               </Panel.Styles>
             </Panel>
+          </Border>
+
+          <!-- Prediction mode: read-only predicted hot temp -->
+          <TextBlock Grid.Row="0" Grid.Column="2" Text="Predicted hot °C"
+                     FontSize="11" HorizontalAlignment="Center" Margin="0,2"
+                     IsVisible="{Binding IsPredictionMode, RelativeSource={RelativeSource AncestorType=views:MainView}}" />
+          <Border Grid.Row="1" Grid.Column="2"
+                  BorderBrush="#4090C090" BorderThickness="1.5" CornerRadius="4"
+                  IsVisible="{Binding IsPredictionMode, RelativeSource={RelativeSource AncestorType=views:MainView}}">
+            <TextBlock Text="{Binding PredictedHotTempC, StringFormat='{}{0:F1}', FallbackValue='—'}"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Padding="6,2" />
           </Border>
 
           <TextBlock Grid.Row="0" Grid.Column="4" Text="Target bar"
@@ -123,7 +153,7 @@
           </Border>
         </Grid>
 
-        <!-- Narrow layout: all three fields stacked vertically at full width -->
+        <!-- Narrow layout: all fields stacked vertically at full width -->
         <StackPanel Spacing="4"
                     IsVisible="{Binding IsNarrow, RelativeSource={RelativeSource AncestorType=views:MainView}}">
           <TextBlock Text="Current °C"
@@ -136,29 +166,43 @@
                            HorizontalContentAlignment="Center" />
           </Border>
 
-          <TextBlock Text="Target °C (Corr. °C)"
-                     FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
-          <Border BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
-            <Panel>
-              <NumericUpDown Value="{Binding TargetHotTemp}"
-                             Minimum="0" Maximum="200"
-                             FormatString="F1" Increment="1"
-                             ShowButtonSpinner="False"
-                             HorizontalContentAlignment="Center" />
-              <TextBlock Text="{Binding TargetHotTempDisplay}"
-                         HorizontalAlignment="Center"
-                         VerticalAlignment="Center"
-                         IsHitTestVisible="False" />
-              <Panel.Styles>
-                <Style Selector="Panel:not(:focus-within) > NumericUpDown">
-                  <Setter Property="Foreground" Value="Transparent" />
-                </Style>
-                <Style Selector="Panel:focus-within > TextBlock">
-                  <Setter Property="IsVisible" Value="False" />
-                </Style>
-              </Panel.Styles>
-            </Panel>
-          </Border>
+          <!-- Manual mode: Target °C input -->
+          <StackPanel IsVisible="{Binding IsManualMode, RelativeSource={RelativeSource AncestorType=views:MainView}}">
+            <TextBlock Text="Target °C (Corr. °C)"
+                       FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+            <Border BorderBrush="#40FF4040" BorderThickness="1.5" CornerRadius="4">
+              <Panel>
+                <NumericUpDown Value="{Binding TargetHotTemp}"
+                               Minimum="0" Maximum="200"
+                               FormatString="F1" Increment="1"
+                               ShowButtonSpinner="False"
+                               HorizontalContentAlignment="Center" />
+                <TextBlock Text="{Binding TargetHotTempDisplay}"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           IsHitTestVisible="False" />
+                <Panel.Styles>
+                  <Style Selector="Panel:not(:focus-within) > NumericUpDown">
+                    <Setter Property="Foreground" Value="Transparent" />
+                  </Style>
+                  <Style Selector="Panel:focus-within > TextBlock">
+                    <Setter Property="IsVisible" Value="False" />
+                  </Style>
+                </Panel.Styles>
+              </Panel>
+            </Border>
+          </StackPanel>
+
+          <!-- Prediction mode: read-only predicted hot temp -->
+          <StackPanel IsVisible="{Binding IsPredictionMode, RelativeSource={RelativeSource AncestorType=views:MainView}}">
+            <TextBlock Text="Predicted hot °C"
+                       FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
+            <Border BorderBrush="#4090C090" BorderThickness="1.5" CornerRadius="4">
+              <TextBlock Text="{Binding PredictedHotTempC, StringFormat='{}{0:F1}', FallbackValue='—'}"
+                         HorizontalAlignment="Center" VerticalAlignment="Center"
+                         Padding="6,2" />
+            </Border>
+          </StackPanel>
 
           <TextBlock Text="Target bar"
                      FontSize="11" HorizontalAlignment="Center" Margin="0,2" />
@@ -192,48 +236,70 @@
                 VerticalScrollBarVisibility="Hidden">
     <LayoutTransformControl x:Name="RootLayoutTransform">
     <Grid x:Name="RootGrid"
-          RowDefinitions="Auto,*,*,Auto" ColumnDefinitions="*,*">
+          RowDefinitions="Auto,Auto,*,*,Auto,Auto" ColumnDefinitions="*,*">
 
-      <!-- Front arrow (broad, flat) centered at top -->
-      <Panel Grid.Row="0" Grid.ColumnSpan="2" Height="32" Margin="0,6,0,0">
+      <!-- ROW 0: Mode toggle (always visible) -->
+      <Border Grid.Row="0" Grid.ColumnSpan="2"
+              Padding="12,6"
+              Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center"
+                    VerticalAlignment="Center" Spacing="12">
+          <TextBlock Text="Mode:" VerticalAlignment="Center" FontWeight="SemiBold" />
+          <ToggleSwitch x:Name="ModeToggle"
+                        OffContent="Manual"
+                        OnContent="Circuit Prediction"
+                        IsChecked="{Binding IsPredictionMode, Mode=OneWay}"
+                        IsCheckedChanged="OnModeToggleCheckedChanged"
+                        Tapped="OnModeToggleTapped"
+                        IsEnabled="{Binding TireModelAvailable}" />
+          <TextBlock Text=" (tire model unavailable on this build)"
+                     IsVisible="{Binding !TireModelAvailable}"
+                     Foreground="OrangeRed" FontSize="11" VerticalAlignment="Center" />
+        </StackPanel>
+      </Border>
+
+      <!-- ROW 1: Front arrow (broad, flat) centered at top of corners -->
+      <Panel Grid.Row="1" Grid.ColumnSpan="2" Height="32" Margin="0,6,0,0">
         <Polygon Points="0,28 100,0 200,28"
                  Stroke="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                  StrokeThickness="2"
                  HorizontalAlignment="Center" VerticalAlignment="Center" />
       </Panel>
 
-      <!-- Vertical divider line (overlaps arrow row by 1px to close gap) -->
-      <Border Grid.Row="0" Grid.RowSpan="3" Grid.ColumnSpan="2"
+      <!-- Vertical divider line through the corner grid -->
+      <Border Grid.Row="1" Grid.RowSpan="3" Grid.ColumnSpan="2"
               HorizontalAlignment="Center" Width="2" Margin="0,37,0,8"
               Background="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
 
-      <!-- Horizontal divider line -->
-      <Border Grid.Row="1" Grid.RowSpan="2" Grid.ColumnSpan="2"
+      <!-- Horizontal divider line between front and rear rows -->
+      <Border Grid.Row="2" Grid.RowSpan="2" Grid.ColumnSpan="2"
               VerticalAlignment="Center" Height="2" Margin="8,0"
               Background="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
 
       <!-- Four quadrants -->
-      <ContentControl x:Name="FLCorner" Grid.Row="1" Grid.Column="0"
+      <ContentControl x:Name="FLCorner" Grid.Row="2" Grid.Column="0"
                       Content="{Binding FrontLeft}"
                       ContentTemplate="{StaticResource CornerTemplate}" />
-      <ContentControl x:Name="FRCorner" Grid.Row="1" Grid.Column="1"
+      <ContentControl x:Name="FRCorner" Grid.Row="2" Grid.Column="1"
                       Content="{Binding FrontRight}"
                       ContentTemplate="{StaticResource CornerTemplate}" />
-      <ContentControl x:Name="RLCorner" Grid.Row="2" Grid.Column="0"
+      <ContentControl x:Name="RLCorner" Grid.Row="3" Grid.Column="0"
                       Content="{Binding RearLeft}"
                       ContentTemplate="{StaticResource CornerTemplate}" />
-      <ContentControl x:Name="RRCorner" Grid.Row="2" Grid.Column="1"
+      <ContentControl x:Name="RRCorner" Grid.Row="3" Grid.Column="1"
                       Content="{Binding RearRight}"
                       ContentTemplate="{StaticResource CornerTemplate}" />
-      <!-- Bottom bar: reset + slider -->
-      <Button Grid.Row="3" Grid.Column="0"
+
+      <!-- ROW 4: Bottom bar — reset (always) + correction slider (manual only) -->
+      <Button Grid.Row="4" Grid.Column="0"
               Content="Reset to Defaults"
               Command="{Binding ResetCommand}"
               HorizontalAlignment="Left" VerticalAlignment="Center"
               Margin="8,4,0,8" />
-      <StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal"
+      <StackPanel Grid.Row="4" Grid.Column="1" Orientation="Horizontal"
                   HorizontalAlignment="Right" VerticalAlignment="Center"
-                  Margin="0,4,8,8" Spacing="8">
+                  Margin="0,4,8,8" Spacing="8"
+                  IsVisible="{Binding IsManualMode}">
         <TextBlock Text="{Binding TempAdjustLabel}"
                    VerticalAlignment="Center" FontSize="12" />
         <Slider Value="{Binding TempAdjustPercent}"
@@ -241,6 +307,57 @@
                 TickFrequency="0.5" IsSnapToTickEnabled="True"
                 Width="150" VerticalAlignment="Center" />
       </StackPanel>
+
+      <!-- ROW 5: Prediction inputs panel at the BOTTOM (visible only in prediction mode) -->
+      <Border Grid.Row="5" Grid.ColumnSpan="2"
+              IsVisible="{Binding IsPredictionMode}"
+              Padding="12,8"
+              Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}">
+        <!-- WrapPanel without ItemHeight/ItemWidth so each row sizes to its
+             tallest item; that prevents label/input overlap when items reflow
+             to a second row on narrow screens. -->
+        <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center">
+          <StackPanel Margin="6,4" MinWidth="150">
+            <TextBlock Text="Track" FontSize="11" />
+            <ComboBox ItemsSource="{Binding AvailableTracks}"
+                      SelectedItem="{Binding SelectedTrack}"
+                      HorizontalAlignment="Stretch" />
+          </StackPanel>
+          <StackPanel Margin="6,4" MinWidth="150">
+            <TextBlock Text="Car" FontSize="11" />
+            <ComboBox ItemsSource="{Binding AvailableCars}"
+                      SelectedItem="{Binding SelectedCar}"
+                      HorizontalAlignment="Stretch" />
+          </StackPanel>
+          <StackPanel Margin="6,4" MinWidth="120">
+            <TextBlock Text="Condition" FontSize="11" />
+            <ComboBox ItemsSource="{Binding AvailableConditions}"
+                      SelectedItem="{Binding SelectedCondition}"
+                      HorizontalAlignment="Stretch" />
+          </StackPanel>
+          <StackPanel Margin="6,4" MinWidth="120">
+            <TextBlock Text="Lap within stint" FontSize="11" />
+            <NumericUpDown Value="{Binding LapWithinStint}"
+                           Minimum="1" Maximum="60" Increment="1"
+                           FormatString="F0"
+                           ShowButtonSpinner="True" />
+          </StackPanel>
+          <StackPanel Margin="6,4" MinWidth="120">
+            <TextBlock Text="Ambient °C" FontSize="11" />
+            <NumericUpDown Value="{Binding AmbientTempC}"
+                           Minimum="-20" Maximum="50" Increment="0.5"
+                           FormatString="F1"
+                           ShowButtonSpinner="True" />
+          </StackPanel>
+          <StackPanel Margin="6,4" MinWidth="120">
+            <TextBlock Text="Cloud cover %" FontSize="11" />
+            <NumericUpDown Value="{Binding CloudCoverPct}"
+                           Minimum="0" Maximum="100" Increment="10"
+                           FormatString="F0"
+                           ShowButtonSpinner="True" />
+          </StackPanel>
+        </WrapPanel>
+      </Border>
     </Grid>
     </LayoutTransformControl>
   </ScrollViewer>

--- a/tire_pressure_calculator/Core/Views/MainView.axaml.cs
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml.cs
@@ -51,6 +51,33 @@ public partial class MainView : UserControl
     public static readonly DirectProperty<MainView, bool> IsMediumProperty =
         AvaloniaProperty.RegisterDirect<MainView, bool>(nameof(IsMedium), o => o.IsMedium);
 
+    // Mode proxy properties — let the compiled CornerTemplate bindings reach the
+    // VM via the existing `AncestorType=views:MainView` pattern that
+    // IsMedium/IsWide/IsNarrow already use. Kept in sync with DataContext.Mode
+    // through DataContextChanged + the VM's PropertyChanged.
+    public static readonly DirectProperty<MainView, bool> IsManualModeProperty =
+        AvaloniaProperty.RegisterDirect<MainView, bool>(
+            nameof(IsManualMode), o => o.IsManualMode);
+
+    public static readonly DirectProperty<MainView, bool> IsPredictionModeProperty =
+        AvaloniaProperty.RegisterDirect<MainView, bool>(
+            nameof(IsPredictionMode), o => o.IsPredictionMode);
+
+    private bool _isManualMode = true;
+    private bool _isPredictionMode;
+
+    public bool IsManualMode
+    {
+        get => _isManualMode;
+        private set => SetAndRaise(IsManualModeProperty, ref _isManualMode, value);
+    }
+
+    public bool IsPredictionMode
+    {
+        get => _isPredictionMode;
+        private set => SetAndRaise(IsPredictionModeProperty, ref _isPredictionMode, value);
+    }
+
     // True when the smallest screen dimension is below the tablet threshold.
     // Drives the phone-only zoom-to-quadrant behavior.
     public bool IsPhoneSize { get; private set; } = true;
@@ -75,6 +102,77 @@ public partial class MainView : UserControl
         AddHandler(LostFocusEvent, OnChildLostFocus);
         AddHandler(KeyDownEvent, OnChildKeyDown, RoutingStrategies.Bubble, handledEventsToo: true);
         AddHandler(PointerPressedEvent, OnBackgroundPointerPressed, RoutingStrategies.Bubble, handledEventsToo: true);
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private TirePressureCalculator.ViewModels.MainViewModel? _boundVm;
+
+    private void OnDataContextChanged(object? sender, System.EventArgs e)
+    {
+        if (_boundVm is not null)
+        {
+            _boundVm.PropertyChanged -= OnVmPropertyChanged;
+            _boundVm = null;
+        }
+        if (DataContext is TirePressureCalculator.ViewModels.MainViewModel vm)
+        {
+            _boundVm = vm;
+            vm.PropertyChanged += OnVmPropertyChanged;
+            SyncModeFromVm(vm);
+        }
+        else
+        {
+            IsManualMode = true;
+            IsPredictionMode = false;
+        }
+    }
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TirePressureCalculator.ViewModels.MainViewModel.Mode)
+            && sender is TirePressureCalculator.ViewModels.MainViewModel vm)
+        {
+            SyncModeFromVm(vm);
+        }
+    }
+
+    private void SyncModeFromVm(TirePressureCalculator.ViewModels.MainViewModel vm)
+    {
+        IsManualMode = vm.IsManualMode;
+        IsPredictionMode = vm.IsPredictionMode;
+    }
+
+    /// <summary>
+    /// Event-driven IsChecked → VM.Mode commit. We bypass the converter-based
+    /// binding because in WASM the ToggleSwitch's click-to-toggle path didn't
+    /// reliably commit through compiled bindings, while drag-to-toggle did.
+    /// Wiring this event ensures both gestures push the new value to the VM.
+    /// </summary>
+    private void OnModeToggleCheckedChanged(object? sender, RoutedEventArgs e)
+    {
+        if (sender is ToggleSwitch t
+            && DataContext is TirePressureCalculator.ViewModels.MainViewModel vm
+            && vm.TireModelAvailable)
+        {
+            var desired = t.IsChecked == true ? AppMode.CircuitPrediction : AppMode.Manual;
+            if (vm.Mode != desired) vm.Mode = desired;
+        }
+    }
+
+    // Avalonia 11.3's ToggleSwitch flips IsChecked on drag but the click/tap
+    // path doesn't reliably reach the IsChecked property in the WASM head —
+    // PointerPressed/Released get intercepted by the template's drag detector
+    // and never propagate to a useful update. The gesture-level `Tapped`
+    // event fires AFTER the ToggleSwitch's drag tracker has decided "this
+    // wasn't a drag", so it's the right hook for the no-drag tap case.
+    // (On drag, Tapped does not fire — only the native drag-toggle path runs,
+    // which we already commit via IsCheckedChanged above.)
+    private void OnModeToggleTapped(object? sender, Avalonia.Input.TappedEventArgs e)
+    {
+        if (sender is ToggleSwitch t && t.IsEnabled)
+        {
+            t.IsChecked = !(t.IsChecked == true);
+        }
     }
 
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)

--- a/tire_pressure_calculator/Core/Views/ModeBoolConverter.cs
+++ b/tire_pressure_calculator/Core/Views/ModeBoolConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace TirePressureCalculator.Views;
+
+/// <summary>
+/// Converts <see cref="AppMode"/> ↔ bool for the <c>ToggleSwitch.IsChecked</c>
+/// binding in <c>MainView.axaml</c>:
+/// <list type="bullet">
+///   <item><c>Manual</c> ↔ <c>false</c> (toggle off)</item>
+///   <item><c>CircuitPrediction</c> ↔ <c>true</c> (toggle on)</item>
+/// </list>
+/// </summary>
+public sealed class ModeBoolConverter : IValueConverter
+{
+    public static readonly ModeBoolConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is AppMode m && m == AppMode.CircuitPrediction;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is true ? AppMode.CircuitPrediction : AppMode.Manual;
+}

--- a/tire_pressure_calculator/Tests/AppSettingsTests.cs
+++ b/tire_pressure_calculator/Tests/AppSettingsTests.cs
@@ -26,6 +26,45 @@ public class AppSettingsTests
     }
 
     [Fact]
+    public void AppSettings_Defaults_ModeIsManual()
+    {
+        var s = new AppSettings();
+        Assert.Equal(AppMode.Manual, s.Mode);
+        Assert.NotNull(s.Prediction);
+        Assert.Equal("dry", s.Prediction.Condition);
+    }
+
+    [Fact]
+    public void AppSettings_PredictionFields_RoundTrip()
+    {
+        var original = new AppSettings
+        {
+            Mode = AppMode.CircuitPrediction,
+            Prediction = new PredictionSettings
+            {
+                Track = "tsukuba_2000",
+                Car = "KK-SII",
+                Condition = "damp",
+                LapWithinStint = 7,
+                AmbientTempC = 18.5,
+                TrackTempC = 22.0,
+                CloudCoverPct = 60.0,
+            },
+        };
+        var json = JsonSerializer.Serialize(original);
+        var deserialized = JsonSerializer.Deserialize<AppSettings>(json)!;
+
+        Assert.Equal(AppMode.CircuitPrediction, deserialized.Mode);
+        Assert.Equal("tsukuba_2000", deserialized.Prediction.Track);
+        Assert.Equal("KK-SII", deserialized.Prediction.Car);
+        Assert.Equal("damp", deserialized.Prediction.Condition);
+        Assert.Equal(7, deserialized.Prediction.LapWithinStint);
+        Assert.Equal(18.5, deserialized.Prediction.AmbientTempC);
+        Assert.Equal(22.0, deserialized.Prediction.TrackTempC);
+        Assert.Equal(60.0, deserialized.Prediction.CloudCoverPct);
+    }
+
+    [Fact]
     public void AppSettings_RoundTrip_PreservesValues()
     {
         var original = new AppSettings

--- a/tire_pressure_calculator/Tests/PredictionModeTests.cs
+++ b/tire_pressure_calculator/Tests/PredictionModeTests.cs
@@ -1,0 +1,231 @@
+using TirePressureCalculator.Services.Modeling;
+using TirePressureCalculator.ViewModels;
+
+namespace TirePressureCalculator.Tests;
+
+/// <summary>
+/// Tests for the Circuit Prediction UI mode end-to-end: TireCornerViewModel's
+/// optional <see cref="TireCornerViewModel.PredictedHotTempC"/> override of
+/// the manual hot temp, MainViewModel's mode + prediction inputs wiring, and
+/// AppSettings persistence for the new fields.
+/// </summary>
+public class PredictionModeTests
+{
+    private static MainViewModel CreateWithModel() =>
+        new(TireModelLoader.LoadEmbedded(typeof(TireModel).Assembly));
+
+    // ---------- TireCornerViewModel.PredictedHotTempC ----------
+
+    [Fact]
+    public void Corner_PredictedHotTempC_Null_UsesAdjustedHotTemp()
+    {
+        var corner = new TireCornerViewModel
+        {
+            Label = "FL",
+            CurrentTemp = 20.0,
+            TargetHotTemp = 80.0,
+            TargetHotPressure = 1.80,
+        };
+        Assert.Null(corner.PredictedHotTempC);
+        Assert.False(corner.HasPrediction);
+        // ColdPressure should match the pre-prediction behavior — using AdjustedHotTemp.
+        double expectedManual = (1.80 + 1.0) * (293.15 / 353.15) - 1.0;
+        Assert.Equal(Math.Round(expectedManual, 3), corner.ColdPressure);
+    }
+
+    [Fact]
+    public void Corner_PredictedHotTempC_Set_OverridesGayLussacHotSide()
+    {
+        var corner = new TireCornerViewModel
+        {
+            Label = "FL",
+            CurrentTemp = 20.0,
+            TargetHotTemp = 80.0,  // Manual target — should be ignored
+            TargetHotPressure = 1.80,
+        };
+        corner.PredictedHotTempC = 55.0;
+        Assert.True(corner.HasPrediction);
+        Assert.Equal(55.0, corner.EffectiveHotTempC);
+        // Cold pressure should now invert against 55 °C, not 80 °C.
+        double expectedPredict = (1.80 + 1.0) * (293.15 / (55.0 + 273.15)) - 1.0;
+        Assert.Equal(Math.Round(expectedPredict, 3), corner.ColdPressure);
+    }
+
+    [Fact]
+    public void Corner_PredictedHotTempC_ClearedToNull_RestoresManual()
+    {
+        var corner = new TireCornerViewModel
+        {
+            Label = "FL",
+            CurrentTemp = 20.0,
+            TargetHotTemp = 80.0,
+            TargetHotPressure = 1.80,
+        };
+        corner.PredictedHotTempC = 55.0;
+        corner.PredictedHotTempC = null;
+        Assert.False(corner.HasPrediction);
+        Assert.Equal(80.0, corner.EffectiveHotTempC);
+        double expectedManual = (1.80 + 1.0) * (293.15 / 353.15) - 1.0;
+        Assert.Equal(Math.Round(expectedManual, 3), corner.ColdPressure);
+    }
+
+    [Fact]
+    public void Corner_PredictedHotTempC_FiresPropertyChangeForColdPressure()
+    {
+        var corner = new TireCornerViewModel
+        {
+            Label = "FL",
+            CurrentTemp = 20.0,
+            TargetHotTemp = 80.0,
+            TargetHotPressure = 1.80,
+        };
+        var changes = new List<string?>();
+        corner.PropertyChanged += (_, e) => changes.Add(e.PropertyName);
+
+        corner.PredictedHotTempC = 55.0;
+
+        Assert.Contains(nameof(TireCornerViewModel.PredictedHotTempC), changes);
+        Assert.Contains(nameof(TireCornerViewModel.ColdPressure), changes);
+        Assert.Contains(nameof(TireCornerViewModel.HasPrediction), changes);
+    }
+
+    // ---------- MainViewModel mode + wiring ----------
+
+    [Fact]
+    public void Mode_DefaultsToManual()
+    {
+        // Use the parametric ctor so the test doesn't depend on persisted
+        // settings from a previous run.
+        var vm = new MainViewModel(tireModel: null);
+        Assert.Equal(AppMode.Manual, vm.Mode);
+        Assert.True(vm.IsManualMode);
+        Assert.False(vm.IsPredictionMode);
+    }
+
+    [Fact]
+    public void Mode_NoModel_TireModelAvailableIsFalse()
+    {
+        var vm = new MainViewModel(tireModel: null);
+        Assert.False(vm.TireModelAvailable);
+    }
+
+    [Fact]
+    public void Mode_WithEmbeddedModel_PopulatesAvailableTracksAndCars()
+    {
+        var vm = CreateWithModel();
+        Assert.True(vm.TireModelAvailable);
+        Assert.Contains("tsukuba_2000", vm.AvailableTracks);
+        Assert.Contains("KK-SII", vm.AvailableCars);
+        Assert.Contains("dry", vm.AvailableConditions);
+        Assert.Contains("damp", vm.AvailableConditions);
+        Assert.Contains("wet", vm.AvailableConditions);
+    }
+
+    [Fact]
+    public void SwitchingToPredictionMode_PushesPredictedHotTempCToCorners()
+    {
+        var vm = CreateWithModel();
+        // Pick a known-dense bucket so the model returns a real number.
+        vm.SelectedTrack = "tsukuba_2000";
+        vm.SelectedCar = "KK-SII";
+        vm.SelectedCondition = "dry";
+        vm.LapWithinStint = 5;
+        vm.AmbientTempC = 18.0;
+        vm.Mode = AppMode.CircuitPrediction;
+
+        Assert.True(vm.IsPredictionMode);
+        Assert.True(vm.FrontLeft.HasPrediction);
+        Assert.True(vm.FrontRight.HasPrediction);
+        Assert.True(vm.RearLeft.HasPrediction);
+        Assert.True(vm.RearRight.HasPrediction);
+        // Physical sanity: KK-SII at Tsukuba lap 5 dry should warm above ambient.
+        Assert.True(vm.FrontLeft.PredictedHotTempC > vm.AmbientTempC);
+    }
+
+    [Fact]
+    public void SwitchingBackToManual_ClearsPredictedHotTempC()
+    {
+        var vm = CreateWithModel();
+        vm.SelectedTrack = "tsukuba_2000";
+        vm.SelectedCar = "KK-SII";
+        vm.Mode = AppMode.CircuitPrediction;
+        Assert.True(vm.FrontLeft.HasPrediction);
+
+        vm.Mode = AppMode.Manual;
+        Assert.False(vm.FrontLeft.HasPrediction);
+        Assert.False(vm.FrontRight.HasPrediction);
+        Assert.False(vm.RearLeft.HasPrediction);
+        Assert.False(vm.RearRight.HasPrediction);
+    }
+
+    [Fact]
+    public void PredictionMode_LapChange_UpdatesPredictedHotTemp()
+    {
+        var vm = CreateWithModel();
+        vm.SelectedTrack = "tsukuba_2000";
+        vm.SelectedCar = "KK-SII";
+        vm.SelectedCondition = "dry";
+        vm.AmbientTempC = 18.0;
+        vm.Mode = AppMode.CircuitPrediction;
+
+        vm.LapWithinStint = 2;
+        var earlyHot = vm.FrontLeft.PredictedHotTempC!.Value;
+        vm.LapWithinStint = 10;
+        var lateHot = vm.FrontLeft.PredictedHotTempC!.Value;
+        // Tires get hotter as the stint progresses.
+        Assert.True(lateHot > earlyHot);
+    }
+
+    [Fact]
+    public void PredictionMode_ConditionChange_ChangesPredictedTemps()
+    {
+        var vm = CreateWithModel();
+        vm.SelectedTrack = "tsukuba_2000";
+        vm.SelectedCar = "KK-SII";
+        vm.LapWithinStint = 5;
+        vm.AmbientTempC = 15.0;
+        vm.Mode = AppMode.CircuitPrediction;
+
+        vm.SelectedCondition = "dry";
+        var dryHot = vm.FrontLeft.PredictedHotTempC!.Value;
+        vm.SelectedCondition = "damp";
+        var dampHot = vm.FrontLeft.PredictedHotTempC!.Value;
+        // Damp should equilibrate to a different hot temp than dry.
+        Assert.NotEqual(dryHot, dampHot);
+    }
+
+    [Fact]
+    public void PredictionMode_CrossCheck_ColdPressureMatchesPredictorOutput()
+    {
+        // The MainVM should drive corner.PredictedHotTempC from the same
+        // numbers the CircuitPredictor would return when called directly.
+        var model = TireModelLoader.LoadEmbedded(typeof(TireModel).Assembly);
+        var directPredictor = new TirePressureCalculator.Services.CircuitPredictor(model);
+
+        var vm = new MainViewModel(model);
+        vm.SelectedTrack = "tsukuba_2000";
+        vm.SelectedCar = "KK-SII";
+        vm.SelectedCondition = "dry";
+        vm.LapWithinStint = 10;
+        vm.AmbientTempC = 15.0;
+        vm.FrontLeft.CurrentTemp = 15.0;
+        vm.FrontLeft.TargetHotPressure = 1.7;
+        vm.Mode = AppMode.CircuitPrediction;
+
+        var direct = directPredictor.Predict(
+            track: "tsukuba_2000",
+            car: "KK-SII",
+            condition: "dry",
+            lapWithinStint: 10,
+            ambientTempC: 15.0,
+            trackTempC: null,
+            cloudCoverPct: null,
+            corner: "fl",
+            targetHotPressureBar: 1.7,
+            coldTireTempC: 15.0);
+
+        Assert.Equal(direct.PredictedHotTempC, vm.FrontLeft.PredictedHotTempC!.Value, precision: 6);
+        // Corner's cold pressure should agree (rounded to 3 decimals).
+        Assert.Equal(Math.Round(direct.ColdPressureBar, 3), vm.FrontLeft.ColdPressure);
+    }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1558,7 +1558,7 @@ wheels = [
 
 [[package]]
 name = "motorsports-data-notebook"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "ipywidgets" },


### PR DESCRIPTION

Marks the release that lands the C# tire-pressure-calculator integration:

- Bundled tire model artifact + JSON parser + condition fallback chain
- C# Gay-Lussac predictor + Python-parity test fixture
- Circuit Prediction UI mode in the existing calculator (mode toggle,
  per-corner predicted hot temp, prediction-inputs panel at the bottom)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/122).
* __->__ #122
* #121