### PR TITLE
tire-model 0.21.0: decomposed K (c_track × base × compound multiplier), forced selection

### DIFF
--- a/data/tire_dataset/tire_model.json
+++ b/data/tire_dataset/tire_model.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "fit_at_utc": "2026-08-16T14:01:49+00:00",
+  "fit_at_utc": "2026-08-16T14:11:52+00:00",
   "model_form": "T_hot - T_eff = K[car,corner,cond] * c_track[track] * g2 * (1 - exp(-t / tau_sec[car,corner,cond]))   where T_eff = (1-w_road)*T_air + w_road*T_road, t = N * lap_time_s, g2 = g2_typ[track,car,cond] * clamp((lap_time_typ_s / target_lap_time_s)^g2_lap_time_exponent) when a target lap time is given, else g2_typ",
   "g2_lap_time_model": {
     "method": "sector_knn_median_curve",
@@ -805,41 +805,104 @@
       }
     }
   ],
+  "K_compound_multipliers": [
+    {
+      "car": "Inferno 86",
+      "compound": "A050",
+      "multiplier": 1.1802
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "multiplier": 0.8595
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "multiplier": 1.0494
+    },
+    {
+      "car": "KK-SII",
+      "compound": "DRY",
+      "multiplier": 1.0
+    },
+    {
+      "car": "KK-SII",
+      "compound": "WET",
+      "multiplier": 1.0
+    }
+  ],
   "K_by_car_compound_corner_cond": [
     {
       "car": "Inferno 86",
       "compound": "A050",
       "corner": "fl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 90.1215859218612,
+      "stderr_kelvin_per_g2": 1.2605105033849933,
+      "n_laps": 41
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A050",
+      "corner": "fl",
       "condition": "dry",
-      "value_kelvin_per_g2": 65.36183136260313,
-      "stderr_kelvin_per_g2": 0.7066559171525434,
-      "n_laps": 140
+      "value_kelvin_per_g2": 67.56702848161832,
+      "stderr_kelvin_per_g2": 0.7000837510842268,
+      "n_laps": 148
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A050",
+      "corner": "fr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 80.94490281675868,
+      "stderr_kelvin_per_g2": 1.243100282059229,
+      "n_laps": 41
     },
     {
       "car": "Inferno 86",
       "compound": "A050",
       "corner": "fr",
       "condition": "dry",
-      "value_kelvin_per_g2": 57.46033560728896,
-      "stderr_kelvin_per_g2": 0.6331267277086666,
-      "n_laps": 140
+      "value_kelvin_per_g2": 60.660573230552984,
+      "stderr_kelvin_per_g2": 0.6485882253503934,
+      "n_laps": 148
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A050",
+      "corner": "rl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 80.82775759516421,
+      "stderr_kelvin_per_g2": 1.7698996449874072,
+      "n_laps": 49
     },
     {
       "car": "Inferno 86",
       "compound": "A050",
       "corner": "rl",
       "condition": "dry",
-      "value_kelvin_per_g2": 65.33681938858986,
-      "stderr_kelvin_per_g2": 0.7982807081503374,
+      "value_kelvin_per_g2": 64.55019199825892,
+      "stderr_kelvin_per_g2": 0.8027988115387489,
       "n_laps": 142
     },
     {
       "car": "Inferno 86",
       "compound": "A050",
       "corner": "rr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 75.3937323127093,
+      "stderr_kelvin_per_g2": 1.002119068435593,
+      "n_laps": 49
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A050",
+      "corner": "rr",
       "condition": "dry",
-      "value_kelvin_per_g2": 58.577138133892085,
-      "stderr_kelvin_per_g2": 0.7388574476853758,
+      "value_kelvin_per_g2": 58.991295849732204,
+      "stderr_kelvin_per_g2": 0.7411282877196229,
       "n_laps": 144
     },
     {
@@ -847,125 +910,125 @@
       "compound": "A052",
       "corner": "fl",
       "condition": "damp",
-      "value_kelvin_per_g2": 64.6167777057696,
-      "stderr_kelvin_per_g2": 0.8424520330746385,
-      "n_laps": 122
+      "value_kelvin_per_g2": 65.63278846904393,
+      "stderr_kelvin_per_g2": 0.759694950764711,
+      "n_laps": 153
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "fl",
       "condition": "dry",
-      "value_kelvin_per_g2": 54.936163068911256,
-      "stderr_kelvin_per_g2": 0.7113682758526773,
-      "n_laps": 133
+      "value_kelvin_per_g2": 49.20699566539916,
+      "stderr_kelvin_per_g2": 1.045903199496626,
+      "n_laps": 92
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "fr",
       "condition": "damp",
-      "value_kelvin_per_g2": 61.51885382438194,
-      "stderr_kelvin_per_g2": 0.746473992647269,
-      "n_laps": 122
+      "value_kelvin_per_g2": 58.94969146266356,
+      "stderr_kelvin_per_g2": 0.6886323319070649,
+      "n_laps": 153
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "fr",
       "condition": "dry",
-      "value_kelvin_per_g2": 49.24734846476183,
-      "stderr_kelvin_per_g2": 0.5780511266520388,
-      "n_laps": 133
+      "value_kelvin_per_g2": 44.17723601428618,
+      "stderr_kelvin_per_g2": 0.8748649454122502,
+      "n_laps": 92
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "rl",
       "condition": "damp",
-      "value_kelvin_per_g2": 54.123251469451745,
-      "stderr_kelvin_per_g2": 0.8136343934920222,
-      "n_laps": 129
+      "value_kelvin_per_g2": 58.86437818870791,
+      "stderr_kelvin_per_g2": 0.8433596947930535,
+      "n_laps": 148
     },
     {
       "car": "Inferno 86",
       "compound": "A052",
       "corner": "rl",
       "condition": "dry",
-      "value_kelvin_per_g2": 46.47938038617607,
-      "stderr_kelvin_per_g2": 0.8598832726272675,
+      "value_kelvin_per_g2": 47.00992613169502,
+      "stderr_kelvin_per_g2": 0.8498328766711376,
+      "n_laps": 101
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "corner": "rr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 54.90694414834349,
+      "stderr_kelvin_per_g2": 0.66753689409363,
+      "n_laps": 148
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "A052",
+      "corner": "rr",
+      "condition": "dry",
+      "value_kelvin_per_g2": 42.9615524673215,
+      "stderr_kelvin_per_g2": 0.8202167844188984,
+      "n_laps": 101
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "fl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 80.13484569533291,
+      "stderr_kelvin_per_g2": 3.3464403611213256,
+      "n_laps": 23
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "fl",
+      "condition": "dry",
+      "value_kelvin_per_g2": 60.07965068614306,
+      "stderr_kelvin_per_g2": 0.7176471167593298,
       "n_laps": 98
     },
     {
       "car": "Inferno 86",
-      "compound": "A052",
-      "corner": "rr",
-      "condition": "damp",
-      "value_kelvin_per_g2": 52.64803932167738,
-      "stderr_kelvin_per_g2": 0.6560181049062472,
-      "n_laps": 129
+      "compound": "RE-71RS",
+      "corner": "fl",
+      "condition": "wet",
+      "value_kelvin_per_g2": 58.03435247767883,
+      "stderr_kelvin_per_g2": 2.4910097630320327,
+      "n_laps": 5
     },
     {
       "car": "Inferno 86",
-      "compound": "A052",
-      "corner": "rr",
+      "compound": "RE-71RS",
+      "corner": "fr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 71.97506824467916,
+      "stderr_kelvin_per_g2": 2.231128191455655,
+      "n_laps": 23
+    },
+    {
+      "car": "Inferno 86",
+      "compound": "RE-71RS",
+      "corner": "fr",
       "condition": "dry",
-      "value_kelvin_per_g2": 42.97193196635482,
-      "stderr_kelvin_per_g2": 0.8318949844523905,
+      "value_kelvin_per_g2": 53.93852788870691,
+      "stderr_kelvin_per_g2": 0.6571959365357596,
       "n_laps": 98
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
-      "corner": "fl",
-      "condition": "damp",
-      "value_kelvin_per_g2": 92.0887318810469,
-      "stderr_kelvin_per_g2": 1.2771399520414595,
-      "n_laps": 63
-    },
-    {
-      "car": "Inferno 86",
-      "compound": "RE-71RS",
-      "corner": "fl",
-      "condition": "dry",
-      "value_kelvin_per_g2": 63.44665461851166,
-      "stderr_kelvin_per_g2": 0.8953924783791637,
-      "n_laps": 65
-    },
-    {
-      "car": "Inferno 86",
-      "compound": "RE-71RS",
-      "corner": "fl",
-      "condition": "wet",
-      "value_kelvin_per_g2": 58.034549490010484,
-      "stderr_kelvin_per_g2": 2.4910097610843556,
-      "n_laps": 5
-    },
-    {
-      "car": "Inferno 86",
-      "compound": "RE-71RS",
-      "corner": "fr",
-      "condition": "damp",
-      "value_kelvin_per_g2": 75.37173131909438,
-      "stderr_kelvin_per_g2": 0.9818953326071564,
-      "n_laps": 63
-    },
-    {
-      "car": "Inferno 86",
-      "compound": "RE-71RS",
-      "corner": "fr",
-      "condition": "dry",
-      "value_kelvin_per_g2": 59.577916606591906,
-      "stderr_kelvin_per_g2": 0.8144124170158817,
-      "n_laps": 65
-    },
-    {
-      "car": "Inferno 86",
-      "compound": "RE-71RS",
       "corner": "fr",
       "condition": "wet",
-      "value_kelvin_per_g2": 54.59931658549087,
-      "stderr_kelvin_per_g2": 2.702305053367426,
+      "value_kelvin_per_g2": 54.59913123488917,
+      "stderr_kelvin_per_g2": 2.7023050549565926,
       "n_laps": 5
     },
     {
@@ -973,26 +1036,26 @@
       "compound": "RE-71RS",
       "corner": "rl",
       "condition": "damp",
-      "value_kelvin_per_g2": 89.82682841465454,
-      "stderr_kelvin_per_g2": 1.1277493328645238,
-      "n_laps": 63
+      "value_kelvin_per_g2": 71.87090436251493,
+      "stderr_kelvin_per_g2": 3.0040911065972464,
+      "n_laps": 21
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "rl",
       "condition": "dry",
-      "value_kelvin_per_g2": 56.42232470192222,
-      "stderr_kelvin_per_g2": 0.6998245971211606,
-      "n_laps": 90
+      "value_kelvin_per_g2": 57.397122148621925,
+      "stderr_kelvin_per_g2": 0.7279446563694231,
+      "n_laps": 87
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "rl",
       "condition": "wet",
-      "value_kelvin_per_g2": 56.4230634412304,
-      "stderr_kelvin_per_g2": 2.675072393311696,
+      "value_kelvin_per_g2": 56.42287189947837,
+      "stderr_kelvin_per_g2": 2.6750723950260564,
       "n_laps": 5
     },
     {
@@ -1000,98 +1063,170 @@
       "compound": "RE-71RS",
       "corner": "rr",
       "condition": "damp",
-      "value_kelvin_per_g2": 78.46085182924837,
-      "stderr_kelvin_per_g2": 0.912978990641706,
-      "n_laps": 63
+      "value_kelvin_per_g2": 67.03904556797909,
+      "stderr_kelvin_per_g2": 2.6065222745016996,
+      "n_laps": 21
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "rr",
       "condition": "dry",
-      "value_kelvin_per_g2": 52.87589043221988,
-      "stderr_kelvin_per_g2": 0.6684624505459186,
-      "n_laps": 95
+      "value_kelvin_per_g2": 52.45422993759491,
+      "stderr_kelvin_per_g2": 0.6809720461667953,
+      "n_laps": 93
     },
     {
       "car": "Inferno 86",
       "compound": "RE-71RS",
       "corner": "rr",
       "condition": "wet",
-      "value_kelvin_per_g2": 55.72673995501048,
-      "stderr_kelvin_per_g2": 3.008170860066068,
+      "value_kelvin_per_g2": 55.72655077709714,
+      "stderr_kelvin_per_g2": 3.0081708615532095,
       "n_laps": 5
     },
     {
       "car": "KK-SII",
       "compound": "DRY",
       "corner": "fl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 28.066824931263177,
+      "stderr_kelvin_per_g2": 0.9436093214883247,
+      "n_laps": 49
+    },
+    {
+      "car": "KK-SII",
+      "compound": "DRY",
+      "corner": "fl",
       "condition": "dry",
-      "value_kelvin_per_g2": 29.769114483308798,
-      "stderr_kelvin_per_g2": 0.17309840053439704,
+      "value_kelvin_per_g2": 29.7691144833092,
+      "stderr_kelvin_per_g2": 0.17309840053439668,
       "n_laps": 352
     },
     {
       "car": "KK-SII",
       "compound": "DRY",
       "corner": "fr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 20.08330435862786,
+      "stderr_kelvin_per_g2": 0.7504005838937664,
+      "n_laps": 49
+    },
+    {
+      "car": "KK-SII",
+      "compound": "DRY",
+      "corner": "fr",
       "condition": "dry",
-      "value_kelvin_per_g2": 22.832336126571033,
-      "stderr_kelvin_per_g2": 0.1454745532368311,
+      "value_kelvin_per_g2": 22.832336126571334,
+      "stderr_kelvin_per_g2": 0.14547455323683184,
       "n_laps": 351
     },
     {
       "car": "KK-SII",
       "compound": "DRY",
       "corner": "rl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 22.587963228012036,
+      "stderr_kelvin_per_g2": 1.0607243847090961,
+      "n_laps": 49
+    },
+    {
+      "car": "KK-SII",
+      "compound": "DRY",
+      "corner": "rl",
       "condition": "dry",
-      "value_kelvin_per_g2": 26.694569451937703,
-      "stderr_kelvin_per_g2": 0.16705887610034179,
+      "value_kelvin_per_g2": 26.694569451938058,
+      "stderr_kelvin_per_g2": 0.16705887610034192,
       "n_laps": 319
     },
     {
       "car": "KK-SII",
       "compound": "DRY",
       "corner": "rr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 23.639496865187485,
+      "stderr_kelvin_per_g2": 0.991821074077947,
+      "n_laps": 49
+    },
+    {
+      "car": "KK-SII",
+      "compound": "DRY",
+      "corner": "rr",
       "condition": "dry",
-      "value_kelvin_per_g2": 26.885470377460162,
-      "stderr_kelvin_per_g2": 0.1896023728325511,
+      "value_kelvin_per_g2": 26.885470377460518,
+      "stderr_kelvin_per_g2": 0.18960237283255116,
       "n_laps": 313
     },
     {
       "car": "KK-SII",
       "compound": "WET",
       "corner": "fl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 28.06682493123364,
+      "stderr_kelvin_per_g2": 0.9436093215109244,
+      "n_laps": 49
+    },
+    {
+      "car": "KK-SII",
+      "compound": "WET",
+      "corner": "fl",
       "condition": "wet",
-      "value_kelvin_per_g2": 27.885263537828273,
-      "stderr_kelvin_per_g2": 1.0144298130045655,
+      "value_kelvin_per_g2": 27.88526353782449,
+      "stderr_kelvin_per_g2": 1.014429813004565,
       "n_laps": 24
     },
     {
       "car": "KK-SII",
       "compound": "WET",
       "corner": "fr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 20.08330435860672,
+      "stderr_kelvin_per_g2": 0.7504005839061451,
+      "n_laps": 49
+    },
+    {
+      "car": "KK-SII",
+      "compound": "WET",
+      "corner": "fr",
       "condition": "wet",
-      "value_kelvin_per_g2": 22.547227287479217,
-      "stderr_kelvin_per_g2": 0.833945983090787,
+      "value_kelvin_per_g2": 22.547227287476158,
+      "stderr_kelvin_per_g2": 0.8339459830907868,
       "n_laps": 24
     },
     {
       "car": "KK-SII",
       "compound": "WET",
       "corner": "rl",
+      "condition": "damp",
+      "value_kelvin_per_g2": 22.58796322798826,
+      "stderr_kelvin_per_g2": 1.0607243847228045,
+      "n_laps": 49
+    },
+    {
+      "car": "KK-SII",
+      "compound": "WET",
+      "corner": "rl",
       "condition": "wet",
-      "value_kelvin_per_g2": 21.197883151328643,
-      "stderr_kelvin_per_g2": 0.9969799982677807,
+      "value_kelvin_per_g2": 21.197883151325765,
+      "stderr_kelvin_per_g2": 0.9969799982677818,
       "n_laps": 24
     },
     {
       "car": "KK-SII",
       "compound": "WET",
       "corner": "rr",
+      "condition": "damp",
+      "value_kelvin_per_g2": 23.639496865162606,
+      "stderr_kelvin_per_g2": 0.9918210740910179,
+      "n_laps": 49
+    },
+    {
+      "car": "KK-SII",
+      "compound": "WET",
+      "corner": "rr",
       "condition": "wet",
-      "value_kelvin_per_g2": 21.735339090688292,
-      "stderr_kelvin_per_g2": 0.6834068688418996,
+      "value_kelvin_per_g2": 21.73533909068534,
+      "stderr_kelvin_per_g2": 0.6834068688418982,
       "n_laps": 13
     }
   ],

