### PR TITLE
tire-model 0.19.0: compound-aware K from the curated tire history

### DIFF
--- a/data/tire_dataset/tire_compounds.yaml
+++ b/data/tire_dataset/tire_compounds.yaml
@@ -14,6 +14,15 @@
 # arrived 2025-06-09 ("A052 Sticker"). Review [inferred] rows
 # before trusting them.
 
+# Wheel-set -> compound mapping: resolves "SET:<name>" labels coming from
+# the notes extraction (e.g. "Black wheels"). Valid for the 2025 sets; if a
+# set is re-shod with a different tire, date-scope the sidecar entries
+# instead of relying on this map. "silver-blue" (first seen 2026-02-07) is
+# deliberately unmapped until its tire is known.
+wheel_sets:
+  black: RE-71RS
+  silver: A052
+
 sessions:
   - session_id: 9eaa8cd142548a9d  # 2025-03-08 09:09 sodegaura (0 usable laps) [no TPMS]
     front: null

--- a/data/tire_dataset/tire_model.json
+++ b/data/tire_dataset/tire_model.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "fit_at_utc": "2026-08-16T06:04:34+00:00",
+  "fit_at_utc": "2026-08-16T10:54:13+00:00",
   "model_form": "T_hot - T_eff = K[car,corner,cond] * c_track[track] * g2 * (1 - exp(-t / tau_sec[car,corner,cond]))   where T_eff = (1-w_road)*T_air + w_road*T_road, t = N * lap_time_s, g2 = g2_typ[track,car,cond] * clamp((lap_time_typ_s / target_lap_time_s)^g2_lap_time_exponent) when a target lap time is given, else g2_typ",
   "g2_lap_time_model": {
     "method": "sector_knn_median_curve",
@@ -803,6 +803,152 @@
         ],
         "n_laps": 299
       }
