### PR TITLE
tire-model 0.20.0: multi-task compound fit with partial supervision

### DIFF
--- a/data/tire_dataset/tire_compounds.yaml
+++ b/data/tire_dataset/tire_compounds.yaml
@@ -23,6 +23,15 @@ wheel_sets:
   black: RE-71RS
   silver: A052
 
+# Weather-driven tire choices: cars whose compound follows the conditions.
+# An all-dry session seeds as the dry tire, an all-wet session as the wet
+# tire; damp/mixed sessions are left to signature inference. Human labels
+# in `sessions:` below always override seeds.
+condition_seeds:
+  KK-SII:
+    dry: DRY
+    wet: WET
+
 sessions:
   - session_id: 9eaa8cd142548a9d  # 2025-03-08 09:09 sodegaura (0 usable laps) [no TPMS]
     front: null

--- a/data/tire_dataset/tire_model.json
+++ b/data/tire_dataset/tire_model.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "fit_at_utc": "2026-08-16T13:43:46+00:00",
+  "fit_at_utc": "2026-08-16T14:01:49+00:00",
   "model_form": "T_hot - T_eff = K[car,corner,cond] * c_track[track] * g2 * (1 - exp(-t / tau_sec[car,corner,cond]))   where T_eff = (1-w_road)*T_air + w_road*T_road, t = N * lap_time_s, g2 = g2_typ[track,car,cond] * clamp((lap_time_typ_s / target_lap_time_s)^g2_lap_time_exponent) when a target lap time is given, else g2_typ",
   "g2_lap_time_model": {
     "method": "sector_knn_median_curve",
@@ -811,180 +811,288 @@
       "compound": "A050",
       "corner": "fl",
       "condition": "dry",
-      "value_kelvin_per_g2": 66.12435277236563,
-      "stderr_kelvin_per_g2": 0.8498679602191533,
-      "n_laps": 99
+      "value_kelvin_per_g2": 65.36183136260313,
+      "stderr_kelvin_per_g2": 0.7066559171525434,
+      "n_laps": 140
     },
     {
       "car": "Inferno 86",
       "compound": "A050",
       "corner": "fr",
       "condition": "dry",
-      "value_kelvin_per_g2": 57.40604453220069,
-      "stderr_kelvin_per_g2": 0.7718853616390704,
-      "n_laps": 99
+      "value_kelvin_per_g2": 57.46033560728896,
+      "stderr_kelvin_per_g2": 0.6331267277086666,
+      "n_laps": 140
     },
     {
       "car": "Inferno 86",
       "compound": "A050",
       "corner": "rl",
       "condition": "dry",
-      "value_kelvin_per_g2": 64.1915214486994,
-      "stderr_kelvin_per_g2": 0.8545315461349715,
-      "n_laps": 99
+      "value_kelvin_per_g2": 65.33681938858986,
+      "stderr_kelvin_per_g2": 0.7982807081503374,
+      "n_laps": 142
     },
     {
       "car": "Inferno 86",
       "compound": "A050",
       "corner": "rr",
       "condition": "dry",
-      "value_kelvin_per_g2": 57.499575045160526,
-      "stderr_kelvin_per_g2": 0.7237151693154246,
-      "n_laps": 99
+      "value_kelvin_per_g2": 58.577138133892085,
+      "stderr_kelvin_per_g2": 0.7388574476853758,
+      "n_laps": 144
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "fl",
       "condition": "damp",
-      "value_kelvin_per_g2": 64.62748415661098,
-      "stderr_kelvin_per_g2": 0.9343794451716717,
-      "n_laps": 99
+      "value_kelvin_per_g2": 64.6167777057696,
+      "stderr_kelvin_per_g2": 0.8424520330746385,
+      "n_laps": 122
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "fl",
       "condition": "dry",
-      "value_kelvin_per_g2": 53.22740118686269,
-      "stderr_kelvin_per_g2": 1.1795091400013198,
-      "n_laps": 74
+      "value_kelvin_per_g2": 54.936163068911256,
+      "stderr_kelvin_per_g2": 0.7113682758526773,
+      "n_laps": 133
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "fr",
       "condition": "damp",
-      "value_kelvin_per_g2": 62.38637524523621,
-      "stderr_kelvin_per_g2": 0.8107401905315348,
-      "n_laps": 99
+      "value_kelvin_per_g2": 61.51885382438194,
+      "stderr_kelvin_per_g2": 0.746473992647269,
+      "n_laps": 122
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "fr",
       "condition": "dry",
-      "value_kelvin_per_g2": 47.55948134248078,
-      "stderr_kelvin_per_g2": 0.964611655646727,
-      "n_laps": 74
+      "value_kelvin_per_g2": 49.24734846476183,
+      "stderr_kelvin_per_g2": 0.5780511266520388,
+      "n_laps": 133
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "rl",
       "condition": "damp",
-      "value_kelvin_per_g2": 54.60627146325913,
-      "stderr_kelvin_per_g2": 0.968665387578184,
-      "n_laps": 99
+      "value_kelvin_per_g2": 54.123251469451745,
+      "stderr_kelvin_per_g2": 0.8136343934920222,
+      "n_laps": 129
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "rl",
       "condition": "dry",
-      "value_kelvin_per_g2": 44.09192175053722,
-      "stderr_kelvin_per_g2": 1.0430597556551748,
-      "n_laps": 74
+      "value_kelvin_per_g2": 46.47938038617607,
+      "stderr_kelvin_per_g2": 0.8598832726272675,
+      "n_laps": 98
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "rr",
       "condition": "damp",
-      "value_kelvin_per_g2": 51.51978833444082,
-      "stderr_kelvin_per_g2": 0.7488780294662825,
-      "n_laps": 99
+      "value_kelvin_per_g2": 52.64803932167738,
+      "stderr_kelvin_per_g2": 0.6560181049062472,
+      "n_laps": 129
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "rr",
       "condition": "dry",
-      "value_kelvin_per_g2": 40.6487780255588,
-      "stderr_kelvin_per_g2": 1.0239747056146633,
-      "n_laps": 74
+      "value_kelvin_per_g2": 42.97193196635482,
+      "stderr_kelvin_per_g2": 0.8318949844523905,
+      "n_laps": 98
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "fl",
       "condition": "damp",
-      "value_kelvin_per_g2": 64.67967396100013,
-      "stderr_kelvin_per_g2": 2.887952627649214,
-      "n_laps": 14
+      "value_kelvin_per_g2": 92.0887318810469,
+      "stderr_kelvin_per_g2": 1.2771399520414595,
+      "n_laps": 63
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "fl",
       "condition": "dry",
-      "value_kelvin_per_g2": 65.97640588705617,
-      "stderr_kelvin_per_g2": 1.37460356323152,
-      "n_laps": 20
+      "value_kelvin_per_g2": 63.44665461851166,
+      "stderr_kelvin_per_g2": 0.8953924783791637,
+      "n_laps": 65
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "fl",
+      "condition": "wet",
+      "value_kelvin_per_g2": 58.034549490010484,
+      "stderr_kelvin_per_g2": 2.4910097610843556,
+      "n_laps": 5
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "fr",
       "condition": "damp",
-      "value_kelvin_per_g2": 60.601701445657284,
-      "stderr_kelvin_per_g2": 2.7589079770932488,
-      "n_laps": 14
+      "value_kelvin_per_g2": 75.37173131909438,
+      "stderr_kelvin_per_g2": 0.9818953326071564,
+      "n_laps": 63
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "fr",
       "condition": "dry",
-      "value_kelvin_per_g2": 59.10488685386076,
-      "stderr_kelvin_per_g2": 1.2272296094099133,
-      "n_laps": 20
+      "value_kelvin_per_g2": 59.577916606591906,
+      "stderr_kelvin_per_g2": 0.8144124170158817,
+      "n_laps": 65
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "fr",
+      "condition": "wet",
+      "value_kelvin_per_g2": 54.59931658549087,
+      "stderr_kelvin_per_g2": 2.702305053367426,
+      "n_laps": 5
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "rl",
       "condition": "damp",
-      "value_kelvin_per_g2": 65.56252484301028,
-      "stderr_kelvin_per_g2": 3.09189552952972,
-      "n_laps": 14
+      "value_kelvin_per_g2": 89.82682841465454,
+      "stderr_kelvin_per_g2": 1.1277493328645238,
+      "n_laps": 63
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "rl",
       "condition": "dry",
-      "value_kelvin_per_g2": 61.4547016964946,
-      "stderr_kelvin_per_g2": 1.4427891509218889,
-      "n_laps": 20
+      "value_kelvin_per_g2": 56.42232470192222,
+      "stderr_kelvin_per_g2": 0.6998245971211606,
+      "n_laps": 90
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "rl",
+      "condition": "wet",
+      "value_kelvin_per_g2": 56.4230634412304,
+      "stderr_kelvin_per_g2": 2.675072393311696,
+      "n_laps": 5
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "rr",
       "condition": "damp",
-      "value_kelvin_per_g2": 61.71975759766632,
-      "stderr_kelvin_per_g2": 2.9842329141575648,
-      "n_laps": 14
+      "value_kelvin_per_g2": 78.46085182924837,
+      "stderr_kelvin_per_g2": 0.912978990641706,
+      "n_laps": 63
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "rr",
       "condition": "dry",
-      "value_kelvin_per_g2": 59.14303232546258,
-      "stderr_kelvin_per_g2": 1.3090382539988996,
-      "n_laps": 20
+      "value_kelvin_per_g2": 52.87589043221988,
+      "stderr_kelvin_per_g2": 0.6684624505459186,
+      "n_laps": 95
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "rr",
+      "condition": "wet",
+      "value_kelvin_per_g2": 55.72673995501048,
+      "stderr_kelvin_per_g2": 3.008170860066068,
+      "n_laps": 5
+    },
+    {
+      "car": "KK-SII",
+      "compound": "DRY",
+      "corner": "fl",
+      "condition": "dry",
+      "value_kelvin_per_g2": 29.769114483308798,
+      "stderr_kelvin_per_g2": 0.17309840053439704,
+      "n_laps": 352
+    },
+    {
+      "car": "KK-SII",
+      "compound": "DRY",
+      "corner": "fr",
+      "condition": "dry",
+      "value_kelvin_per_g2": 22.832336126571033,
+      "stderr_kelvin_per_g2": 0.1454745532368311,
+      "n_laps": 351
+    },
+    {
+      "car": "KK-SII",
+      "compound": "DRY",
+      "corner": "rl",
+      "condition": "dry",
+      "value_kelvin_per_g2": 26.694569451937703,
+      "stderr_kelvin_per_g2": 0.16705887610034179,
+      "n_laps": 319
+    },
+    {
+      "car": "KK-SII",
+      "compound": "DRY",
+      "corner": "rr",
+      "condition": "dry",
+      "value_kelvin_per_g2": 26.885470377460162,
+      "stderr_kelvin_per_g2": 0.1896023728325511,
+      "n_laps": 313
+    },
+    {
+      "car": "KK-SII",
+      "compound": "WET",
+      "corner": "fl",
+      "condition": "wet",
+      "value_kelvin_per_g2": 27.885263537828273,
+      "stderr_kelvin_per_g2": 1.0144298130045655,
+      "n_laps": 24
+    },
+    {
+      "car": "KK-SII",
+      "compound": "WET",
+      "corner": "fr",
+      "condition": "wet",
+      "value_kelvin_per_g2": 22.547227287479217,
+      "stderr_kelvin_per_g2": 0.833945983090787,
+      "n_laps": 24
+    },
+    {
+      "car": "KK-SII",
+      "compound": "WET",
+      "corner": "rl",
+      "condition": "wet",
+      "value_kelvin_per_g2": 21.197883151328643,
+      "stderr_kelvin_per_g2": 0.9969799982677807,
+      "n_laps": 24
+    },
+    {
+      "car": "KK-SII",
+      "compound": "WET",
+      "corner": "rr",
+      "condition": "wet",
+      "value_kelvin_per_g2": 21.735339090688292,
+      "stderr_kelvin_per_g2": 0.6834068688418996,
+      "n_laps": 13
     }
   ],
   "lap_time_typ_by_track_car_cond": [

--- a/docs/tire_model.md
+++ b/docs/tire_model.md
@@ -241,10 +241,32 @@ without compound support ignore the table).
 Prediction: ``predict_cold_pressure(compound_front=..., compound_rear=...)``
 (CLI ``--compound`` / ``--compound-front`` / ``--compound-rear``) swaps in
 the compound K per axle when a fitted bucket exists (condition chain
-applies); unknown compounds and unlabeled cars keep the pooled K. Held-out
-CV on the labeled Inferno sessions (same folds, pooled vs compound K):
-FL 6.80→4.95, FR 5.39→4.28, RL 5.99→4.49, RR 4.99→4.51 °C MAE, with the
-per-corner bias collapsing (RL +3.50→0.00).
+applies); unknown compounds and unlabeled cars keep the pooled K.
+
+**Partial supervision** (``tire_model/compound_infer.py``): labels are
+sparse, so the compound K is fitted as a multi-task objective — the
+compound-assignment task is supervised where labels exist and latent
+elsewhere, sharing K with the temperature-regression task. Solved by EM
+(mixture of regressions): labeled/seeded sessions are pinned one-hot,
+unlabeled (session, axle) units get posteriors from their lap residuals,
+and each K is refit by responsibility-weighted least squares. Guard
+rails: posteriors are tempered to ``SESSION_EFF_SAMPLES`` effective
+observations (laps within a session are correlated); buckets only exist
+with pinned support (free sessions refine, never spawn, buckets — else a
+symmetric fixed point forms); and an outlier gate (χ²/lap against
+pinned-only variance) leaves sessions that match NO known compound
+unlabeled instead of absorbing them. Weather-driven tire choices use
+declarative ``condition_seeds`` in the sidecar (KK-SII: all-dry session ⇒
+DRY tires, all-wet ⇒ WET; damp/mixed left to the classifier — the EM
+independently recovers the known 2026-04-04 rain day as WET at ≥0.998).
+Soft assignments are training-only; held-out evaluation uses human/seed
+labels exclusively. ``just tire-model infer-compounds`` audits every
+latent assignment for human review.
+
+Held-out CV, fleet pooled MAE at v0.20: FL 4.22 / FR 4.21 / RL 4.61 /
+RR 4.18 °C with pooled bias within ±0.75 °C — versus FL 4.95 / FR 4.01 /
+RL 5.63 / RR 4.70 before the compound era (v0.17), with the Inferno's
+rear bias collapsing from ≈−5 °C to −0.7/−1.5 °C.
 
 ### 2.9 Track condition (rain)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motorsports-data-notebook"
