### PR TITLE
tire-pressure-calculator: Reset button + CI/test hygiene (0.17.2)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -3,16 +3,8 @@ name: Build Desktop App
 on:
   push:
     branches: [master]
-    paths:
-      - 'desktop_app/**'
-      - 'src/motorsports_data_notebook/**'
-      - '.github/workflows/build-desktop.yml'
   pull_request:
     branches: [master]
-    paths:
-      - 'desktop_app/**'
-      - 'src/motorsports_data_notebook/**'
-      - '.github/workflows/build-desktop.yml'
   release:
     types: [published]
 

--- a/.github/workflows/build-tire-pressure.yml
+++ b/.github/workflows/build-tire-pressure.yml
@@ -3,14 +3,8 @@ name: Build Tire Pressure Calculator
 on:
   push:
     branches: [master]
-    paths:
-      - 'tire_pressure_calculator/**'
-      - '.github/workflows/build-tire-pressure.yml'
   pull_request:
     branches: [master]
-    paths:
-      - 'tire_pressure_calculator/**'
-      - '.github/workflows/build-tire-pressure.yml'
   release:
     types: [published]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motorsports-data-notebook"
-version = "0.17.1"
+version = "0.17.2"
 description = ""
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/scripts/regen_tire_predict_fixture.py
+++ b/scripts/regen_tire_predict_fixture.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Regenerate tire_pressure_calculator/Tests/Fixtures/python_predictions.json
+against the current tire model (data/tire_dataset/tire_model.json).
+
+Run after retraining the tire model to keep the C# parity test in sync:
+
+    uv run scripts/regen_tire_predict_fixture.py
+
+The case list mirrors the scenarios the C# `Predict_MatchesPythonOutputOnVendoredFixture`
+test cares about: dry/damp/wet at multiple lap counts, a different track+car pair,
+and an explicit cold-tire-temp override.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from motorsports_data_notebook.tire_model.predict import CORNERS, predict_cold_pressure
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_PATH = (
+    REPO_ROOT / "tire_pressure_calculator" / "Tests" / "Fixtures" / "python_predictions.json"
+)
+
+# Each case is the input dict that lands in the fixture's "inputs" block
+# (target_hot_pressure_bar appears here as a scalar; predict_cold_pressure
+# expects a per-corner dict, so we broadcast below).
+CASES: list[tuple[str, dict]] = [
+    (
+        "tsukuba_KKSII_dry_lap5",
+        {
+            "track": "tsukuba_2000",
+            "car": "KK-SII",
+            "lap_within_stint": 5,
+            "track_condition": "dry",
+            "ambient_temp_c": 18.0,
+            "target_hot_pressure_bar": 1.7,
+        },
+    ),
+    (
+        "tsukuba_KKSII_dry_lap10_cold15",
+        {
+            "track": "tsukuba_2000",
+            "car": "KK-SII",
+            "lap_within_stint": 10,
+            "track_condition": "dry",
+            "ambient_temp_c": 15.0,
+            "cloud_cover_pct": 100.0,
+            "target_hot_pressure_bar": 1.7,
+        },
+    ),
+    (
+        "tsukuba_KKSII_damp_lap10",
+        {
+            "track": "tsukuba_2000",
+            "car": "KK-SII",
+            "lap_within_stint": 10,
+            "track_condition": "damp",
+            "ambient_temp_c": 15.0,
+            "target_hot_pressure_bar": 1.7,
+        },
+    ),
+    (
+        "tsukuba_KKSII_wet_falls_back",
+        {
+            "track": "tsukuba_2000",
+            "car": "KK-SII",
+            "lap_within_stint": 10,
+            "track_condition": "wet",
+            "ambient_temp_c": 15.0,
+            "target_hot_pressure_bar": 1.7,
+        },
+    ),
+    (
+        "sodegaura_Inferno_dry_lap5",
+        {
+            "track": "sodegaura",
+            "car": "Inferno 86",
+            "lap_within_stint": 5,
+            "track_condition": "dry",
+            "ambient_temp_c": 22.0,
+            "target_hot_pressure_bar": 1.7,
+        },
+    ),
+    (
+        "tsukuba_KKSII_warmtire",
+        {
+            "track": "tsukuba_2000",
+            "car": "KK-SII",
+            "lap_within_stint": 10,
+            "track_condition": "dry",
+            "ambient_temp_c": 15.0,
+            "cold_tire_temp_c": 22.0,
+            "target_hot_pressure_bar": 1.7,
+        },
+    ),
+]
+
+
+def _run_case(label: str, inputs: dict) -> dict:
+    scalar_target = inputs["target_hot_pressure_bar"]
+    kwargs = {k: v for k, v in inputs.items() if k != "target_hot_pressure_bar"}
+    kwargs["target_hot_pressure_bar"] = {c: scalar_target for c in CORNERS}
+    predictions = predict_cold_pressure(**kwargs)
+    return {
+        "label": label,
+        "inputs": inputs,
+        "corners": {
+            c: {
+                "cold_pressure_bar": predictions[c].cold_pressure_bar,
+                "predicted_hot_temp_c": predictions[c].predicted_hot_temp_c,
+                "K_source_bucket": list(predictions[c].K_source_bucket),
+            }
+            for c in CORNERS
+        },
+    }
+
+
+def main() -> None:
+    cases_out = [_run_case(label, inputs) for label, inputs in CASES]
+    FIXTURE_PATH.write_text(json.dumps(cases_out, indent=2) + "\n")
+    print(f"Wrote {len(cases_out)} cases to {FIXTURE_PATH.relative_to(REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tire_pressure_calculator/Core/ViewModels/MainViewModel.cs
+++ b/tire_pressure_calculator/Core/ViewModels/MainViewModel.cs
@@ -288,6 +288,16 @@ public class MainViewModel : INotifyPropertyChanged
             FrontRight.ResetToDefaults();
             RearLeft.ResetToDefaults();
             RearRight.ResetToDefaults();
+            // Prediction inputs (only reachable when the model is loaded).
+            // Routed through the public setters so persistence and
+            // RefreshPredictions() run exactly as they do on user input.
+            SelectedTrack = AvailableTracks.FirstOrDefault();
+            SelectedCar = AvailableCars.FirstOrDefault();
+            SelectedCondition = "dry";
+            LapWithinStint = 5;
+            AmbientTempC = 20.0;
+            TrackTempC = null;
+            CloudCoverPct = null;
         });
 
         RefreshPredictions();