+    }
+  ],
+  "K_by_car_compound_corner_cond": [
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "corner": "fl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 64.82657357540609,
+      "stderr_kelvin_per_g2": 0.9491016258176805,
+      "n_laps": 94
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "corner": "fl",
+      "condition": "dry",
+      "value_kelvin_per_g2": 51.5422420978422,
+      "stderr_kelvin_per_g2": 1.2984213807193392,
+      "n_laps": 64
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "corner": "fr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 63.0195081267862,
+      "stderr_kelvin_per_g2": 0.7883680834777407,
+      "n_laps": 94
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "corner": "fr",
+      "condition": "dry",
+      "value_kelvin_per_g2": 45.95324753491066,
+      "stderr_kelvin_per_g2": 1.0305419466470014,
+      "n_laps": 64
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "corner": "rl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 54.525326468494065,
+      "stderr_kelvin_per_g2": 0.9819536904316191,
+      "n_laps": 94
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "corner": "rl",
+      "condition": "dry",
+      "value_kelvin_per_g2": 41.20472476899598,
+      "stderr_kelvin_per_g2": 0.911673414793766,
+      "n_laps": 64
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "corner": "rr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 51.512823343884996,
+      "stderr_kelvin_per_g2": 0.7521732307438973,
+      "n_laps": 94
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "corner": "rr",
+      "condition": "dry",
+      "value_kelvin_per_g2": 37.721606419228586,
+      "stderr_kelvin_per_g2": 0.8696632512020939,
+      "n_laps": 64
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "fl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 64.67967396100013,
+      "stderr_kelvin_per_g2": 2.887952627649214,
+      "n_laps": 14
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "fl",
+      "condition": "dry",
+      "value_kelvin_per_g2": 65.97640588705617,
+      "stderr_kelvin_per_g2": 1.37460356323152,
+      "n_laps": 20
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "fr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 60.601701445657284,
+      "stderr_kelvin_per_g2": 2.7589079770932488,
+      "n_laps": 14
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "fr",
+      "condition": "dry",
+      "value_kelvin_per_g2": 59.10488685386076,
+      "stderr_kelvin_per_g2": 1.2272296094099133,
+      "n_laps": 20
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "rl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 65.56252484301028,
+      "stderr_kelvin_per_g2": 3.09189552952972,
+      "n_laps": 14
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "rl",
+      "condition": "dry",
+      "value_kelvin_per_g2": 61.4547016964946,
+      "stderr_kelvin_per_g2": 1.4427891509218889,
+      "n_laps": 20
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "rr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 61.71975759766632,
+      "stderr_kelvin_per_g2": 2.9842329141575648,
+      "n_laps": 14
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "rr",
+      "condition": "dry",
+      "value_kelvin_per_g2": 59.14303232546258,
+      "stderr_kelvin_per_g2": 1.3090382539988996,
+      "n_laps": 20
     }
   ],
   "lap_time_typ_by_track_car_cond": [

--- a/docs/tire_model.md
+++ b/docs/tire_model.md
@@ -217,6 +217,35 @@ currently *hurts* — that car's heat does not track measured g²
 proportionally (even the oracle underperforms a constant), so leave the
 target blank there until the per-car g² sensitivity is modeled.
 
+### 2.11 Tire compound (per-axle K overrides)
+
+The Inferno 86 alternates between tire sets (A052 and RE-71RS through
+2025-2026, sometimes different compounds per axle in the same session),
+and the two heat very differently: session-median implied K separates by
+~45% on the rears (A052 ≈ 39-43, RE-71RS ≈ 59-61 K/G² dry) with
+within-compound spread of ±2-4 vs ±10 for the pooled mix. The pooled K
+splits the difference and mis-predicts both — this was the dominant
+source of the car's dry-rear MAE.
+
+Labels come from ``data/tire_dataset/tire_compounds.yaml`` (human-curated
+per-session, per-axle; authoritative) with the notes-extraction compounds
+as fallback; wheel-set names from the notes ("Black wheels") resolve
+through the sidecar's ``wheel_sets`` mapping. Labeled sessions get a
+per-(car, compound, corner, condition) K fitted by closed-form weighted
+least squares with the pooled τ and c_track held fixed
+(``ΔT = K · g²·c_track·warmup_frac``), which stays stable on sparse
+buckets; ``MIN_LAPS_FOR_COMPOUND_K = 10``. The artifact carries these in
+``K_by_car_compound_corner_cond`` (additive to schema v3 — consumers
+without compound support ignore the table).
+
+Prediction: ``predict_cold_pressure(compound_front=..., compound_rear=...)``
+(CLI ``--compound`` / ``--compound-front`` / ``--compound-rear``) swaps in
+the compound K per axle when a fitted bucket exists (condition chain
+applies); unknown compounds and unlabeled cars keep the pooled K. Held-out
+CV on the labeled Inferno sessions (same folds, pooled vs compound K):
+FL 6.80→4.95, FR 5.39→4.28, RL 5.99→4.49, RR 4.99→4.51 °C MAE, with the
+per-corner bias collapsing (RL +3.50→0.00).
+
 ### 2.9 Track condition (rain)
 
 v0.3 adds a `condition` dimension to K, τ_sec, ⟨g²⟩, and lap_time_typ. The
@@ -525,6 +554,11 @@ just tire-predict --track tsukuba_2000 --car KK-SII --lap 5 --ambient 15 \
 # g² vs lap-time curve and sets time-on-track t = N × target)
 just tire-predict --track tsukuba_2000 --car KK-SII --lap 5 --ambient 15 \
                   --hot-all 1.7 --target-lap-time 60
+
+# Predict with the tire compound (per-axle K override; --compound-front /
+# --compound-rear for split setups)
+just tire-predict --track sodegaura --car "Inferno 86" --lap 5 --ambient 22 \
+                  --hot-all 1.9 --compound A052
 
 # Held-out validation (train without N sessions per bucket, report per-corner T_hot residuals)
 just tire-predict-holdout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motorsports-data-notebook"
-version = "0.18.0"
+version = "0.19.0"
 description = ""
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/src/motorsports_data_notebook/tire_model/cli.py
+++ b/src/motorsports_data_notebook/tire_model/cli.py
@@ -101,6 +101,25 @@ def main(argv: list[str] | None = None) -> int:
         help="Target pace for the stint in seconds. Scales tire energy via the "
         "sector-fit g² vs lap-time curve and sets time-on-track (t = N × target).",
     )
+    p_predict.add_argument(
+        "--compound",
+        type=str,
+        default=None,
+        help="Tire compound on all four corners (e.g. A052, RE-71RS). Uses the "
+        "compound-specific K when the artifact has one fitted.",
+    )
+    p_predict.add_argument(
+        "--compound-front",
+        type=str,
+        default=None,
+        help="Front-axle compound (overrides --compound for FL/FR).",
+    )
+    p_predict.add_argument(
+        "--compound-rear",
+        type=str,
+        default=None,
+        help="Rear-axle compound (overrides --compound for RL/RR).",
+    )
     group = p_predict.add_argument_group("Target hot pressures (bar gauge)")
     group.add_argument(
         "--hot-all", type=float, default=None, help="Shorthand: same target for all 4 corners."
@@ -224,6 +243,8 @@ def _cmd_predict(args: argparse.Namespace) -> int:
         g2_typ_override=args.g2_typ,
         lap_time_typ_override_s=args.lap_time_s,
         target_lap_time_s=args.target_lap_time,
+        compound_front=args.compound_front or args.compound,
+        compound_rear=args.compound_rear or args.compound,
         dataset_root=args.dataset_root,
     )
     _print_prediction(result, args)