-version = "0.19.0"
+version = "0.20.0"
 description = ""
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/src/motorsports_data_notebook/tire_model/cli.py
+++ b/src/motorsports_data_notebook/tire_model/cli.py
@@ -144,6 +144,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     _add_dataset_root_arg(p_audit)
 
+    p_infer = sub.add_parser(
+        "infer-compounds",
+        help=(
+            "Audit semi-supervised compound inference: list which unlabeled "
+            "sessions the K-signature classifier would label, with evidence. "
+            "Promote assignments you trust into tire_compounds.yaml."
+        ),
+    )
+    _add_dataset_root_arg(p_infer)
+
     p_holdout = sub.add_parser(
         "holdout",
         help="Held-out validation: exclude sessions from training, predict per-lap T_hot, report residuals.",
@@ -189,8 +199,92 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_holdout(args)
     if args.cmd == "audit-sensors":
         return _cmd_audit_sensors(args)
+    if args.cmd == "infer-compounds":
+        return _cmd_infer_compounds(args)
     parser.print_help()
     return 2
+
+
+def _cmd_infer_compounds(args: argparse.Namespace) -> int:
+    from pathlib import Path
+
+    import pandas as pd
+
+    from ..tire_etl.paths import default_dataset_root
+    from .compound_infer import apply_condition_seeds, fit_compounds_em
+    from .compounds import load_compound_labels, load_condition_seeds
+    from .warmup_table import (
+        FitParam,
+        _apply_blacklist,
+        _attach_weather,
+        _build_g2_typ,
+        _compute_delta_t,
+        _compute_stint_clock,
+        _laps_for_fit,
+        _load_filtered_laps,
+        _load_weather,
+        build_warmup_table,
+        load_sensor_blacklist,
+    )
+
+    root = Path(args.dataset_root) if args.dataset_root else default_dataset_root()
+    model = build_warmup_table(root, write_artifacts=False)
+    tau = {
+        (d["car"], d["corner"], d["condition"]): FitParam(
+            d["value_seconds"], d["stderr_seconds"], d["n_samples_used"], d["from_prior"]
+        )
+        for d in model["tau_sec_by_car_corner_cond"]
+    }
+    c_track = {
+        d["track_canonical"]: FitParam(d["value"], d["stderr"], d["n_buckets_used"])
+        for d in model["c_track_by_track"]
+    }
+
+    laps = _load_filtered_laps(root)
+    laps = _attach_weather(laps, _load_weather(root))
+    laps = _compute_stint_clock(laps)
+    laps, _ = _apply_blacklist(laps, load_sensor_blacklist(root), warn_on_unknown=False)
+    laps = _compute_delta_t(laps)
+    laps = _laps_for_fit(laps, _build_g2_typ(laps))
+
+    labels = load_compound_labels(root)
+    labels = apply_condition_seeds(labels, laps, load_condition_seeds(root))
+    _, assignments = fit_compounds_em(laps, labels, tau, c_track)
+    detail = [a for a in assignments if not a.pinned]
+
+    sess_meta = pd.concat(
+        [
+            __import__("pyarrow.parquet", fromlist=["read_table"]).read_table(f).to_pandas()
+            for f in sorted((root / "sessions").glob("*.parquet"))
+        ]
+    )[["session_id", "date", "car", "track_canonical"]]
+
+    if not detail:
+        print("No latent assignments (all sessions labeled/seeded, or car ineligible).")
+        return 0
+    df = (
+        pd.DataFrame([d.__dict__ for d in detail])
+        .drop(columns=["car"])
+        .merge(sess_meta, on="session_id")
+    )
+    df = df.sort_values(["date", "session_id", "axle"])
+    cols = [
+        "date",
+        "car",
+        "track_canonical",
+        "session_id",
+        "axle",
+        "compound",
+        "responsibility",
+        "n_laps",
+    ]
+    print(df[cols].to_string(index=False))
+    confident = df[df.responsibility >= 0.9].session_id.nunique()
+    print(
+        f"\n{confident} sessions with responsibility >= 0.9 "
+        "(training uses soft posteriors; promote rows you trust into tire_compounds.yaml)."
+    )
+    return 0
 
 
 def _cmd_build(args: argparse.Namespace) -> int:

--- a/src/motorsports_data_notebook/tire_model/compound_infer.py
+++ b/src/motorsports_data_notebook/tire_model/compound_infer.py
@@ -1,0 +1,447 @@
+"""Joint compound-assignment + K estimation (multi-task, two losses).
+
+Compound labels are sparse, but compounds separate strongly in heat-per-G².
+Rather than classify-then-refit, this fits a single joint objective per
+car and axle:
+
+- latent variable: the axle's compound for each session;
+- supervised loss: labeled/seeded sessions are pinned to their compound
+  (responsibility 1);
+- regression loss: every lap contributes
+  ``(ΔT − K[compound, corner, cond] · x)²`` with
+  ``x = g²·c_track·warmup_frac``, weighted by the session's compound
+  responsibilities.
+
+Under Gaussian residuals the optimum is a mixture of linear regressions,
+solved by EM in closed form: the E-step computes per-(session, axle)
+posteriors over compounds from the lap residuals; the M-step refits each
+``K[car, compound, corner, condition]`` by responsibility-weighted least
+squares through the origin. Iterated to convergence.
+
+Ground rules:
+- Human/seeded labels always win (pinned); inference never overrides.
+- Soft assignments are TRAINING-only. Held-out evaluation uses human/seed
+  labels exclusively — classifying a held-out session from its own
+  temperatures would leak the target into the model choice.
+- A car participates only when at least two compounds each have at least
+  ``MIN_LABELED_SESSIONS`` labeled sessions.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+MIN_LABELED_SESSIONS = 2  # per (car, compound) for that car to participate
+MIN_LAPS_PER_AXLE = 5  # session laps needed for a meaningful posterior
+HARD_ASSIGN_RESP = 0.9  # report threshold for the audit CLI
+SIGMA2_FLOOR = 4.0  # °C² — residual-variance floor so the E-step stays sane
+# Laps within a session share setup, driver and weather, so they are far
+# from independent draws: temper each session's posterior to this many
+# effective observations. Without it the E-step saturates (softmax over a
+# sum of dozens of laps) and even genuinely ambiguous sessions get claimed
+# with certainty, dragging a cluster toward them.
+SESSION_EFF_SAMPLES = 4.0
+# Outlier gate: a free session whose BEST cluster still fits badly (mean
+# per-lap chi² above this) matches no known compound — e.g. a tire we have
+# no labels for — and must stay unlabeled rather than be absorbed into the
+# nearest cluster and drag its K.
+OUTLIER_CHI2_PER_LAP = 9.0
+# A (compound, corner, condition) bucket only exists when pinned sessions
+# put at least this many laps in it. Free sessions refine anchored buckets
+# but cannot spawn new ones — otherwise a symmetric-fixed-point forms where
+# unlabeled laps create identical K for every compound in a bucket no
+# pinned data covers, and the E-step can never tell them apart.
+MIN_PINNED_LAPS_PER_BUCKET = 5.0
+EM_MAX_ITER = 30
+EM_TOL = 1e-4
+
+_AXLE_CORNERS = {"front": ("fl", "fr"), "rear": ("rl", "rr")}
+_CORNER_AXLE = {c: a for a, cs in _AXLE_CORNERS.items() for c in cs}
+
+
+@dataclass(frozen=True)
+class AxleAssignment:
+    session_id: str
+    car: str
+    axle: str
+    compound: str  # argmax compound
+    responsibility: float
+    n_laps: int
+    pinned: bool  # True when from a human/seed label
+
+
+def _suff_stats(
+    laps_for_fit: pd.DataFrame,
+    tau_by_car_corner_cond: dict,
+    c_track_by_track: dict,
+) -> pd.DataFrame:
+    """Per-(session, corner, condition) sufficient statistics.
+
+    Columns: session_id, car, corner, condition, sxx, sxy, syy, n where
+    x = g²·c_track·warmup_frac and y = ΔT.
+    """
+    laps = laps_for_fit.copy()
+    laps["g2_lap"] = laps["heat_proxy"] / laps["on_track_s"]
+    laps = laps[
+        laps["g2_lap"].notna()
+        & (laps["g2_lap"] > 0)
+        & (laps["t_cum_s"] > 0)
+        & (laps["condition"] != "unknown")
+    ]
+
+    def c_val(track: object) -> float:
+        fp = c_track_by_track.get(str(track))
+        return fp.value if fp is not None else 1.0
+
+    rows = []
+    for corner in _CORNER_AXLE:
+        delta_col = f"delta_t_{corner}"
+        sub = laps[laps[delta_col].notna()]
+        for (sid, car, cond), grp in sub.groupby(["session_id", "car", "condition"]):
+            tau_fp = tau_by_car_corner_cond.get(
+                (str(car), corner, str(cond))
+            ) or tau_by_car_corner_cond.get((str(car), corner, "dry"))
+            if tau_fp is None or tau_fp.value <= 0:
+                continue
+            frac = 1.0 - np.exp(-grp["t_cum_s"].to_numpy() / tau_fp.value)
+            x = grp["g2_lap"].to_numpy() * grp["track_canonical"].map(c_val).to_numpy() * frac
+            y = grp[delta_col].to_numpy(dtype=float)
+            ok = x > 0
+            if not ok.any():
+                continue
+            x, y = x[ok], y[ok]
+            rows.append(
+                {
+                    "session_id": sid,
+                    "car": str(car),
+                    "corner": corner,
+                    "condition": str(cond),
+                    "sxx": float(np.sum(x * x)),
+                    "sxy": float(np.sum(x * y)),
+                    "syy": float(np.sum(y * y)),
+                    "n": int(len(y)),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def fit_compounds_em(
+    laps_for_fit: pd.DataFrame,
+    labels: pd.DataFrame,
+    tau_by_car_corner_cond: dict,
+    c_track_by_track: dict,
+    *,
+    max_iter: int = EM_MAX_ITER,
+) -> tuple[dict[tuple[str, str, str, str], tuple[float, float, float]], list[AxleAssignment]]:
+    """Joint EM over compound assignments and per-compound K.
+
+    Returns ``(k_by_compound, assignments)`` where ``k_by_compound`` maps
+    ``(car, compound, corner, condition) -> (K, stderr, n_effective)`` and
+    ``assignments`` carries the final per-(session, axle) posteriors.
+    """
+    if laps_for_fit.empty or labels.empty:
+        return {}, []
+
+    stats = _suff_stats(laps_for_fit, tau_by_car_corner_cond, c_track_by_track)
+    if stats.empty:
+        return {}, []
+    stats["axle"] = stats["corner"].map(_CORNER_AXLE)
+
+    label_cols = {"front": "compound_front", "rear": "compound_rear"}
+    pinned: dict[tuple[str, str], str] = {}
+    for r in labels.itertuples():
+        for axle, col in label_cols.items():
+            comp = getattr(r, col)
+            if isinstance(comp, str) and comp:
+                pinned[(str(r.session_id), axle)] = comp
+
+    out_k: dict[tuple[str, str, str, str], tuple[float, float, float]] = {}
+    assignments: list[AxleAssignment] = []
+
+    for car_key, car_stats in stats.groupby("car"):
+        car = str(car_key)
+        # Eligibility: ≥2 compounds with ≥MIN_LABELED_SESSIONS pinned sessions.
+        pinned_here: dict[str, set] = {}
+        for (sid, axle), comp in pinned.items():
+            if sid in set(car_stats["session_id"]):
+                pinned_here.setdefault(comp, set()).add(sid)
+        compounds = sorted(
+            c for c, sids in pinned_here.items() if len(sids) >= MIN_LABELED_SESSIONS
+        )
+        if len(compounds) < 2:
+            # Still fit K for whatever labeled compounds exist (no latents).
+            compounds = sorted(pinned_here)
+            if not compounds:
+                continue
+            fixed_only = True
+        else:
+            fixed_only = False
+
+        # Units: (session, axle) with enough laps.
+        unit_lap_counts: dict[tuple[str, str], int] = {
+            (str(k[0]), str(k[1])): int(v)  # type: ignore[index]
+            for k, v in car_stats.groupby(["session_id", "axle"])["n"].sum().items()
+        }
+        units = [u for u, n in unit_lap_counts.items() if n >= MIN_LAPS_PER_AXLE or u in pinned]
+        if not units:
+            continue
+        unit_idx = {u: i for i, u in enumerate(units)}
+        n_units, n_comp = len(units), len(compounds)
+        comp_idx = {c: j for j, c in enumerate(compounds)}
+
+        # Responsibilities: pinned one-hot; unlabeled start uniform.
+        resp = np.full((n_units, n_comp), 1.0 / n_comp)
+        pin_mask = np.zeros(n_units, dtype=bool)
+        for u, i in unit_idx.items():
+            comp = pinned.get(u)
+            if comp is not None and comp in comp_idx:
+                resp[i] = 0.0
+                resp[i, comp_idx[comp]] = 1.0
+                pin_mask[i] = True
+            elif fixed_only:
+                # No latents for this car: unlabeled units don't participate.
+                resp[i] = 0.0
+
+        # Index sufficient stats by unit.
+        s_unit = car_stats.copy()
+        s_unit["unit"] = list(zip(s_unit["session_id"], s_unit["axle"]))
+        s_unit = s_unit[s_unit["unit"].isin(unit_idx)]
+        s_unit["ui"] = s_unit["unit"].map(unit_idx)
+
+        buckets = s_unit.groupby(["corner", "condition"])
+        sigma2: dict[str, float] = {c: 25.0 for c in _CORNER_AXLE}  # start: (5 °C)²
+        k_val: dict[tuple[str, str, str], float] = {}  # (compound, corner, cond) -> K
+
+        def k_for_scoring(comp: str, corner: str, cond: str) -> float | None:
+            """K for likelihood scoring: exact condition, then dry, then any.
+
+            A compound with NO K anywhere for this corner must not be
+            scored at all — treating a missing bucket as zero residual
+            would make "no coverage" look like a perfect fit.
+            """
+            for c2 in (cond, "dry"):
+                k = k_val.get((comp, corner, c2))
+                if k is not None:
+                    return k
+            for (c_comp, c_corner, _c2), k in k_val.items():
+                if c_comp == comp and c_corner == corner:
+                    return k
+            return None
+
+        prev_ll = -np.inf
+        for _ in range(max_iter):
+            # ---- M-step: responsibility-weighted least squares per bucket ----
+            k_val.clear()
+            for bkey, grp in buckets:
+                corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
+                ui = grp["ui"].to_numpy()
+                for comp, j in comp_idx.items():
+                    w = resp[ui, j]
+                    w_pinned = float(np.sum(w * pin_mask[ui] * grp["n"].to_numpy()))
+                    if not fixed_only and w_pinned < MIN_PINNED_LAPS_PER_BUCKET:
+                        continue
+                    sxx = float(np.sum(w * grp["sxx"].to_numpy()))
+                    if sxx <= 0:
+                        continue
+                    sxy = float(np.sum(w * grp["sxy"].to_numpy()))
+                    k_val[(comp, corner, cond)] = sxy / sxx
+            # Residual variance per corner (pooled over compounds/conds).
+            for corner in _CORNER_AXLE:
+                num = den = 0.0
+                for bkey, grp in buckets:
+                    c2, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
+                    if c2 != corner:
+                        continue
+                    ui = grp["ui"].to_numpy()
+                    for comp, j in comp_idx.items():
+                        k = k_val.get((comp, corner, cond))
+                        if k is None:
+                            continue
+                        w = resp[ui, j]
+                        rss_arr = (
+                            grp["syy"].to_numpy()
+                            - 2 * k * grp["sxy"].to_numpy()
+                            + k * k * grp["sxx"].to_numpy()
+                        )
+                        num += float(np.sum(w * rss_arr))
+                        den += float(np.sum(w * grp["n"].to_numpy()))
+                if den > 0:
+                    sigma2[corner] = max(num / den, SIGMA2_FLOOR)
+
+            # ---- E-step: posteriors for un-pinned units ----
+            loglik = np.zeros((n_units, n_comp))
+            covered = np.zeros((n_units, n_comp))
+            for bkey, grp in buckets:
+                corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
+                ui = grp["ui"].to_numpy()
+                s2 = sigma2[corner]
+                for comp, j in comp_idx.items():
+                    k = k_for_scoring(comp, corner, cond)
+                    if k is None:
+                        continue
+                    rss_arr = (
+                        grp["syy"].to_numpy()
+                        - 2 * k * grp["sxy"].to_numpy()
+                        + k * k * grp["sxx"].to_numpy()
+                    )
+                    np.add.at(loglik[:, j], ui, -0.5 * rss_arr / s2)
+                    np.add.at(covered[:, j], ui, grp["n"].to_numpy())
+            # A compound that covers none of a unit's laps is not a candidate.
+            loglik = np.where(covered > 0, loglik, -np.inf)
+            free = ~pin_mask if not fixed_only else np.zeros(n_units, dtype=bool)
+            if free.any():
+                n_u = np.array([max(float(unit_lap_counts.get(u, 1)), 1.0) for u in units])
+                temper = np.minimum(1.0, SESSION_EFF_SAMPLES / n_u)[:, None]
+                ll = (loglik * temper)[free]
+                row_max = ll.max(axis=1, keepdims=True)
+                ok_rows = np.isfinite(row_max[:, 0])
+                p = np.zeros_like(ll)
+                if ok_rows.any():
+                    z = np.exp(ll[ok_rows] - row_max[ok_rows])
+                    p[ok_rows] = z / z.sum(axis=1, keepdims=True)
+                resp[free] = p
+            total_ll = float(np.sum(np.where(resp > 0, loglik * resp, 0.0)))
+            if abs(total_ll - prev_ll) < EM_TOL * (1 + abs(prev_ll)):
+                break
+            prev_ll = total_ll
+
+        # Outlier gate: free units whose best cluster still fits badly get
+        # their responsibilities zeroed (unknown compound — stays unlabeled).
+        # The gate's variance comes from PINNED sessions only: the mixture
+        # σ² is inflated by the very outliers we are trying to detect.
+        if not fixed_only:
+            sig_num: dict[str, float] = {c: 0.0 for c in _CORNER_AXLE}
+            sig_den: dict[str, float] = {c: 0.0 for c in _CORNER_AXLE}
+            chi2_num = np.zeros((n_units, n_comp))
+            for bkey, grp in buckets:
+                corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
+                ui = grp["ui"].to_numpy()
+                for comp, j in comp_idx.items():
+                    k = k_for_scoring(comp, corner, cond)
+                    if k is None:
+                        np.add.at(chi2_num[:, j], ui, np.inf * np.ones(len(ui)))
+                        continue
+                    rss_arr = (
+                        grp["syy"].to_numpy()
+                        - 2 * k * grp["sxy"].to_numpy()
+                        + k * k * grp["sxx"].to_numpy()
+                    )
+                    np.add.at(chi2_num[:, j], ui, rss_arr)
+                    w_pin = resp[ui, j] * pin_mask[ui]
+                    sig_num[corner] += float(np.sum(w_pin * rss_arr))
+                    sig_den[corner] += float(np.sum(w_pin * grp["n"].to_numpy()))
+            sigma2_clean = np.mean(
+                [
+                    max(sig_num[c] / sig_den[c], SIGMA2_FLOOR) if sig_den[c] > 0 else SIGMA2_FLOOR
+                    for c in _CORNER_AXLE
+                ]
+            )
+            n_u_arr = np.array([max(float(unit_lap_counts.get(u, 1)), 1.0) for u in units])
+            best_chi2 = chi2_num.min(axis=1) / (n_u_arr * sigma2_clean)
+            outlier = (~pin_mask) & (best_chi2 > OUTLIER_CHI2_PER_LAP)
+            if outlier.any():
+                resp[outlier] = 0.0
+                # One more M-step so exported K excludes the outliers.
+                k_val.clear()
+                for bkey, grp in buckets:
+                    corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
+                    ui = grp["ui"].to_numpy()
+                    for comp, j in comp_idx.items():
+                        w = resp[ui, j]
+                        w_pinned = float(np.sum(w * pin_mask[ui] * grp["n"].to_numpy()))
+                        if not fixed_only and w_pinned < MIN_PINNED_LAPS_PER_BUCKET:
+                            continue
+                        sxx = float(np.sum(w * grp["sxx"].to_numpy()))
+                        if sxx > 0:
+                            k_val[(comp, corner, cond)] = float(
+                                np.sum(w * grp["sxy"].to_numpy()) / sxx
+                            )
+
+        # ---- Export K with stderr + effective n ----
+        for bkey, grp in buckets:
+            corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
+            ui = grp["ui"].to_numpy()
+            for comp, j in comp_idx.items():
+                k = k_val.get((comp, corner, cond))
+                if k is None:
+                    continue
+                w = resp[ui, j]
+                sxx = float(np.sum(w * grp["sxx"].to_numpy()))
+                n_eff = float(np.sum(w * grp["n"].to_numpy()))
+                if sxx <= 0 or n_eff < MIN_LAPS_PER_AXLE:
+                    continue
+                rss = float(
+                    np.sum(
+                        w
+                        * (
+                            grp["syy"].to_numpy()
+                            - 2 * k * grp["sxy"].to_numpy()
+                            + k * k * grp["sxx"].to_numpy()
+                        )
+                    )
+                )
+                stderr = float(np.sqrt(max(rss, 0.0) / max(n_eff - 1, 1.0) / sxx))
+                out_k[(str(car), comp, corner, cond)] = (k, stderr, n_eff)
+
+        for u, i in unit_idx.items():
+            j = int(np.argmax(resp[i]))
+            if resp[i].sum() == 0:
+                continue
+            assignments.append(
+                AxleAssignment(
+                    session_id=u[0],
+                    car=str(car),
+                    axle=u[1],
+                    compound=compounds[j],
+                    responsibility=round(float(resp[i, j]), 3),
+                    n_laps=unit_lap_counts.get(u, 0),
+                    pinned=bool(pin_mask[i]),
+                )
+            )
+
+    return out_k, assignments
+
+
+def apply_condition_seeds(
+    labels: pd.DataFrame,
+    laps: pd.DataFrame,
+    seeds: dict[str, dict[str, str]],
+) -> pd.DataFrame:
+    """Expand declarative condition seeds into per-session labels.
+
+    ``seeds`` (from the sidecar's ``condition_seeds`` block) maps
+    ``car -> {condition -> compound}`` — e.g. every all-dry KK-SII session
+    seeds as DRY tires, every all-wet one as WET. Sessions with mixed or
+    unlisted conditions are left alone, and existing labels always win.
+    """
+    if not seeds or laps.empty:
+        return labels
+    have = set(labels["session_id"]) if not labels.empty else set()
+    lp = laps[laps["condition"] != "unknown"]
+    conds = lp.groupby(["session_id", "car"])["condition"].agg(set).reset_index()
+    rows = []
+    for sid, car, condset in zip(conds["session_id"], conds["car"], conds["condition"]):
+        if sid in have or len(condset) != 1:
+            continue
+        mapping = seeds.get(str(car))
+        if not mapping:
+            continue
+        compound = mapping.get(next(iter(condset)))
+        if compound:
+            rows.append(
+                {
+                    "session_id": sid,
+                    "compound_front": compound,
+                    "compound_rear": compound,
+                    "source": "seed",
+                }
+            )
+    if not rows:
+        return labels
+    return pd.concat([labels, pd.DataFrame(rows)], ignore_index=True)

--- a/src/motorsports_data_notebook/tire_model/compounds.py
+++ b/src/motorsports_data_notebook/tire_model/compounds.py
@@ -59,6 +59,27 @@ def normalize_compound(raw: object) -> str | None:
     return None
 
 
+def load_condition_seeds(dataset_root: Path) -> dict[str, dict[str, str]]:
+    """The sidecar's declarative ``condition_seeds`` block.
+
+    Maps ``car -> {track_condition -> compound}`` for cars whose tire
+    choice follows the weather (e.g. the KK-SII's DRY/WET tires): an
+    all-dry session seeds as the dry tire, an all-wet one as the wet
+    tire, and mixed/damp sessions are left for signature inference.
+    """
+    import yaml
+
+    sidecar_path = dataset_root / COMPOUNDS_FILE
+    if not sidecar_path.exists():
+        return {}
+    doc = yaml.safe_load(sidecar_path.read_text(encoding="utf-8")) or {}
+    out: dict[str, dict[str, str]] = {}
+    for car, mapping in (doc.get("condition_seeds") or {}).items():
+        if isinstance(mapping, dict):
+            out[str(car)] = {str(k): str(v) for k, v in mapping.items() if v}
+    return out
+
+
 def load_compound_labels(dataset_root: Path) -> pd.DataFrame:
     """Return per-session compound labels: columns
     ``session_id, compound_front, compound_rear, source``.

--- a/src/motorsports_data_notebook/tire_model/validate.py
+++ b/src/motorsports_data_notebook/tire_model/validate.py
@@ -207,16 +207,13 @@ def _evaluate_fold(root: Path, holdout_ids: list[str]) -> pd.DataFrame:
     }
     # Held-out sessions' compound labels (metadata, not telemetry — using
     # them mirrors a driver entering the compound in the calculator).
-    from .compounds import load_compound_labels
+    # Condition seeds count as metadata too (the driver knows whether wets
+    # are bolted on); signature-INFERRED labels do not — classifying a
+    # held-out session from its own temps would leak the target.
+    from .compound_infer import apply_condition_seeds
+    from .compounds import load_compound_labels, load_condition_seeds
 
     labels = load_compound_labels(root)
-    label_by_session = {
-        r.session_id: (
-            r.compound_front if isinstance(r.compound_front, str) else None,
-            r.compound_rear if isinstance(r.compound_rear, str) else None,
-        )
-        for r in labels.itertuples()
-    }
     tau_lookup = {
         (d["car"], d["corner"], d["condition"]): d["value_seconds"]
         for d in model["tau_sec_by_car_corner_cond"]
@@ -249,6 +246,15 @@ def _evaluate_fold(root: Path, holdout_ids: list[str]) -> pd.DataFrame:
     all_laps = _compute_delta_t(all_laps)
     # Drop out-laps from evaluation (same convention as training)
     all_laps = all_laps[all_laps["lap_within_stint"] > 0].reset_index(drop=True)
+
+    labels = apply_condition_seeds(labels, all_laps, load_condition_seeds(root))
+    label_by_session = {
+        r.session_id: (
+            r.compound_front if isinstance(r.compound_front, str) else None,
+            r.compound_rear if isinstance(r.compound_rear, str) else None,
+        )
+        for r in labels.itertuples()
+    }
 
     # Per-lap predictions. Per-lap g² (heat_proxy / on_track_s) is the
     # held-out lap's actual driving intensity; falls back to the bucket

--- a/src/motorsports_data_notebook/tire_model/warmup_table.py
+++ b/src/motorsports_data_notebook/tire_model/warmup_table.py
@@ -309,22 +309,41 @@ def build_warmup_table(
     # Same physical-prior clip on K (rain ⇒ less heat ⇒ K ≤ dry K).
     k_by_car_corner_cond = _clip_wet_k_to_dry_ratio(k_by_car_corner_cond)
 
-    # Compound-aware K for labeled sessions (sidecar + notes labels).
-    from .compounds import load_compound_labels
+    # Compound-aware K: multi-task fit with partial supervision. The
+    # compound-assignment task is supervised where labels exist (sidecar +
+    # notes, plus weather-driven condition seeds like the KK-SII's
+    # DRY/WET) and latent elsewhere; the temperature-regression task
+    # shares the per-compound K parameters. Solved jointly by EM
+    # (mixture of regressions with pinned responsibilities). Soft
+    # assignments are training-only — held-out evaluation uses human/seed
+    # labels exclusively (see validate._evaluate_fold).
+    from .compound_infer import apply_condition_seeds, fit_compounds_em
+    from .compounds import load_compound_labels, load_condition_seeds
 
     compound_labels = load_compound_labels(root)
     if exclude_session_ids:
         compound_labels = compound_labels[
             ~compound_labels["session_id"].isin(exclude_session_ids)
         ].reset_index(drop=True)
-    k_by_compound = _fit_compound_k(
+    compound_labels = apply_condition_seeds(
+        compound_labels, laps_for_fit, load_condition_seeds(root)
+    )
+    k_em, em_assignments = fit_compounds_em(
         laps_for_fit, compound_labels, tau_by_car_corner_cond, c_track_by_track
     )
+    k_by_compound = {
+        key: FitParam(value=k, stderr=stderr, n_samples=int(round(n_eff)))
+        for key, (k, stderr, n_eff) in k_em.items()
+    }
     if k_by_compound:
+        inferred = [a for a in em_assignments if not a.pinned and a.responsibility >= 0.9]
         logger.info(
-            "Fitted %d compound-specific K buckets from %d labeled sessions",
+            "Fitted %d compound K buckets (EM over %d session-axles, "
+            "%d pinned, %d confidently inferred)",
             len(k_by_compound),
-            compound_labels["session_id"].nunique(),
+            len(em_assignments),
+            sum(1 for a in em_assignments if a.pinned),
+            len(inferred),
         )
 
     model = _assemble_model(
@@ -662,65 +681,6 @@ def _build_g2_typ_per_corner(
                 float(np.percentile(g2_per_lap, percentile)),
                 int(len(g2_per_lap)),
             )
-    return out
-
-
-def _fit_compound_k(
-    laps_for_fit: pd.DataFrame,
-    labels: pd.DataFrame,
-    tau_by_car_corner_cond: dict[tuple[str, str, str], "FitParam"],
-    c_track_by_track: dict[str, "FitParam"],
-) -> dict[tuple[str, str, str, str], "FitParam"]:
-    """Per-(car, compound, corner, condition) K from labeled sessions.
-
-    The pooled τ and c_track are held fixed, which reduces the fit to
-    closed-form weighted least squares through the origin:
-    ``ΔT_i = K · x_i`` with ``x_i = g²_i · c_track · (1 − exp(−t_i/τ))``.
-    That keeps sparse compound buckets stable where a joint curve fit
-    would wander.
-    """
-    if labels.empty:
-        return {}
-    laps = laps_for_fit.merge(labels, on="session_id", how="inner")
-    if laps.empty:
-        return {}
-    laps = laps.copy()
-    laps["g2_lap"] = laps["heat_proxy"] / laps["on_track_s"]
-    laps = laps[laps["g2_lap"].notna() & (laps["g2_lap"] > 0) & (laps["t_cum_s"] > 0)]
-
-    out: dict[tuple[str, str, str, str], FitParam] = {}
-    axis_of = {
-        "fl": "compound_front",
-        "fr": "compound_front",
-        "rl": "compound_rear",
-        "rr": "compound_rear",
-    }
-    for corner in CORNERS:
-        comp_col = axis_of[corner]
-        delta_col = f"delta_t_{corner}"
-        sub_all = laps[laps[comp_col].notna() & laps[delta_col].notna()]
-        for (car, compound, cond), grp in sub_all.groupby(["car", comp_col, "condition"]):
-            if cond == "unknown" or len(grp) < MIN_LAPS_FOR_COMPOUND_K:
-                continue
-            tau_fp = tau_by_car_corner_cond.get(
-                (str(car), corner, str(cond))
-            ) or tau_by_car_corner_cond.get((str(car), corner, "dry"))
-            if tau_fp is None or tau_fp.value <= 0:
-                continue
-            c_track = grp["track_canonical"].map(
-                lambda t: c_track_by_track.get(str(t), FitParam(PRIOR_C_TRACK, 0.0, 0, True)).value
-            )
-            frac = 1.0 - np.exp(-grp["t_cum_s"].to_numpy() / tau_fp.value)
-            x = grp["g2_lap"].to_numpy() * c_track.to_numpy() * frac
-            y = grp[delta_col].to_numpy(dtype=float)
-            sxx = float(np.sum(x * x))
-            if sxx <= 0:
-                continue
-            k = float(np.sum(x * y) / sxx)
-            resid = y - k * x
-            n = len(y)
-            stderr = float(np.sqrt(np.sum(resid * resid) / max(n - 1, 1) / sxx))
-            out[(str(car), str(compound), corner, str(cond))] = FitParam(k, stderr, n)
     return out
 
 

--- a/tests/tire_model/test_compound_infer.py
+++ b/tests/tire_model/test_compound_infer.py
@@ -1,0 +1,153 @@
+"""Tests for the joint (multi-task, partially supervised) compound EM."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from motorsports_data_notebook.tire_model.compound_infer import (
+    apply_condition_seeds,
+    fit_compounds_em,
+)
+
+CORNERS = ("fl", "fr", "rl", "rr")
+
+
+@dataclass
+class _FP:
+    value: float
+
+
+TAU = {("ToyCar", c, "dry"): _FP(200.0) for c in CORNERS}
+C_TRACK = {"track_a": _FP(1.0)}
+
+
+def _session_laps(sid: str, k_true: float, n_laps: int = 12, noise: float = 1.0) -> pd.DataFrame:
+    rng = np.random.default_rng(abs(hash(sid)) % 2**32)
+    t = np.linspace(120, 120 * n_laps, n_laps)
+    g2 = rng.uniform(0.5, 1.1, n_laps)
+    frac = 1 - np.exp(-t / 200.0)
+    rows = {
+        "session_id": [sid] * n_laps,
+        "car": ["ToyCar"] * n_laps,
+        "condition": ["dry"] * n_laps,
+        "track_canonical": ["track_a"] * n_laps,
+        "t_cum_s": t,
+        "on_track_s": np.full(n_laps, 100.0),
+        "heat_proxy": g2 * 100.0,
+    }
+    for c in CORNERS:
+        rows[f"delta_t_{c}"] = k_true * g2 * frac + rng.normal(0, noise, n_laps)
+    return pd.DataFrame(rows)
+
+
+def _labels(entries: dict[str, str]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "session_id": sid,
+                "compound_front": comp,
+                "compound_rear": comp,
+                "source": "sidecar",
+            }
+            for sid, comp in entries.items()
+        ]
+    )
+
+
+def _mixture_frame() -> pd.DataFrame:
+    parts = [
+        _session_laps("soft1", 30.0),
+        _session_laps("soft2", 30.0),
+        _session_laps("hard1", 60.0),
+        _session_laps("hard2", 60.0),
+        _session_laps("mystery_soft", 30.0),
+        _session_laps("mystery_hard", 60.0),
+        _session_laps("ambiguous", 45.0),
+    ]
+    return pd.concat(parts, ignore_index=True)
+
+
+class TestFitCompoundsEM:
+    def test_recovers_unlabeled_assignments_and_k(self):
+        laps = _mixture_frame()
+        labels = _labels({"soft1": "SOFT", "soft2": "SOFT", "hard1": "HARD", "hard2": "HARD"})
+        k, assignments = fit_compounds_em(laps, labels, TAU, C_TRACK)
+
+        by_unit = {(a.session_id, a.axle): a for a in assignments}
+        assert by_unit[("mystery_soft", "front")].compound == "SOFT"
+        assert by_unit[("mystery_soft", "front")].responsibility > 0.95
+        assert by_unit[("mystery_hard", "rear")].compound == "HARD"
+        assert by_unit[("mystery_hard", "rear")].responsibility > 0.95
+        # The mid-K session fits neither compound: the outlier gate must
+        # leave it unlabeled rather than absorb it into a cluster.
+        assert ("ambiguous", "front") not in by_unit
+
+        assert k[("ToyCar", "SOFT", "fl", "dry")][0] == pytest.approx(30.0, abs=2.0)
+        assert k[("ToyCar", "HARD", "fl", "dry")][0] == pytest.approx(60.0, abs=2.0)
+
+    def test_pinned_labels_never_flip(self):
+        laps = _mixture_frame()
+        # Deliberately mislabel a hard session as SOFT: it must stay pinned.
+        labels = _labels(
+            {
+                "soft1": "SOFT",
+                "soft2": "SOFT",
+                "hard1": "HARD",
+                "hard2": "HARD",
+                "mystery_hard": "SOFT",
+            }
+        )
+        _, assignments = fit_compounds_em(laps, labels, TAU, C_TRACK)
+        by_unit = {(a.session_id, a.axle): a for a in assignments}
+        a = by_unit[("mystery_hard", "front")]
+        assert a.pinned and a.compound == "SOFT" and a.responsibility == 1.0
+
+    def test_single_compound_car_fits_without_latents(self):
+        laps = pd.concat(
+            [_session_laps("s1", 40.0), _session_laps("s2", 40.0), _session_laps("un", 40.0)],
+            ignore_index=True,
+        )
+        labels = _labels({"s1": "ONLY", "s2": "ONLY"})
+        k, assignments = fit_compounds_em(laps, labels, TAU, C_TRACK)
+        assert k[("ToyCar", "ONLY", "fl", "dry")][0] == pytest.approx(40.0, abs=2.0)
+        # The unlabeled session contributes nothing and gets no assignment.
+        assert all(a.session_id != "un" for a in assignments)
+
+    def test_no_labels_no_output(self):
+        laps = _mixture_frame()
+        k, assignments = fit_compounds_em(laps, laps.iloc[0:0], TAU, C_TRACK)
+        assert k == {} and assignments == []
+
+
+class TestApplyConditionSeeds:
+    def test_seeds_uniform_condition_sessions_only(self):
+        laps = pd.DataFrame(
+            {
+                "session_id": ["dry1", "dry1", "wet1", "mixed", "mixed"],
+                "car": ["KK-SII"] * 5,
+                "condition": ["dry", "dry", "wet", "dry", "wet"],
+            }
+        )
+        labels = pd.DataFrame(columns=["session_id", "compound_front", "compound_rear", "source"])
+        out = apply_condition_seeds(labels, laps, {"KK-SII": {"dry": "DRY", "wet": "WET"}})
+        got = dict(zip(out.session_id, out.compound_front))
+        assert got == {"dry1": "DRY", "wet1": "WET"}  # mixed stays unlabeled
+
+    def test_existing_labels_win(self):
+        laps = pd.DataFrame({"session_id": ["s1"], "car": ["KK-SII"], "condition": ["dry"]})
+        labels = pd.DataFrame(
+            [
+                {
+                    "session_id": "s1",
+                    "compound_front": "WET",
+                    "compound_rear": "WET",
+                    "source": "sidecar",
+                }
+            ]
+        )
+        out = apply_condition_seeds(labels, laps, {"KK-SII": {"dry": "DRY"}})
+        assert len(out) == 1 and out.iloc[0].compound_front == "WET"

--- a/uv.lock
+++ b/uv.lock
@@ -1558,7 +1558,7 @@ wheels = [
 
 [[package]]
 name = "motorsports-data-notebook"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "ipywidgets" },


### PR DESCRIPTION

Replaces the classify-then-refit compound pass with a single joint
objective (user suggestion): the compound-assignment task is supervised
where labels exist and latent elsewhere, sharing per-compound K with the
temperature-regression task. Solved as a mixture of linear regressions
by EM — labeled/seeded (session, axle) units pinned one-hot, free units
get posteriors from their lap residuals, K refit by responsibility-
weighted least squares, iterated to convergence.

Robustness guards, each added after observing the failure mode:
- Posterior tempering to SESSION_EFF_SAMPLES effective observations —
  laps within a session are correlated, and untampered softmax over
  dozens of laps saturates.
- Buckets require pinned support (free sessions refine but never spawn
  them) — otherwise unlabeled laps create identical K for every compound
  in uncovered buckets and stall at a symmetric 0.5 fixed point.
- Coverage mask: a compound with no K anywhere for a corner scores -inf,
  not 0 (a missing bucket is not a perfect fit).
- Outlier gate on chi^2/lap vs pinned-only variance: sessions matching NO
  known compound stay unlabeled instead of dragging the nearest cluster.

KK-SII joins via declarative condition_seeds in the sidecar (all-dry
session => DRY tires, all-wet => WET; damp/mixed left latent). Blind
validation: the EM recovers the known 2026-04-04 rain day as WET at
>= 0.998 responsibility. 22 session-axles confidently inferred on top of
126 pinned; `tire-model infer-compounds` audits every latent assignment.
Soft assignments are training-only — held-out evaluation uses human/seed
labels exclusively (no target leakage).

5-fold CV fleet pooled MAE: FL 4.22, FR 4.21, RL 4.61, RR 4.18 °C
(biases within ±0.75 °C); KK-SII RR 3.55 -> 3.24 from the DRY/WET split;
Inferno rear bias down to -0.7/-1.5 °C. 598 Python / 80 C# / 18 web
tests pass.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/142).
* __->__ #142
* #141
* #140
* #139
* #138
* #137
* #136
* #135
* #133
* #132
* #131
* #130
* #129