--- a/docs/tire_model.md
+++ b/docs/tire_model.md
@@ -243,19 +243,28 @@ Prediction: ``predict_cold_pressure(compound_front=..., compound_rear=...)``
 the compound K per axle when a fitted bucket exists (condition chain
 applies); unknown compounds and unlabeled cars keep the pooled K.
 
-**Partial supervision** (``tire_model/compound_infer.py``): labels are
-sparse, so the compound K is fitted as a multi-task objective — the
-compound-assignment task is supervised where labels exist and latent
-elsewhere, sharing K with the temperature-regression task. Solved by EM
-(mixture of regressions): labeled/seeded sessions are pinned one-hot,
-unlabeled (session, axle) units get posteriors from their lap residuals,
-and each K is refit by responsibility-weighted least squares. Guard
-rails: posteriors are tempered to ``SESSION_EFF_SAMPLES`` effective
-observations (laps within a session are correlated); buckets only exist
-with pinned support (free sessions refine, never spawn, buckets — else a
-symmetric fixed point forms); and an outlier gate (χ²/lap against
-pinned-only variance) leaves sessions that match NO known compound
-unlabeled instead of absorbing them. Weather-driven tire choices use
+**Decomposed K with partial supervision**
+(``tire_model/compound_infer.py``): the compound K is not fitted as free
+buckets but decomposed as
+
+    K_effective = c_track[track] · K_base[car, corner, condition] · m[car, compound]
+
+so every lap of every tire informs the car's base K, and each compound is
+one scalar multiplier shared across corners and conditions (fitted
+Inferno ratios: A050 ×1.18, RE-71RS ×1.05, A052 ×0.86; identifiability:
+lap-weighted geometric mean of m per car is 1, making K_base the
+"average tire"). Labels are sparse, so the fit is a multi-task objective
+— the compound-assignment task is supervised where labels exist and
+latent elsewhere, sharing (K_base, m) with the temperature-regression
+task. Solved by EM: labeled/seeded sessions pinned one-hot, free
+(session, axle) units get posteriors from their lap residuals, and the
+M-step alternates least squares on (K_base, m). Selection is FORCED —
+every unit in a participating car carries an assignment — with two guard
+rails: posteriors tempered to ``SESSION_EFF_SAMPLES`` effective
+observations (laps within a session are correlated), and robust
+down-weighting by best-fit χ²/lap so a session matching no known tire is
+still assigned (flagged ``poor_fit``) but cannot drag a cluster toward
+itself. Weather-driven tire choices use
 declarative ``condition_seeds`` in the sidecar (KK-SII: all-dry session ⇒
 DRY tires, all-wet ⇒ WET; damp/mixed left to the classifier — the EM
 independently recovers the known 2026-04-04 rain day as WET at ≥0.998).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motorsports-data-notebook"