--- a/tire_pressure_calculator/Core/Views/MainView.axaml
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml
@@ -307,9 +307,14 @@
                       ContentTemplate="{StaticResource CornerTemplate}" />
 
       <!-- ROW 4: Bottom bar — reset (always) + correction slider (manual only) -->
+      <!-- Tapped wired in addition to Command: in the WASM head the Button's
+           Click path doesn't reliably reach the bound Command (same class of
+           pointer-event interception that bit ToggleSwitch above). Tapped is
+           the gesture-level fallback that fires on both desktop and WASM. -->
       <Button Grid.Row="4" Grid.Column="0"
               Content="{Binding T_ResetButton}"
               Command="{Binding ResetCommand}"
+              Tapped="OnResetButtonTapped"
               HorizontalAlignment="Left" VerticalAlignment="Center"
               Margin="8,4,0,8" />
       <StackPanel Grid.Row="4" Grid.Column="1" Orientation="Horizontal"

--- a/tire_pressure_calculator/Core/Views/MainView.axaml.cs
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml.cs
@@ -175,6 +175,19 @@ public partial class MainView : UserControl
         }
     }
 
+    // Same WASM mitigation as the ToggleSwitch above: the Button's bound
+    // Command doesn't always fire from a tap in the browser host, so route
+    // through the gesture-level Tapped event too. On desktop the Command
+    // path fires as well; the command body is idempotent so the double-fire
+    // is harmless.
+    private void OnResetButtonTapped(object? sender, Avalonia.Input.TappedEventArgs e)
+    {
+        if (DataContext is TirePressureCalculator.ViewModels.MainViewModel vm)
+        {
+            vm.ResetCommand.Execute(null);
+        }
+    }
+
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);