--- a/src/motorsports_data_notebook/tire_model/compounds.py
+++ b/src/motorsports_data_notebook/tire_model/compounds.py
@@ -1,0 +1,136 @@
+"""Per-session tire-compound labels for model training and prediction.
+
+Two sources, in priority order:
+
+1. ``data/tire_dataset/tire_compounds.yaml`` — the human-curated sidecar
+   (per-session, per-axle). Authoritative wherever it has a value.
+2. ``notes_matches.parquet`` — compounds extracted from run notes by the
+   LLM stage, normalized here. Wheel-set labels (``SET:<name>``) resolve
+   through the sidecar's optional ``wheel_sets`` mapping (e.g. the 86's
+   black wheels carried the RE-71RS set through 2025).
+
+Sessions with no label from either source stay unlabeled and train/predict
+on the pooled per-car parameters exactly as before.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+import pandas as pd
+import pyarrow.parquet as pq
+
+logger = logging.getLogger(__name__)
+
+COMPOUNDS_FILE = "tire_compounds.yaml"
+
+# Canonical spellings for the tires this team runs. Extend as new tires
+# appear in the notes.
+_CANONICAL = ("A052", "RE-71RS", "A050", "NS-2R", "AD09", "CR-S", "ZIII")
+
+
+def normalize_compound(raw: object) -> str | None:
+    """Map a free-text compound mention to its canonical name, or None.
+
+    ``SET:<name>`` wheel-set labels are returned verbatim (upper-cased name)
+    so the caller can resolve them via the sidecar's wheel_sets mapping.
+    """
+    if raw is None or not isinstance(raw, str) or not raw.strip():
+        return None
+    s = re.sub(r"[\s\-_]", "", raw.upper())
+    if s.startswith("SET:"):
+        return "SET:" + s[4:].lower()
+    if "A052" in s or s == "052":
+        return "A052"
+    if "71RS" in s or "RE71" in s:
+        return "RE-71RS"
+    if "NS2R" in s:
+        return "NS-2R"
+    if "A050" in s or s == "050":
+        return "A050"
+    if "AD09" in s:
+        return "AD09"
+    if "CRS" in s:
+        return "CR-S"
+    if "ZIII" in s or s == "Z3":
+        return "ZIII"
+    return None
+
+
+def load_compound_labels(dataset_root: Path) -> pd.DataFrame:
+    """Return per-session compound labels: columns
+    ``session_id, compound_front, compound_rear, source``.
+
+    Sidecar rows win over notes-derived rows; either axle may be null.
+    """
+    import yaml  # local import to keep top-of-module deps minimal
+
+    frames: list[pd.DataFrame] = []
+    wheel_sets: dict[str, str] = {}
+
+    sidecar_path = dataset_root / COMPOUNDS_FILE
+    if sidecar_path.exists():
+        doc = yaml.safe_load(sidecar_path.read_text(encoding="utf-8")) or {}
+        for name, compound in (doc.get("wheel_sets") or {}).items():
+            canon = normalize_compound(compound)
+            if canon and not canon.startswith("SET:"):
+                wheel_sets[str(name).lower()] = canon
+        rows = []
+        for entry in doc.get("sessions") or []:
+            front = normalize_compound(entry.get("front"))
+            rear = normalize_compound(entry.get("rear"))
+            if front is None and rear is None:
+                continue
+            rows.append(
+                {
+                    "session_id": entry["session_id"],
+                    "compound_front": front,
+                    "compound_rear": rear,
+                    "source": "sidecar",
+                }
+            )
+        if rows:
+            frames.append(pd.DataFrame(rows))
+
+    matches_path = dataset_root / "notes_matches.parquet"
+    if matches_path.exists():
+        m = pq.read_table(
+            matches_path,
+            columns=[
+                "session_id",
+                "tire_compound_fl",
+                "tire_compound_rl",
+                "match_confidence",
+            ],
+        ).to_pandas()
+
+        def _resolve(raw: object) -> str | None:
+            canon = normalize_compound(raw)
+            if canon is None:
+                return None
+            if canon.startswith("SET:"):
+                return wheel_sets.get(canon[4:])
+            return canon
+
+        m["compound_front"] = m["tire_compound_fl"].map(_resolve)
+        m["compound_rear"] = m["tire_compound_rl"].map(_resolve)
+        m = m[(m["compound_front"].notna()) | (m["compound_rear"].notna())]
+        if len(m) > 0:
+            # One note-session may match several telemetry sessions; keep the
+            # highest-confidence row per session.
+            m = (
+                m.sort_values("match_confidence", ascending=False)
+                .drop_duplicates("session_id")
+                .assign(source="notes")
+            )
+            frames.append(m[["session_id", "compound_front", "compound_rear", "source"]])
+
+    if not frames:
+        return pd.DataFrame(columns=["session_id", "compound_front", "compound_rear", "source"])
+
+    out = pd.concat(frames, ignore_index=True)
+    # Sidecar first (it was appended first) — drop notes rows it covers.
+    out = out.drop_duplicates("session_id", keep="first").reset_index(drop=True)
+    return out

--- a/src/motorsports_data_notebook/tire_model/predict.py
+++ b/src/motorsports_data_notebook/tire_model/predict.py
@@ -191,6 +191,31 @@ def _lookup_g2(
     return 0.7, 0, "global"
 
 
+def _lookup_compound_k(
+    model: dict[str, Any], car: str, compound: str, corner: str, condition: str
+) -> tuple[float, float, int, tuple[str, ...]] | None:
+    """Compound-specific K via the condition chain, or None if unavailable.
+
+    Returns (value, stderr, n_laps, source_bucket_tuple).
+    """
+    table = model.get("K_by_car_compound_corner_cond", [])
+    for cond in _condition_chain(condition):
+        for r in table:
+            if (
+                r["car"] == car
+                and r["compound"] == compound
+                and r["corner"] == corner
+                and r["condition"] == cond
+            ):
+                return (
+                    float(r["value_kelvin_per_g2"]),
+                    float(r.get("stderr_kelvin_per_g2", 0.0)),
+                    int(r.get("n_laps", 0)),
+                    (car, compound, corner, cond),
+                )
+    return None
+
+
 def _interp_clamped(x: float, xs: list[float], ys: list[float]) -> float:
     """Piecewise-linear interpolation, clamped to the endpoints.
 