-version = "0.20.0"
+version = "0.21.0"
 description = ""
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/src/motorsports_data_notebook/tire_model/cli.py
+++ b/src/motorsports_data_notebook/tire_model/cli.py
@@ -249,7 +249,10 @@ def _cmd_infer_compounds(args: argparse.Namespace) -> int:
 
     labels = load_compound_labels(root)
     labels = apply_condition_seeds(labels, laps, load_condition_seeds(root))
-    _, assignments = fit_compounds_em(laps, labels, tau, c_track)
+    _, assignments, multipliers = fit_compounds_em(laps, labels, tau, c_track)
+    print("Fitted compound multipliers (K_effective = c_track × K_base × m):")
+    for car, comps in sorted(multipliers.items()):
+        print(f"  {car}: " + ", ".join(f"{c}×{v}" for c, v in sorted(comps.items())))
     detail = [a for a in assignments if not a.pinned]
 
     sess_meta = pd.concat(

--- a/src/motorsports_data_notebook/tire_model/compound_infer.py
+++ b/src/motorsports_data_notebook/tire_model/compound_infer.py
@@ -74,6 +74,7 @@ class AxleAssignment:
     responsibility: float
     n_laps: int
     pinned: bool  # True when from a human/seed label
+    poor_fit: bool = False  # best compound still fits badly (unknown tire?)
 
 
 def _suff_stats(
@@ -138,19 +139,44 @@ def fit_compounds_em(
     c_track_by_track: dict,
     *,
     max_iter: int = EM_MAX_ITER,
-) -> tuple[dict[tuple[str, str, str, str], tuple[float, float, float]], list[AxleAssignment]]:
-    """Joint EM over compound assignments and per-compound K.
+) -> tuple[
+    dict[tuple[str, str, str, str], tuple[float, float, float]],
+    list[AxleAssignment],
+    dict[str, dict[str, float]],
+]:
+    """Joint EM over compound assignments and a DECOMPOSED K.
 
-    Returns ``(k_by_compound, assignments)`` where ``k_by_compound`` maps
-    ``(car, compound, corner, condition) -> (K, stderr, n_effective)`` and
-    ``assignments`` carries the final per-(session, axle) posteriors.
+    K is structured, not free per bucket:
+
+        K_effective = c_track[track] · K_base[car, corner, cond] · m[car, compound]
+
+    (c_track is already inside the regressor ``x``, so this function fits
+    ``K_base`` per (car, corner, condition) and one scalar multiplier per
+    (car, compound), by responsibility-weighted alternating least squares
+    inside each M-step.) The structure pools statistical strength — every
+    lap of every compound informs K_base, and each compound's m is shared
+    across corners and conditions — and it removes the symmetric fixed
+    point free-bucket fitting suffered from. Identifiability: the
+    lap-weighted geometric mean of m over a car's compounds is 1, so
+    K_base is the car's "average tire" and m the compound's ratio.
+
+    Selection is FORCED: every eligible (session, axle) carries a posterior
+    over the car's compounds (pinned one-hot where labeled/seeded, softmax
+    elsewhere) — there is no unlabeled pool inside a participating car.
+    Sessions whose best fit is still poor are flagged ``poor_fit`` (audit:
+    possible unknown tire) but still assigned softly.
+
+    Returns ``(k_by_compound, assignments, multipliers)`` where
+    ``k_by_compound`` maps ``(car, compound, corner, condition) ->
+    (K, stderr, n_effective)`` (the base·m product, ready for the artifact),
+    and ``multipliers`` maps ``car -> {compound: m}``.
     """
     if laps_for_fit.empty or labels.empty:
-        return {}, []
+        return {}, [], {}
 
     stats = _suff_stats(laps_for_fit, tau_by_car_corner_cond, c_track_by_track)
     if stats.empty:
-        return {}, []
+        return {}, [], {}
     stats["axle"] = stats["corner"].map(_CORNER_AXLE)
 
     label_cols = {"front": "compound_front", "rear": "compound_rear"}
@@ -163,10 +189,10 @@ def fit_compounds_em(
 
     out_k: dict[tuple[str, str, str, str], tuple[float, float, float]] = {}
     assignments: list[AxleAssignment] = []
+    multipliers: dict[str, dict[str, float]] = {}
 
     for car_key, car_stats in stats.groupby("car"):
         car = str(car_key)
-        # Eligibility: ≥2 compounds with ≥MIN_LABELED_SESSIONS pinned sessions.
         pinned_here: dict[str, set] = {}
         for (sid, axle), comp in pinned.items():
             if sid in set(car_stats["session_id"]):
@@ -175,15 +201,10 @@ def fit_compounds_em(
             c for c, sids in pinned_here.items() if len(sids) >= MIN_LABELED_SESSIONS
         )
         if len(compounds) < 2:
-            # Still fit K for whatever labeled compounds exist (no latents).
             compounds = sorted(pinned_here)
             if not compounds:
                 continue
-            fixed_only = True
-        else:
-            fixed_only = False
 
-        # Units: (session, axle) with enough laps.
         unit_lap_counts: dict[tuple[str, str], int] = {
             (str(k[0]), str(k[1])): int(v)  # type: ignore[index]
             for k, v in car_stats.groupby(["session_id", "axle"])["n"].sum().items()
@@ -195,7 +216,7 @@ def fit_compounds_em(
         n_units, n_comp = len(units), len(compounds)
         comp_idx = {c: j for j, c in enumerate(compounds)}
 
-        # Responsibilities: pinned one-hot; unlabeled start uniform.
+        # Forced selection: every unit starts uniform (pinned -> one-hot).
         resp = np.full((n_units, n_comp), 1.0 / n_comp)
         pin_mask = np.zeros(n_units, dtype=bool)
         for u, i in unit_idx.items():
@@ -204,208 +225,188 @@ def fit_compounds_em(
                 resp[i] = 0.0
                 resp[i, comp_idx[comp]] = 1.0
                 pin_mask[i] = True
-            elif fixed_only:
-                # No latents for this car: unlabeled units don't participate.
-                resp[i] = 0.0
 
-        # Index sufficient stats by unit.
         s_unit = car_stats.copy()
         s_unit["unit"] = list(zip(s_unit["session_id"], s_unit["axle"]))
         s_unit = s_unit[s_unit["unit"].isin(unit_idx)]
         s_unit["ui"] = s_unit["unit"].map(unit_idx)
+        buckets = list(s_unit.groupby(["corner", "condition"]))
+        bucket_arrays = []
+        for bkey, grp in buckets:
+            corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
+            bucket_arrays.append(
+                (
+                    corner,
+                    cond,
+                    grp["ui"].to_numpy(),
+                    grp["sxx"].to_numpy(),
+                    grp["sxy"].to_numpy(),
+                    grp["syy"].to_numpy(),
+                    grp["n"].to_numpy(),
+                )
+            )
 
-        buckets = s_unit.groupby(["corner", "condition"])
-        sigma2: dict[str, float] = {c: 25.0 for c in _CORNER_AXLE}  # start: (5 °C)²
-        k_val: dict[tuple[str, str, str], float] = {}  # (compound, corner, cond) -> K
-
-        def k_for_scoring(comp: str, corner: str, cond: str) -> float | None:
-            """K for likelihood scoring: exact condition, then dry, then any.
-
-            A compound with NO K anywhere for this corner must not be
-            scored at all — treating a missing bucket as zero residual
-            would make "no coverage" look like a perfect fit.
-            """
-            for c2 in (cond, "dry"):
-                k = k_val.get((comp, corner, c2))
-                if k is not None:
-                    return k
-            for (c_comp, c_corner, _c2), k in k_val.items():
-                if c_comp == comp and c_corner == corner:
-                    return k
-            return None
+        sigma2: dict[str, float] = {c: 25.0 for c in _CORNER_AXLE}
+        base: dict[tuple[str, str], float] = {}
+        m = np.ones(n_comp)
+        # Robust weights: selection is forced, but a free unit's INFLUENCE
+        # on (base, m) shrinks as its best-compound fit degrades — a
+        # mid-cluster or unknown-tire session is still assigned (and
+        # flagged poor_fit) without dragging any cluster toward itself.
+        robust_w = np.ones(n_units)
+        n_u_arr = np.array([max(float(unit_lap_counts.get(u, 1)), 1.0) for u in units])
+        temper = np.minimum(1.0, SESSION_EFF_SAMPLES / n_u_arr)[:, None]
+        free = ~pin_mask
 
         prev_ll = -np.inf
         for _ in range(max_iter):
-            # ---- M-step: responsibility-weighted least squares per bucket ----
-            k_val.clear()
-            for bkey, grp in buckets:
-                corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
-                ui = grp["ui"].to_numpy()
-                for comp, j in comp_idx.items():
-                    w = resp[ui, j]
-                    w_pinned = float(np.sum(w * pin_mask[ui] * grp["n"].to_numpy()))
-                    if not fixed_only and w_pinned < MIN_PINNED_LAPS_PER_BUCKET:
-                        continue
-                    sxx = float(np.sum(w * grp["sxx"].to_numpy()))
-                    if sxx <= 0:
-                        continue
-                    sxy = float(np.sum(w * grp["sxy"].to_numpy()))
-                    k_val[(comp, corner, cond)] = sxy / sxx
-            # Residual variance per corner (pooled over compounds/conds).
+            # ---- M-step: alternating LS on (base, m) ----
+            resp_eff = resp * robust_w[:, None]
+            for _als in range(3):
+                for corner, cond, ui, sxx, sxy, syy, n_arr in bucket_arrays:
+                    num = den = 0.0
+                    for j in range(n_comp):
+                        w = resp_eff[ui, j]
+                        num += m[j] * float(np.sum(w * sxy))
+                        den += m[j] * m[j] * float(np.sum(w * sxx))
+                    if den > 0:
+                        base[(corner, cond)] = num / den
+                for j in range(n_comp):
+                    num = den = 0.0
+                    for corner, cond, ui, sxx, sxy, syy, n_arr in bucket_arrays:
+                        b = base.get((corner, cond))
+                        if b is None:
+                            continue
+                        w = resp_eff[ui, j]
+                        num += b * float(np.sum(w * sxy))
+                        den += b * b * float(np.sum(w * sxx))
+                    if den > 0:
+                        m[j] = num / den
+                # Anchor: lap-weighted geometric mean of m == 1.
+                w_c = np.array(
+                    [max(float(np.sum(resp[:, j] * n_u_arr)), 1e-9) for j in range(n_comp)]
+                )
+                m = np.clip(m, 1e-3, None)
+                g = float(np.exp(np.sum(w_c * np.log(m)) / np.sum(w_c)))
+                if g > 0:
+                    m = m / g
+                    for key in list(base):
+                        base[key] *= g
+
+            def k_for_scoring(j: int, corner: str, cond: str) -> float | None:
+                for c2 in (cond, "dry"):
+                    b = base.get((corner, c2))
+                    if b is not None:
+                        return b * float(m[j])
+                for (c_corner, _c2), b in base.items():
+                    if c_corner == corner:
+                        return b * float(m[j])
+                return None
+
+            # Residual variance per corner from pinned units only (kept
+            # clean of whatever the free units turn out to be).
             for corner in _CORNER_AXLE:
                 num = den = 0.0
-                for bkey, grp in buckets:
-                    c2, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
+                for c2, cond, ui, sxx, sxy, syy, n_arr in bucket_arrays:
                     if c2 != corner:
                         continue
-                    ui = grp["ui"].to_numpy()
-                    for comp, j in comp_idx.items():
-                        k = k_val.get((comp, corner, cond))
+                    for j in range(n_comp):
+                        k = k_for_scoring(j, corner, cond)
                         if k is None:
                             continue
-                        w = resp[ui, j]
-                        rss_arr = (
-                            grp["syy"].to_numpy()
-                            - 2 * k * grp["sxy"].to_numpy()
-                            + k * k * grp["sxx"].to_numpy()
-                        )
+                        w = resp[ui, j] * pin_mask[ui]
+                        rss_arr = syy - 2 * k * sxy + k * k * sxx
                         num += float(np.sum(w * rss_arr))
-                        den += float(np.sum(w * grp["n"].to_numpy()))
+                        den += float(np.sum(w * n_arr))
                 if den > 0:
                     sigma2[corner] = max(num / den, SIGMA2_FLOOR)
 
-            # ---- E-step: posteriors for un-pinned units ----
+            # ---- E-step ----
             loglik = np.zeros((n_units, n_comp))
             covered = np.zeros((n_units, n_comp))
-            for bkey, grp in buckets:
-                corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
-                ui = grp["ui"].to_numpy()
+            for corner, cond, ui, sxx, sxy, syy, n_arr in bucket_arrays:
                 s2 = sigma2[corner]
-                for comp, j in comp_idx.items():
-                    k = k_for_scoring(comp, corner, cond)
+                for j in range(n_comp):
+                    k = k_for_scoring(j, corner, cond)
                     if k is None:
                         continue
-                    rss_arr = (
-                        grp["syy"].to_numpy()
-                        - 2 * k * grp["sxy"].to_numpy()
-                        + k * k * grp["sxx"].to_numpy()
-                    )
+                    rss_arr = syy - 2 * k * sxy + k * k * sxx
                     np.add.at(loglik[:, j], ui, -0.5 * rss_arr / s2)
-                    np.add.at(covered[:, j], ui, grp["n"].to_numpy())
-            # A compound that covers none of a unit's laps is not a candidate.
+                    np.add.at(covered[:, j], ui, n_arr)
             loglik = np.where(covered > 0, loglik, -np.inf)
-            free = ~pin_mask if not fixed_only else np.zeros(n_units, dtype=bool)
             if free.any():
-                n_u = np.array([max(float(unit_lap_counts.get(u, 1)), 1.0) for u in units])
-                temper = np.minimum(1.0, SESSION_EFF_SAMPLES / n_u)[:, None]
                 ll = (loglik * temper)[free]
                 row_max = ll.max(axis=1, keepdims=True)
                 ok_rows = np.isfinite(row_max[:, 0])
-                p = np.zeros_like(ll)
+                p = np.full_like(ll, 1.0 / n_comp)
                 if ok_rows.any():
                     z = np.exp(ll[ok_rows] - row_max[ok_rows])
                     p[ok_rows] = z / z.sum(axis=1, keepdims=True)
                 resp[free] = p
+            # Refresh robust weights for free units from best-fit quality.
+            with np.errstate(invalid="ignore"):
+                best_chi2_iter = np.where(
+                    np.isfinite(loglik).any(axis=1),
+                    -2.0
+                    * np.nanmax(np.where(np.isfinite(loglik), loglik, np.nan), axis=1)
+                    / n_u_arr,
+                    np.inf,
+                )
+            new_w = np.minimum(1.0, OUTLIER_CHI2_PER_LAP / np.maximum(best_chi2_iter, 1e-9))
+            robust_w = np.where(pin_mask, 1.0, new_w)
             total_ll = float(np.sum(np.where(resp > 0, loglik * resp, 0.0)))
             if abs(total_ll - prev_ll) < EM_TOL * (1 + abs(prev_ll)):
                 break
             prev_ll = total_ll
 
-        # Outlier gate: free units whose best cluster still fits badly get
-        # their responsibilities zeroed (unknown compound — stays unlabeled).
-        # The gate's variance comes from PINNED sessions only: the mixture
-        # σ² is inflated by the very outliers we are trying to detect.
-        if not fixed_only:
-            sig_num: dict[str, float] = {c: 0.0 for c in _CORNER_AXLE}
-            sig_den: dict[str, float] = {c: 0.0 for c in _CORNER_AXLE}
-            chi2_num = np.zeros((n_units, n_comp))
-            for bkey, grp in buckets:
-                corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
-                ui = grp["ui"].to_numpy()
-                for comp, j in comp_idx.items():
-                    k = k_for_scoring(comp, corner, cond)
-                    if k is None:
-                        np.add.at(chi2_num[:, j], ui, np.inf * np.ones(len(ui)))
-                        continue
-                    rss_arr = (
-                        grp["syy"].to_numpy()
-                        - 2 * k * grp["sxy"].to_numpy()
-                        + k * k * grp["sxx"].to_numpy()
-                    )
-                    np.add.at(chi2_num[:, j], ui, rss_arr)
-                    w_pin = resp[ui, j] * pin_mask[ui]
-                    sig_num[corner] += float(np.sum(w_pin * rss_arr))
-                    sig_den[corner] += float(np.sum(w_pin * grp["n"].to_numpy()))
-            sigma2_clean = np.mean(
-                [
-                    max(sig_num[c] / sig_den[c], SIGMA2_FLOOR) if sig_den[c] > 0 else SIGMA2_FLOOR
-                    for c in _CORNER_AXLE
-                ]
-            )
-            n_u_arr = np.array([max(float(unit_lap_counts.get(u, 1)), 1.0) for u in units])
-            best_chi2 = chi2_num.min(axis=1) / (n_u_arr * sigma2_clean)
-            outlier = (~pin_mask) & (best_chi2 > OUTLIER_CHI2_PER_LAP)
-            if outlier.any():
-                resp[outlier] = 0.0
-                # One more M-step so exported K excludes the outliers.
-                k_val.clear()
-                for bkey, grp in buckets:
-                    corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
-                    ui = grp["ui"].to_numpy()
-                    for comp, j in comp_idx.items():
-                        w = resp[ui, j]
-                        w_pinned = float(np.sum(w * pin_mask[ui] * grp["n"].to_numpy()))
-                        if not fixed_only and w_pinned < MIN_PINNED_LAPS_PER_BUCKET:
-                            continue
-                        sxx = float(np.sum(w * grp["sxx"].to_numpy()))
-                        if sxx > 0:
-                            k_val[(comp, corner, cond)] = float(
-                                np.sum(w * grp["sxy"].to_numpy()) / sxx
-                            )
-
-        # ---- Export K with stderr + effective n ----
-        for bkey, grp in buckets:
-            corner, cond = str(bkey[0]), str(bkey[1])  # type: ignore[index]
-            ui = grp["ui"].to_numpy()
-            for comp, j in comp_idx.items():
-                k = k_val.get((comp, corner, cond))
+        # Poor-fit flag (possible unknown tire): best cluster still fits
+        # badly against pinned-only variance. Selection stays forced — the
+        # flag is for the audit, not an exclusion.
+        chi2_num = np.zeros((n_units, n_comp))
+        for corner, cond, ui, sxx, sxy, syy, n_arr in bucket_arrays:
+            for j in range(n_comp):
+                k = k_for_scoring(j, corner, cond)
                 if k is None:
+                    chi2_num[:, j] += np.inf
                     continue
-                w = resp[ui, j]
-                sxx = float(np.sum(w * grp["sxx"].to_numpy()))
-                n_eff = float(np.sum(w * grp["n"].to_numpy()))
-                if sxx <= 0 or n_eff < MIN_LAPS_PER_AXLE:
-                    continue
-                rss = float(
-                    np.sum(
-                        w
-                        * (
-                            grp["syy"].to_numpy()
-                            - 2 * k * grp["sxy"].to_numpy()
-                            + k * k * grp["sxx"].to_numpy()
-                        )
-                    )
-                )
-                stderr = float(np.sqrt(max(rss, 0.0) / max(n_eff - 1, 1.0) / sxx))
-                out_k[(str(car), comp, corner, cond)] = (k, stderr, n_eff)
+                rss_arr = syy - 2 * k * sxy + k * k * sxx
+                np.add.at(chi2_num[:, j], ui, rss_arr / sigma2[corner])
+        best_chi2 = chi2_num.min(axis=1) / n_u_arr
+        poor = best_chi2 > OUTLIER_CHI2_PER_LAP
 
+        # ---- Export effective K = base·m with stderr + effective n ----
+        for corner, cond, ui, sxx, sxy, syy, n_arr in bucket_arrays:
+            b = base.get((corner, cond))
+            if b is None:
+                continue
+            for comp, j in comp_idx.items():
+                k = b * float(m[j])
+                w = (resp * robust_w[:, None])[ui, j]
+                sxx_w = float(np.sum(w * sxx))
+                n_eff = float(np.sum(w * n_arr))
+                if sxx_w <= 0 or n_eff < MIN_LAPS_PER_AXLE:
+                    continue
+                rss = float(np.sum(w * (syy - 2 * k * sxy + k * k * sxx)))
+                stderr = float(np.sqrt(max(rss, 0.0) / max(n_eff - 1, 1.0) / sxx_w))
+                out_k[(car, comp, corner, cond)] = (k, stderr, n_eff)
+
+        multipliers[car] = {comp: round(float(m[j]), 4) for comp, j in comp_idx.items()}
         for u, i in unit_idx.items():
             j = int(np.argmax(resp[i]))
-            if resp[i].sum() == 0:
-                continue
             assignments.append(
                 AxleAssignment(
                     session_id=u[0],
-                    car=str(car),
+                    car=car,
                     axle=u[1],
                     compound=compounds[j],
                     responsibility=round(float(resp[i, j]), 3),
                     n_laps=unit_lap_counts.get(u, 0),
                     pinned=bool(pin_mask[i]),
+                    poor_fit=bool(poor[i]),
                 )
             )
 
-    return out_k, assignments
+    return out_k, assignments, multipliers
 
 
 def apply_condition_seeds(

--- a/src/motorsports_data_notebook/tire_model/warmup_table.py
+++ b/src/motorsports_data_notebook/tire_model/warmup_table.py
@@ -328,7 +328,7 @@ def build_warmup_table(
     compound_labels = apply_condition_seeds(
         compound_labels, laps_for_fit, load_condition_seeds(root)
     )
-    k_em, em_assignments = fit_compounds_em(
+    k_em, em_assignments, compound_multipliers = fit_compounds_em(
         laps_for_fit, compound_labels, tau_by_car_corner_cond, c_track_by_track
     )
     k_by_compound = {
@@ -338,12 +338,13 @@ def build_warmup_table(
     if k_by_compound:
         inferred = [a for a in em_assignments if not a.pinned and a.responsibility >= 0.9]
         logger.info(
-            "Fitted %d compound K buckets (EM over %d session-axles, "
-            "%d pinned, %d confidently inferred)",
+            "Fitted %d compound K buckets (decomposed base×m; EM over %d "
+            "session-axles, %d pinned, %d confidently inferred; multipliers %s)",
             len(k_by_compound),
             len(em_assignments),
             sum(1 for a in em_assignments if a.pinned),
             len(inferred),
+            compound_multipliers,
         )
 
     model = _assemble_model(
@@ -357,6 +358,7 @@ def build_warmup_table(
         g2_curves=g2_curves,
         g2_exponent_default=g2_exponent_default,
         k_by_compound=k_by_compound,
+        compound_multipliers=compound_multipliers,
     )
 
     if write_artifacts:
@@ -942,6 +944,7 @@ def _assemble_model(
     g2_curves: dict[tuple[str, str, str], dict] | None = None,
     g2_exponent_default: float = G2_LAP_TIME_EXPONENT_FALLBACK,
     k_by_compound: dict[tuple[str, str, str, str], "FitParam"] | None = None,
+    compound_multipliers: dict[str, dict[str, float]] | None = None,
 ) -> dict[str, Any]:
     """Build the in-memory model dict that matches the JSON artifact schema.
 
@@ -953,6 +956,7 @@ def _assemble_model(
     """
     g2_curves = g2_curves or {}
     k_by_compound = k_by_compound or {}
+    compound_multipliers = compound_multipliers or {}
 
     def _g2_entry(track: str, car: str, cond: str, value: float, n: int) -> dict[str, Any]:
         entry: dict[str, Any] = {
@@ -1072,6 +1076,14 @@ def _assemble_model(
         "g2_typ_by_track_car_cond": [
             _g2_entry(track, car, cond, value, n)
             for (track, car, cond), (value, n) in sorted(g2_lookup.items())
+        ],
+        # Compound decomposition: K_effective = c_track × K_base × m[compound].
+        # The multipliers document the fitted per-compound ratios; the table
+        # below carries the ready-to-use products.
+        "K_compound_multipliers": [
+            {"car": car, "compound": comp, "multiplier": mult}
+            for car, comps in sorted(compound_multipliers.items())
+            for comp, mult in sorted(comps.items())
         ],
         # Compound-specific K overrides (schema v3 additive; consumers that
         # don't know about compounds ignore this table and use K_buckets).

--- a/tests/tire_model/test_compound_infer.py
+++ b/tests/tire_model/test_compound_infer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 
 import numpy as np
@@ -26,7 +27,7 @@ C_TRACK = {"track_a": _FP(1.0)}
 
 
 def _session_laps(sid: str, k_true: float, n_laps: int = 12, noise: float = 1.0) -> pd.DataFrame:
-    rng = np.random.default_rng(abs(hash(sid)) % 2**32)
+    rng = np.random.default_rng(int(hashlib.sha1(sid.encode()).hexdigest()[:8], 16))
     t = np.linspace(120, 120 * n_laps, n_laps)
     g2 = rng.uniform(0.5, 1.1, n_laps)
     frac = 1 - np.exp(-t / 200.0)
@@ -75,19 +76,22 @@ class TestFitCompoundsEM:
     def test_recovers_unlabeled_assignments_and_k(self):
         laps = _mixture_frame()
         labels = _labels({"soft1": "SOFT", "soft2": "SOFT", "hard1": "HARD", "hard2": "HARD"})
-        k, assignments = fit_compounds_em(laps, labels, TAU, C_TRACK)
+        k, assignments, multipliers = fit_compounds_em(laps, labels, TAU, C_TRACK)
 
         by_unit = {(a.session_id, a.axle): a for a in assignments}
         assert by_unit[("mystery_soft", "front")].compound == "SOFT"
         assert by_unit[("mystery_soft", "front")].responsibility > 0.95
         assert by_unit[("mystery_hard", "rear")].compound == "HARD"
         assert by_unit[("mystery_hard", "rear")].responsibility > 0.95
-        # The mid-K session fits neither compound: the outlier gate must
-        # leave it unlabeled rather than absorb it into a cluster.
-        assert ("ambiguous", "front") not in by_unit
-
-        assert k[("ToyCar", "SOFT", "fl", "dry")][0] == pytest.approx(30.0, abs=2.0)
-        assert k[("ToyCar", "HARD", "fl", "dry")][0] == pytest.approx(60.0, abs=2.0)
+        # Selection is forced: the mid-K session gets an assignment but is
+        # flagged as fitting no known compound well.
+        assert by_unit[("ambiguous", "front")].poor_fit
+        # The decomposition keeps clusters honest despite the forced
+        # assignment of a mid-K session.
+        assert k[("ToyCar", "SOFT", "fl", "dry")][0] == pytest.approx(30.0, abs=3.0)
+        assert k[("ToyCar", "HARD", "fl", "dry")][0] == pytest.approx(60.0, abs=3.0)
+        m = multipliers["ToyCar"]
+        assert m["HARD"] / m["SOFT"] == pytest.approx(2.0, rel=0.15)
 
     def test_pinned_labels_never_flip(self):
         laps = _mixture_frame()
@@ -101,7 +105,7 @@ class TestFitCompoundsEM:
                 "mystery_hard": "SOFT",
             }
         )
-        _, assignments = fit_compounds_em(laps, labels, TAU, C_TRACK)
+        _, assignments, _m = fit_compounds_em(laps, labels, TAU, C_TRACK)
         by_unit = {(a.session_id, a.axle): a for a in assignments}
         a = by_unit[("mystery_hard", "front")]
         assert a.pinned and a.compound == "SOFT" and a.responsibility == 1.0
@@ -112,15 +116,18 @@ class TestFitCompoundsEM:
             ignore_index=True,
         )
         labels = _labels({"s1": "ONLY", "s2": "ONLY"})
-        k, assignments = fit_compounds_em(laps, labels, TAU, C_TRACK)
+        k, assignments, multipliers = fit_compounds_em(laps, labels, TAU, C_TRACK)
         assert k[("ToyCar", "ONLY", "fl", "dry")][0] == pytest.approx(40.0, abs=2.0)
-        # The unlabeled session contributes nothing and gets no assignment.
-        assert all(a.session_id != "un" for a in assignments)
+        # Forced selection: the unlabeled session joins the only compound,
+        # whose multiplier is anchored at 1.
+        by_unit = {(a.session_id, a.axle): a for a in assignments}
+        assert by_unit[("un", "front")].compound == "ONLY"
+        assert multipliers["ToyCar"]["ONLY"] == pytest.approx(1.0, abs=0.01)
 
     def test_no_labels_no_output(self):
         laps = _mixture_frame()
-        k, assignments = fit_compounds_em(laps, laps.iloc[0:0], TAU, C_TRACK)
-        assert k == {} and assignments == []
+        k, assignments, multipliers = fit_compounds_em(laps, laps.iloc[0:0], TAU, C_TRACK)
+        assert k == {} and assignments == [] and multipliers == {}
 
 
 class TestApplyConditionSeeds:

--- a/uv.lock
+++ b/uv.lock
@@ -1558,7 +1558,7 @@ wheels = [
 
 [[package]]
 name = "motorsports-data-notebook"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "ipywidgets" },


### PR DESCRIPTION

Restructures compound K per user design: instead of free per-bucket
values, K decomposes as

    K_effective = c_track[track] · K_base[car, corner, condition] · m[car, compound]

fitted inside the EM M-step by responsibility-weighted alternating least
squares. Every lap of every tire now informs the car's base K, and each
compound is one scalar shared across corners and conditions — sparse
compounds inherit structure instead of fitting 8+ independent numbers.
Identifiability: lap-weighted geometric mean of m per car is 1 (K_base =
the "average tire"). The structure also removes the symmetric fixed
point that free-bucket fitting needed a pinned-support guard for.

Selection is now FORCED: every (session, axle) in a participating car
carries a compound posterior — no unlabeled pool. Two guards replace the
old outlier gate: posteriors stay tempered (SESSION_EFF_SAMPLES), and
robust down-weighting by best-fit χ²/lap means a session matching no
known tire is still assigned (flagged poor_fit in the audit) but cannot
drag a cluster toward itself — verified by a synthetic mid-K session
that previously biased its cluster +3.6 K/G².

Fitted multipliers read like a tire catalog: Inferno 86 A050 ×1.18,
RE-71RS ×1.05, A052 ×0.86. (KK-SII DRY/WET stay at ×1.0 — compound and
condition are perfectly confounded there, so the condition-specific base
absorbs the effect; predictions are identical either way.) Artifact
gains K_compound_multipliers alongside the ready-to-use product table,
so the three calculators need no changes.

5-fold CV fleet pooled MAE: FL 4.02, FR 3.98, RL 4.56, RR 4.10 °C —
best yet on every corner (v0.17 baseline: 4.95/4.01/5.63/4.70), biases
within ±0.61 °C. Deterministic test seeding (PYTHONHASHSEED-proof);
598 Python / 80 C# / 18 web tests pass.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/143).
* __->__ #143
* #142
* #141
* #140
* #139
* #138
* #137
* #136
* #135
* #133
* #132
* #131
* #130
* #129