--- a/tire_pressure_calculator/Tests/AssemblyInfo.cs
+++ b/tire_pressure_calculator/Tests/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+// Run test classes sequentially within this assembly. The C# tire-pressure
+// calculator's ViewModels touch two process-wide singletons that don't
+// tolerate concurrent mutation:
+//
+//   - Localizer.Instance — language is global, and language flips fire
+//     PropertyChanged(string.Empty) on every subscribed TireCornerViewModel
+//     ever instantiated in the process. Tests in another class flipping
+//     language race with the assertions of tests creating corner VMs.
+//   - AppSettings.Storage (file-backed) — every MainViewModel ctor reads
+//     and every setter writes the same on-disk settings.json, so two
+//     parallel tests fight over its contents.
+//
+// Disabling parallel test-class execution removes both races and keeps
+// the suite deterministic. Cost is tiny: the whole suite is ~80 fast tests.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/tire_pressure_calculator/Tests/Fixtures/python_predictions.json
+++ b/tire_pressure_calculator/Tests/Fixtures/python_predictions.json
@@ -11,8 +11,8 @@
     },
     "corners": {
       "fl": {
-        "cold_pressure_bar": 1.4970642148503628,
-        "predicted_hot_temp_c": 41.661687791179894,
+        "cold_pressure_bar": 1.4845010271743289,
+        "predicted_hot_temp_c": 43.25357214665859,
         "K_source_bucket": [
           "KK-SII",
           "fl",
@@ -20,8 +20,8 @@
         ]
       },
       "fr": {
-        "cold_pressure_bar": 1.5293622025672535,
-        "predicted_hot_temp_c": 37.64178743246765,
+        "cold_pressure_bar": 1.5185052491135536,
+        "predicted_hot_temp_c": 38.98157100891014,
         "K_source_bucket": [
           "KK-SII",
           "fr",
@@ -29,8 +29,8 @@
         ]
       },
       "rl": {
-        "cold_pressure_bar": 1.5219536431724743,
-        "predicted_hot_temp_c": 38.55477781309439,
+        "cold_pressure_bar": 1.5121181607837721,
+        "predicted_hot_temp_c": 39.7751689955293,
         "K_source_bucket": [
           "KK-SII",
           "rl",
@@ -38,8 +38,8 @@
         ]
       },
       "rr": {
-        "cold_pressure_bar": 1.518356544613408,
-        "predicted_hot_temp_c": 39.00000182616114,
+        "cold_pressure_bar": 1.5129550765732027,
+        "predicted_hot_temp_c": 39.67095224399074,
         "K_source_bucket": [
           "KK-SII",
           "rr",
@@ -61,8 +61,8 @@
     },
     "corners": {
       "fl": {
-        "cold_pressure_bar": 1.4529259249261464,
-        "predicted_hot_temp_c": 44.02427423880505,
+        "cold_pressure_bar": 1.4421624999532288,
+        "predicted_hot_temp_c": 45.42216709162479,
         "K_source_bucket": [
           "KK-SII",
           "fl",
@@ -70,8 +70,8 @@
         ]
       },
       "fr": {
-        "cold_pressure_bar": 1.4975935151829258,
-        "predicted_hot_temp_c": 38.35184978880298,
+        "cold_pressure_bar": 1.4881969623621667,
+        "predicted_hot_temp_c": 39.52822112498764,
         "K_source_bucket": [
           "KK-SII",
           "fr",
@@ -79,8 +79,8 @@
         ]
       },
       "rl": {
-        "cold_pressure_bar": 1.4814735874133604,
-        "predicted_hot_temp_c": 40.375400369454375,
+        "cold_pressure_bar": 1.472138972848481,
+        "predicted_hot_temp_c": 41.559249174433205,
         "K_source_bucket": [
           "KK-SII",
           "rl",
@@ -88,8 +88,8 @@
         ]
       },
       "rr": {
-        "cold_pressure_bar": 1.4721539002328958,
-        "predicted_hot_temp_c": 41.55734889389615,
+        "cold_pressure_bar": 1.468758983176754,
+        "predicted_hot_temp_c": 41.99011910505637,
         "K_source_bucket": [
           "KK-SII",
           "rr",
@@ -110,8 +110,8 @@
     },
     "corners": {
       "fl": {
-        "cold_pressure_bar": 1.5142319003376237,
-        "predicted_hot_temp_c": 36.29042985673898,
+        "cold_pressure_bar": 1.4728141079520536,
+        "predicted_hot_temp_c": 41.473326313975015,
         "K_source_bucket": [
           "KK-SII",
           "fl",
@@ -119,8 +119,8 @@
         ]
       },
       "fr": {
-        "cold_pressure_bar": 1.5557861037831082,
-        "predicted_hot_temp_c": 31.259276992463032,
+        "cold_pressure_bar": 1.524186626496705,
+        "predicted_hot_temp_c": 35.07007843365605,
         "K_source_bucket": [
           "KK-SII",
           "fr",
@@ -128,8 +128,8 @@
         ]
       },
       "rl": {
-        "cold_pressure_bar": 1.5661713557506167,
-        "predicted_hot_temp_c": 30.02733780970762,
+        "cold_pressure_bar": 1.5163361027578128,
+        "predicted_hot_temp_c": 36.031670583406964,
         "K_source_bucket": [
           "KK-SII",
           "rl",
@@ -137,8 +137,8 @@
         ]
       },
       "rr": {
-        "cold_pressure_bar": 1.55594567674096,
-        "predicted_hot_temp_c": 31.240272093740295,
+        "cold_pressure_bar": 1.5080367268886423,
+        "predicted_hot_temp_c": 37.05478753720569,
         "K_source_bucket": [
           "KK-SII",
           "rr",
@@ -159,8 +159,8 @@
     },
     "corners": {
       "fl": {
-        "cold_pressure_bar": 1.5142319003376237,
-        "predicted_hot_temp_c": 36.29042985673898,
+        "cold_pressure_bar": 1.4728141079520536,
+        "predicted_hot_temp_c": 41.473326313975015,
         "K_source_bucket": [
           "KK-SII",
           "fl",
@@ -168,8 +168,8 @@
         ]
       },
       "fr": {
-        "cold_pressure_bar": 1.5557861037831082,
-        "predicted_hot_temp_c": 31.259276992463032,
+        "cold_pressure_bar": 1.524186626496705,
+        "predicted_hot_temp_c": 35.07007843365605,
         "K_source_bucket": [
           "KK-SII",
           "fr",
@@ -177,8 +177,8 @@
         ]
       },
       "rl": {
-        "cold_pressure_bar": 1.5661713557506167,
-        "predicted_hot_temp_c": 30.02733780970762,
+        "cold_pressure_bar": 1.5163361027578128,
+        "predicted_hot_temp_c": 36.031670583406964,
         "K_source_bucket": [
           "KK-SII",
           "rl",
@@ -186,8 +186,8 @@
         ]
       },
       "rr": {
-        "cold_pressure_bar": 1.55594567674096,
-        "predicted_hot_temp_c": 31.240272093740295,
+        "cold_pressure_bar": 1.5080367268886423,
+        "predicted_hot_temp_c": 37.05478753720569,
         "K_source_bucket": [
           "KK-SII",
           "rr",
@@ -208,8 +208,8 @@
     },
     "corners": {
       "fl": {
-        "cold_pressure_bar": 1.4263693850389512,
-        "predicted_hot_temp_c": 55.28515291354006,
+        "cold_pressure_bar": 1.426456485922678,
+        "predicted_hot_temp_c": 55.27336329677513,
         "K_source_bucket": [
           "Inferno 86",
           "fl",
@@ -217,8 +217,8 @@
         ]
       },
       "fr": {
-        "cold_pressure_bar": 1.4500953054700179,
-        "predicted_hot_temp_c": 52.104694468762496,
+        "cold_pressure_bar": 1.4483118239894863,
+        "predicted_hot_temp_c": 52.34162741102789,
         "K_source_bucket": [
           "Inferno 86",
           "fr",
@@ -226,8 +226,8 @@
         ]
       },
       "rl": {
-        "cold_pressure_bar": 1.4798957136777493,
-        "predicted_hot_temp_c": 48.19617419785339,
+        "cold_pressure_bar": 1.4788970335135416,
+        "predicted_hot_temp_c": 48.32563582763339,
         "K_source_bucket": [
           "Inferno 86",
           "rl",
@@ -235,8 +235,8 @@
         ]
       },
       "rr": {
-        "cold_pressure_bar": 1.492408328025241,
-        "predicted_hot_temp_c": 46.58292298834337,
+        "cold_pressure_bar": 1.4952029185709472,
+        "predicted_hot_temp_c": 46.2248268202586,
         "K_source_bucket": [
           "Inferno 86",
           "rr",
@@ -258,8 +258,8 @@
     },
     "corners": {
       "fl": {
-        "cold_pressure_bar": 1.5125146164912442,
-        "predicted_hot_temp_c": 44.02427423880505,
+        "cold_pressure_bar": 1.5014897166794912,
+        "predicted_hot_temp_c": 45.42216709162479,
         "K_source_bucket": [
           "KK-SII",
           "fl",
@@ -267,8 +267,8 @@
         ]
       },
       "fr": {
-        "cold_pressure_bar": 1.5582673121854609,
-        "predicted_hot_temp_c": 38.35184978880298,
+        "cold_pressure_bar": 1.5486424898184747,
+        "predicted_hot_temp_c": 39.52822112498764,
         "K_source_bucket": [
           "KK-SII",
           "fr",
@@ -276,8 +276,8 @@
         ]
       },
       "rl": {
-        "cold_pressure_bar": 1.5417557845741916,
-        "predicted_hot_temp_c": 40.375400369454375,
+        "cold_pressure_bar": 1.5321944051231275,
+        "predicted_hot_temp_c": 41.559249174433205,
         "K_source_bucket": [
           "KK-SII",
           "rl",
@@ -285,8 +285,8 @@
         ]
       },
       "rr": {
-        "cold_pressure_bar": 1.5322096951370443,
-        "predicted_hot_temp_c": 41.55734889389615,
+        "cold_pressure_bar": 1.5287323056901578,
+        "predicted_hot_temp_c": 41.99011910505637,
         "K_source_bucket": [
           "KK-SII",
           "rr",

--- a/tire_pressure_calculator/Tests/MainViewModelTests.cs
+++ b/tire_pressure_calculator/Tests/MainViewModelTests.cs
@@ -73,6 +73,11 @@ public class MainViewModelTests
         vm.FrontLeft.TargetHotTemp = 100.0;
         vm.RearRight.TargetHotPressure = 2.50;
         vm.TempAdjustPercent = 10.0;
+        vm.SelectedCondition = "wet";
+        vm.LapWithinStint = 12;
+        vm.AmbientTempC = 35.0;
+        vm.TrackTempC = 42.0;
+        vm.CloudCoverPct = 80.0;
 
         vm.ResetCommand.Execute(null);
 
@@ -80,6 +85,11 @@ public class MainViewModelTests
         Assert.Equal(20.0, vm.FrontLeft.CurrentTemp);
         Assert.Equal(80.0, vm.FrontLeft.TargetHotTemp);
         Assert.Equal(1.80, vm.RearRight.TargetHotPressure);
+        Assert.Equal("dry", vm.SelectedCondition);
+        Assert.Equal(5, vm.LapWithinStint);
+        Assert.Equal(20.0, vm.AmbientTempC);
+        Assert.Null(vm.TrackTempC);
+        Assert.Null(vm.CloudCoverPct);
     }
 
     [Fact]

--- a/tire_pressure_calculator/Tests/TireCornerViewModelTests.cs
+++ b/tire_pressure_calculator/Tests/TireCornerViewModelTests.cs
@@ -182,6 +182,11 @@ public class TireCornerViewModelTests
 
         vm.CurrentTemp = 20.0;
 
-        Assert.Empty(changedProperties);
+        // Ignore PropertyChanged(string.Empty) — the corner VM uses that
+        // signal to refresh all bindings when the Localizer's Language flips.
+        // The contract under test is "setting CurrentTemp to its current value
+        // fires no value-specific PropertyChanged", so only non-empty
+        // property names matter here.
+        Assert.DoesNotContain(changedProperties, p => !string.IsNullOrEmpty(p));
     }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1558,7 +1558,7 @@ wheels = [
 
 [[package]]
 name = "motorsports-data-notebook"
-version = "0.17.0"
+version = "0.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "ipywidgets" },


### PR DESCRIPTION

User-facing fix
---------------

Two related fixes to the "Reset to Defaults" button in the C# Avalonia
tire pressure calculator.

1. WASM click reliability. In the browser host, the Button's bound
   Command did not fire on tap — the same class of pointer-event
   interception that previously bit ToggleSwitch (see existing
   OnModeToggleTapped). Wire the gesture-level Tapped event in
   addition to the Command binding; on desktop both fire, and the
   command body is idempotent so the double-invocation is harmless.

2. Reset scope. The Circuit Prediction commit (556f497) added seven
   persisted prediction inputs (SelectedTrack, SelectedCar,
   SelectedCondition, LapWithinStint, AmbientTempC, TrackTempC,
   CloudCoverPct) but did not extend ResetCommand to touch them, so
   the most visible UI in Prediction mode never returned to defaults.
   Drive each through its existing public setter so persistence and
   RefreshPredictions() side-effects run as they do on user input.
   Mode and SelectedLanguage are intentionally untouched.

CI + test hygiene (root-cause work surfaced by this PR's CI)
------------------------------------------------------------

- Removed `paths:` filters from build-tire-pressure.yml and
  build-desktop.yml. The tire-pressure workflow had a blind spot:
  Core.csproj embeds `..\..\data\tire_dataset\tire_model.json` via
  EmbeddedResource, so retrains in `data/tire_dataset/**` silently
  flow into the C# build without ever triggering the workflow.
  Releases caught the resulting parity drift but those runs were
  non-blocking. Filters are gone; both workflows now run on every
  push and PR.

- Regenerated Tests/Fixtures/python_predictions.json against the
  current model (tire-model 0.17.1) — the fixture had been stale
  since 207b7fb retrained the model without re-running it. Added
  scripts/regen_tire_predict_fixture.py so the next retrain is a
  one-command refresh; CircuitPredictorTests.cs already references
  this script in its error message.

- Made the .NET test suite deterministic. xUnit was running test
  classes in parallel, but MainViewModel mutates two process-wide
  singletons (Localizer.Instance and the on-disk AppSettings.Storage),
  so PredictionMode_CrossCheck and PropertyChanged_DoesNotFire flaked
  under parallel runs. Tests/AssemblyInfo.cs now disables parallel
  test-class execution. Also tightened
  PropertyChanged_DoesNotFire_WhenSameValue to ignore
  PropertyChanged(string.Empty), which is the "all bindings refresh"
  signal the corner VM emits on Localizer.Language changes — orthogonal
  to the property-set under test.

Version bump 0.17.1 → 0.17.2 (pyproject + uv.lock — master left the
lock at 0.17.0 after the 0.17.0→0.17.1 bump; both are now in sync).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