@@ -292,6 +317,8 @@ def predict_cold_pressure(
     g2_typ_override: float | None = None,
     lap_time_typ_override_s: float | None = None,
     target_lap_time_s: float | None = None,
+    compound_front: str | None = None,
+    compound_rear: str | None = None,
     dataset_root: Path | None = None,
     _model: dict[str, Any] | None = None,
 ) -> dict[str, Prediction]:
@@ -309,6 +336,11 @@ def predict_cold_pressure(
         (clamped per the artifact's ``g2_lap_time_model.multiplier_clamp``)
         — running faster than the historical typical pace puts more energy
         into the tires, and vice versa. Omitted: v2 behavior.
+    compound_front, compound_rear
+        Optional tire compound per axle (canonical names, e.g. "A052",
+        "RE-71RS"). When the artifact carries a fitted compound-specific K
+        for that (car, compound, corner, condition), it replaces the pooled
+        K for the matching corners; otherwise the pooled K is used.
     cold_tire_temp_c
         Optional temperature the tire is at right *now* when you'll measure
         or set cold pressure. Defaults to ``ambient_temp_c`` when omitted.
@@ -377,6 +409,12 @@ def predict_cold_pressure(
             raise KeyError(f"target_hot_pressure_bar missing corner {corner!r}")
         target_hot = float(target_hot_pressure_bar[corner])
         K, K_stderr, K_n, K_from_prior, K_src = _lookup_k(model, car, corner, cond)
+        axle_compound = compound_front if corner in ("fl", "fr") else compound_rear
+        if axle_compound is not None:
+            hit = _lookup_compound_k(model, car, axle_compound, corner, cond)
+            if hit is not None:
+                K, K_stderr, K_n, K_src = hit[0], hit[1], hit[2], hit[3]
+                K_from_prior = False
         tau_sec, tau_stderr, _tau_src = _lookup_tau(model, car, corner, cond)
 
         warmup_frac = 1.0 - math.exp(-t_at_lap_n_s / tau_sec) if tau_sec > 0 else 0.0

--- a/src/motorsports_data_notebook/tire_model/validate.py
+++ b/src/motorsports_data_notebook/tire_model/validate.py
@@ -201,6 +201,22 @@ def _evaluate_fold(root: Path, holdout_ids: list[str]) -> pd.DataFrame:
         (d["key"]["car"], d["key"]["corner"], d["key"]["condition"]): d["value_kelvin_per_g2"]
         for d in model["K_buckets"]
     }
+    k_compound_lookup = {
+        (d["car"], d["compound"], d["corner"], d["condition"]): d["value_kelvin_per_g2"]
+        for d in model.get("K_by_car_compound_corner_cond", [])
+    }
+    # Held-out sessions' compound labels (metadata, not telemetry — using
+    # them mirrors a driver entering the compound in the calculator).
+    from .compounds import load_compound_labels
+
+    labels = load_compound_labels(root)
+    label_by_session = {
+        r.session_id: (
+            r.compound_front if isinstance(r.compound_front, str) else None,
+            r.compound_rear if isinstance(r.compound_rear, str) else None,
+        )
+        for r in labels.itertuples()
+    }
     tau_lookup = {
         (d["car"], d["corner"], d["condition"]): d["value_seconds"]
         for d in model["tau_sec_by_car_corner_cond"]
@@ -263,8 +279,16 @@ def _evaluate_fold(root: Path, holdout_ids: list[str]) -> pd.DataFrame:
         if g2 is None:
             continue
         c_track = c_track_lookup.get(track, 1.0)
+        comp_front, comp_rear = label_by_session.get(lap["session_id"], (None, None))
         for c in CORNERS:
             K = k_lookup.get((car, c, cond)) or k_lookup.get((car, c, "dry"))
+            axle_compound = comp_front if c in ("fl", "fr") else comp_rear
+            if axle_compound is not None:
+                K = (
+                    k_compound_lookup.get((car, axle_compound, c, cond))
+                    or k_compound_lookup.get((car, axle_compound, c, "dry"))
+                    or K
+                )
             tau = tau_lookup.get((car, c, cond)) or tau_lookup.get((car, c, "dry"))
             if K is None or tau is None:
                 continue

--- a/src/motorsports_data_notebook/tire_model/warmup_table.py
+++ b/src/motorsports_data_notebook/tire_model/warmup_table.py
@@ -82,6 +82,13 @@ G2_LAP_TIME_EXPONENT_FALLBACK = 3.0  # used when even the pooled sector fit is e
 # time can't extrapolate the asymptote into nonsense.
 G2_SCALE_MULTIPLIER_CLAMP = (0.4, 2.5)
 
+# ---- Compound-aware K (Inferno 86 runs A052 and RE-71RS interchangeably) ----
+# Labeled sessions (tire_compounds.yaml sidecar + notes extraction) get a
+# per-(car, compound, corner, condition) K fitted with the pooled τ and
+# c_track held fixed — closed-form weighted least squares, so sparse
+# compound buckets stay stable. Unlabeled sessions keep the pooled K.
+MIN_LAPS_FOR_COMPOUND_K = 10
+
 # Damp/wet τ should physically be ≤ the dry τ (faster cooling in rain). When a
 # rain bucket fits a τ_sec much larger than the same (car, corner)'s dry τ,
 # the fit is almost certainly picking up warmup-interrupted short stints
@@ -302,6 +309,24 @@ def build_warmup_table(
     # Same physical-prior clip on K (rain ⇒ less heat ⇒ K ≤ dry K).
     k_by_car_corner_cond = _clip_wet_k_to_dry_ratio(k_by_car_corner_cond)
 
+    # Compound-aware K for labeled sessions (sidecar + notes labels).
+    from .compounds import load_compound_labels
+
+    compound_labels = load_compound_labels(root)
+    if exclude_session_ids:
+        compound_labels = compound_labels[
+            ~compound_labels["session_id"].isin(exclude_session_ids)
+        ].reset_index(drop=True)
+    k_by_compound = _fit_compound_k(
+        laps_for_fit, compound_labels, tau_by_car_corner_cond, c_track_by_track
+    )
+    if k_by_compound:
+        logger.info(
+            "Fitted %d compound-specific K buckets from %d labeled sessions",
+            len(k_by_compound),
+            compound_labels["session_id"].nunique(),
+        )
+
     model = _assemble_model(
         tau_by_car_corner_cond=tau_by_car_corner_cond,
         k_by_car_corner_cond=k_by_car_corner_cond,
@@ -312,6 +337,7 @@ def build_warmup_table(
         blacklist_applied=blacklist_applied,
         g2_curves=g2_curves,
         g2_exponent_default=g2_exponent_default,
+        k_by_compound=k_by_compound,
     )
 
     if write_artifacts:
@@ -639,6 +665,65 @@ def _build_g2_typ_per_corner(
     return out
 
 
+def _fit_compound_k(
+    laps_for_fit: pd.DataFrame,
+    labels: pd.DataFrame,
+    tau_by_car_corner_cond: dict[tuple[str, str, str], "FitParam"],
+    c_track_by_track: dict[str, "FitParam"],
+) -> dict[tuple[str, str, str, str], "FitParam"]:
+    """Per-(car, compound, corner, condition) K from labeled sessions.
+
+    The pooled τ and c_track are held fixed, which reduces the fit to
+    closed-form weighted least squares through the origin:
+    ``ΔT_i = K · x_i`` with ``x_i = g²_i · c_track · (1 − exp(−t_i/τ))``.
+    That keeps sparse compound buckets stable where a joint curve fit
+    would wander.
+    """
+    if labels.empty:
+        return {}
+    laps = laps_for_fit.merge(labels, on="session_id", how="inner")
+    if laps.empty:
+        return {}
+    laps = laps.copy()
+    laps["g2_lap"] = laps["heat_proxy"] / laps["on_track_s"]
+    laps = laps[laps["g2_lap"].notna() & (laps["g2_lap"] > 0) & (laps["t_cum_s"] > 0)]
+
+    out: dict[tuple[str, str, str, str], FitParam] = {}
+    axis_of = {
+        "fl": "compound_front",
+        "fr": "compound_front",
+        "rl": "compound_rear",
+        "rr": "compound_rear",
+    }
+    for corner in CORNERS:
+        comp_col = axis_of[corner]
+        delta_col = f"delta_t_{corner}"
+        sub_all = laps[laps[comp_col].notna() & laps[delta_col].notna()]
+        for (car, compound, cond), grp in sub_all.groupby(["car", comp_col, "condition"]):
+            if cond == "unknown" or len(grp) < MIN_LAPS_FOR_COMPOUND_K:
+                continue
+            tau_fp = tau_by_car_corner_cond.get(
+                (str(car), corner, str(cond))
+            ) or tau_by_car_corner_cond.get((str(car), corner, "dry"))
+            if tau_fp is None or tau_fp.value <= 0:
+                continue
+            c_track = grp["track_canonical"].map(
+                lambda t: c_track_by_track.get(str(t), FitParam(PRIOR_C_TRACK, 0.0, 0, True)).value
+            )
+            frac = 1.0 - np.exp(-grp["t_cum_s"].to_numpy() / tau_fp.value)
+            x = grp["g2_lap"].to_numpy() * c_track.to_numpy() * frac
+            y = grp[delta_col].to_numpy(dtype=float)
+            sxx = float(np.sum(x * x))
+            if sxx <= 0:
+                continue
+            k = float(np.sum(x * y) / sxx)
+            resid = y - k * x
+            n = len(y)
+            stderr = float(np.sqrt(np.sum(resid * resid) / max(n - 1, 1) / sxx))
+            out[(str(car), str(compound), corner, str(cond))] = FitParam(k, stderr, n)
+    return out
+
+
 def _laps_for_fit(
     laps: pd.DataFrame,
     g2_lookup: dict[tuple[str, str, str], tuple[float, int]],
@@ -896,6 +981,7 @@ def _assemble_model(
     blacklist_applied: list[dict] | None = None,
     g2_curves: dict[tuple[str, str, str], dict] | None = None,
     g2_exponent_default: float = G2_LAP_TIME_EXPONENT_FALLBACK,
+    k_by_compound: dict[tuple[str, str, str, str], "FitParam"] | None = None,
 ) -> dict[str, Any]:
     """Build the in-memory model dict that matches the JSON artifact schema.
 
@@ -906,6 +992,7 @@ def _assemble_model(
     lap_time_typ lookups by (track, car, condition).
     """
     g2_curves = g2_curves or {}
+    k_by_compound = k_by_compound or {}
 
     def _g2_entry(track: str, car: str, cond: str, value: float, n: int) -> dict[str, Any]:
         entry: dict[str, Any] = {
@@ -1025,6 +1112,20 @@ def _assemble_model(
         "g2_typ_by_track_car_cond": [
             _g2_entry(track, car, cond, value, n)
             for (track, car, cond), (value, n) in sorted(g2_lookup.items())
+        ],
+        # Compound-specific K overrides (schema v3 additive; consumers that
+        # don't know about compounds ignore this table and use K_buckets).
+        "K_by_car_compound_corner_cond": [
+            {
+                "car": car,
+                "compound": compound,
+                "corner": corner,
+                "condition": cond,
+                "value_kelvin_per_g2": fp.value,
+                "stderr_kelvin_per_g2": fp.stderr,
+                "n_laps": fp.n_samples,
+            }
+            for (car, compound, corner, cond), fp in sorted(k_by_compound.items())
         ],
         "lap_time_typ_by_track_car_cond": [
             {

--- a/tests/tire_model/test_compounds.py
+++ b/tests/tire_model/test_compounds.py
@@ -1,0 +1,104 @@
+"""Tests for compound label loading + normalization (tire_model.compounds)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from motorsports_data_notebook.tire_model.compounds import (
+    load_compound_labels,
+    normalize_compound,
+)
+
+
+class TestNormalizeCompound:
+    def test_canonical_variants(self):
+        assert normalize_compound("A052") == "A052"
+        assert normalize_compound("052") == "A052"
+        assert normalize_compound("a 052") == "A052"
+        assert normalize_compound("RE-71RS") == "RE-71RS"
+        assert normalize_compound("71RS") == "RE-71RS"
+        assert normalize_compound("RE-71 RS") == "RE-71RS"
+        assert normalize_compound("Nankang NS-2R Used") == "NS-2R"
+        assert normalize_compound("A050_22") == "A050"
+
+    def test_set_labels_pass_through(self):
+        assert normalize_compound("SET:black") == "SET:black"
+        assert normalize_compound("SET:Silver") == "SET:silver"
+
+    def test_junk_returns_none(self):
+        for junk in ("15", "2/2", "14c", "silver worn", None, "", 22):
+            assert normalize_compound(junk) is None
+
+
+def _write_sidecar(root: Path, text: str) -> None:
+    (root / "tire_compounds.yaml").write_text(text)
+
+
+def _write_matches(root: Path, rows: list[dict]) -> None:
+    base = {
+        "session_id": "",
+        "tire_compound_fl": None,
+        "tire_compound_rl": None,
+        "match_confidence": 1.0,
+    }
+    table = pa.Table.from_pylist([{**base, **r} for r in rows])
+    pq.write_table(table, root / "notes_matches.parquet")
+
+
+class TestLoadCompoundLabels:
+    def test_sidecar_wins_over_notes(self, tmp_path: Path):
+        _write_sidecar(tmp_path, "sessions:\n  - session_id: s1\n    front: A052\n    rear: A052\n")
+        _write_matches(
+            tmp_path,
+            [
+                {"session_id": "s1", "tire_compound_fl": "RE-71RS", "tire_compound_rl": "RE-71RS"},
+                {"session_id": "s2", "tire_compound_fl": "71RS", "tire_compound_rl": "71RS"},
+            ],
+        )
+        out = load_compound_labels(tmp_path).set_index("session_id")
+        assert out.loc["s1", "compound_front"] == "A052"
+        assert out.loc["s1", "source"] == "sidecar"
+        assert out.loc["s2", "compound_front"] == "RE-71RS"
+        assert out.loc["s2", "source"] == "notes"
+
+    def test_wheel_sets_resolve_set_labels(self, tmp_path: Path):
+        _write_sidecar(tmp_path, "wheel_sets:\n  black: RE-71RS\n  silver: A052\nsessions: []\n")
+        _write_matches(
+            tmp_path,
+            [
+                {
+                    "session_id": "s1",
+                    "tire_compound_fl": "SET:silver",
+                    "tire_compound_rl": "SET:black",
+                },
+                {
+                    "session_id": "s2",
+                    "tire_compound_fl": "SET:silver-blue",
+                    "tire_compound_rl": None,
+                },
+            ],
+        )
+        out = load_compound_labels(tmp_path).set_index("session_id")
+        assert out.loc["s1", "compound_front"] == "A052"
+        assert out.loc["s1", "compound_rear"] == "RE-71RS"
+        # Unmapped set -> no label at all for that session
+        assert "s2" not in out.index
+
+    def test_highest_confidence_note_wins(self, tmp_path: Path):
+        _write_matches(
+            tmp_path,
+            [
+                {"session_id": "s1", "tire_compound_fl": "A052", "match_confidence": 0.6},
+                {"session_id": "s1", "tire_compound_fl": "71RS", "match_confidence": 0.95},
+            ],
+        )
+        out = load_compound_labels(tmp_path).set_index("session_id")
+        assert out.loc["s1", "compound_front"] == "RE-71RS"
+
+    def test_missing_files(self, tmp_path: Path):
+        out = load_compound_labels(tmp_path)
+        assert out.empty

--- a/tests/tire_model/test_predict.py
+++ b/tests/tire_model/test_predict.py
@@ -650,3 +650,90 @@ def test_nonpositive_target_lap_time_raises() -> None:
             target_lap_time_s=0.0,
             _model=model,
         )
+
+
+# ---------- Compound-aware K ----------
+
+
+def _model_with_compound_k() -> dict:
+    model = _model_with_pace_curve()
+    model["K_by_car_compound_corner_cond"] = [
+        {
+            "car": "ToyCar",
+            "compound": "A052",
+            "corner": c,
+            "condition": "dry",
+            "value_kelvin_per_g2": 40.0,
+            "stderr_kelvin_per_g2": 1.0,
+            "n_laps": 50,
+        }
+        for c in CORNERS
+    ]
+    return model
+
+
+def test_compound_k_overrides_pooled_k() -> None:
+    model = _model_with_compound_k()
+    kwargs = dict(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.8 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    pooled = predict_cold_pressure(**kwargs)
+    comp = predict_cold_pressure(compound_front="A052", compound_rear="A052", **kwargs)
+    for c in CORNERS:
+        assert comp[c].K_kelvin_per_g2 == pytest.approx(40.0)
+        assert comp[c].K_source_bucket == ("ToyCar", "A052", c, "dry")
+        assert comp[c].K_kelvin_per_g2 != pooled[c].K_kelvin_per_g2
+
+
+def test_compound_per_axle_only_affects_that_axle() -> None:
+    model = _model_with_compound_k()
+    kwargs = dict(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.8 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    pooled = predict_cold_pressure(**kwargs)
+    rear_only = predict_cold_pressure(compound_rear="A052", **kwargs)
+    assert rear_only["fl"].K_kelvin_per_g2 == pooled["fl"].K_kelvin_per_g2
+    assert rear_only["rl"].K_kelvin_per_g2 == pytest.approx(40.0)
+
+
+def test_unknown_compound_falls_back_to_pooled_k() -> None:
+    model = _model_with_compound_k()
+    kwargs = dict(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.8 for c in CORNERS},
+        ambient_temp_c=20.0,
+        _model=model,
+    )
+    pooled = predict_cold_pressure(**kwargs)
+    unknown = predict_cold_pressure(compound_front="RE-71RS", compound_rear="RE-71RS", **kwargs)
+    for c in CORNERS:
+        assert unknown[c].K_kelvin_per_g2 == pooled[c].K_kelvin_per_g2
+        assert unknown[c].K_source_bucket == pooled[c].K_source_bucket
+
+
+def test_compound_k_condition_chain_falls_back_to_dry() -> None:
+    model = _model_with_compound_k()  # only dry compound entries exist
+    p = predict_cold_pressure(
+        track="track_a",
+        car="ToyCar",
+        lap_within_stint=5,
+        target_hot_pressure_bar={c: 1.8 for c in CORNERS},
+        ambient_temp_c=20.0,
+        track_condition="damp",
+        compound_front="A052",
+        compound_rear="A052",
+        _model=model,
+    )
+    assert p["fl"].K_source_bucket == ("ToyCar", "A052", "fl", "dry")

--- a/uv.lock
+++ b/uv.lock
@@ -1558,7 +1558,7 @@ wheels = [
 
 [[package]]
 name = "motorsports-data-notebook"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "ipywidgets" },


### PR DESCRIPTION

The Inferno 86 alternates between A052 and RE-71RS sets (sometimes split
by axle), and the two heat ~45% differently per G² — the pooled K split
the difference and mis-predicted both. This wires the compound labels
from PR #135 into the fit and the predictor.

- tire_model/compounds.py: label loader — tire_compounds.yaml sidecar is
  authoritative, notes-extraction compounds are the fallback (normalized;
  "SET:<name>" wheel-set labels resolve via the sidecar's wheel_sets map,
  e.g. black wheels -> RE-71RS), highest-confidence match wins per session.
- warmup_table: per-(car, compound, corner, condition) K fitted from
  labeled sessions by closed-form weighted least squares with the pooled
  τ and c_track held fixed (stable on sparse buckets, min 10 laps).
  Artifact gains K_by_car_compound_corner_cond (additive to schema v3;
  compound-unaware consumers ignore it). Fitted 16 buckets, e.g. dry RR:
  A052 37.7 ± 0.9 vs RE-71RS 59.1 ± 1.3 K/G².
- predict: compound_front/compound_rear inputs (CLI --compound[-front/
  -rear]) swap in the compound K per axle when a fitted bucket exists;
  condition chain applies; unknown compounds keep the pooled K.
- holdout: held-out sessions use their compound label when present,
  mirroring a driver entering the compound in the calculator.

5-fold CV, Inferno 86, same labeled held-out sessions, pooled -> compound:
  FL 6.80 -> 4.95   FR 5.39 -> 4.28   RL 5.99 -> 4.49   RR 4.99 -> 4.51 °C
with the systematic bias collapsing (RL +3.50 -> 0.00 °C). Pooled-CV
numbers move less (FL 4.62->4.43, RL 5.76->5.60) because only 17/47
trainable Inferno sessions are labeled so far — more history in
tire_compounds.yaml directly widens the win.

ETL re-run (no new telemetry/notes); parity fixture unchanged; 586
Python / 80 C# / 18 web tests pass. Calculator UI compound pickers are
the natural follow-up.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/136).
* __->__ #136
* #135
* #133
* #132
* #131
* #130
* #129