### PR TITLE
tire-model + web calculator: car-based corner prefills

### DIFF
--- a/data/tire_dataset/tire_model.json
+++ b/data/tire_dataset/tire_model.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "fit_at_utc": "2026-08-16T14:52:56+00:00",
+  "fit_at_utc": "2026-08-16T23:56:04+00:00",
   "model_form": "T_hot - T_eff = K[car,corner,cond] * c_track[track] * g2 * (1 - exp(-t / tau_sec[car,corner,cond]))   where T_eff = (1-w_road)*T_air + w_road*T_road, t = N * lap_time_s, g2 = g2_typ[track,car,cond] * clamp((lap_time_typ_s / target_lap_time_s)^g2_lap_time_exponent) when a target lap time is given, else g2_typ",
   "g2_lap_time_model": {
     "method": "sector_knn_median_curve",
@@ -1228,6 +1228,168 @@
       "value_kelvin_per_g2": 21.735339090688928,
       "stderr_kelvin_per_g2": 0.6834068688418966,
       "n_laps": 13
+    }
+  ],
+  "corner_defaults_by_car_corner_cond": [
+    {
+      "car": "Inferno 86",
+      "corner": "fl",
+      "condition": "damp",
+      "hot_temp_c": 68.5,
+      "hot_pressure_bar": 2.09228253364563,
+      "n_laps_used": 168
+    },
+    {
+      "car": "Inferno 86",
+      "corner": "fl",
+      "condition": "dry",
+      "hot_temp_c": 67.0,
+      "hot_pressure_bar": 1.8795039653778076,
+      "n_laps_used": 259
+    },
+    {
+      "car": "Inferno 86",
+      "corner": "fr",
+      "condition": "damp",
+      "hot_temp_c": 67.0,
+      "hot_pressure_bar": 2.0578603744506836,
+      "n_laps_used": 168
+    },
+    {
+      "car": "Inferno 86",
+      "corner": "fr",
+      "condition": "dry",
+      "hot_temp_c": 62.0,
+      "hot_pressure_bar": 1.8568100929260254,
+      "n_laps_used": 259
+    },
+    {
+      "car": "Inferno 86",
+      "corner": "rl",
+      "condition": "damp",
+      "hot_temp_c": 60.5,
+      "hot_pressure_bar": 2.0687546730041504,
+      "n_laps_used": 168
+    },
+    {
+      "car": "Inferno 86",
+      "corner": "rl",
+      "condition": "dry",
+      "hot_temp_c": 63.0,
+      "hot_pressure_bar": 1.8593504428863525,
+      "n_laps_used": 254
+    },
+    {
+      "car": "Inferno 86",
+      "corner": "rr",
+      "condition": "damp",
+      "hot_temp_c": 59.5,
+      "hot_pressure_bar": 2.0532326698303223,
+      "n_laps_used": 168
+    },
+    {
+      "car": "Inferno 86",
+      "corner": "rr",
+      "condition": "dry",
+      "hot_temp_c": 61.0,
+      "hot_pressure_bar": 1.8656189441680908,
+      "n_laps_used": 259
+    },
+    {
+      "car": "KK-SII",
+      "corner": "fl",
+      "condition": "damp",
+      "hot_temp_c": 43.0,
+      "hot_pressure_bar": 1.5950980186462402,
+      "n_laps_used": 69
+    },
+    {
+      "car": "KK-SII",
+      "corner": "fl",
+      "condition": "dry",
+      "hot_temp_c": 47.0,
+      "hot_pressure_bar": 1.5950578451156616,
+      "n_laps_used": 252
+    },
+    {
+      "car": "KK-SII",
+      "corner": "fl",
+      "condition": "wet",
+      "hot_temp_c": 26.0,
+      "hot_pressure_bar": 1.4291354417800903,
+      "n_laps_used": 14
+    },
+    {
+      "car": "KK-SII",
+      "corner": "fr",
+      "condition": "damp",
+      "hot_temp_c": 35.0,
+      "hot_pressure_bar": 1.5508381128311157,
+      "n_laps_used": 69
+    },
+    {
+      "car": "KK-SII",
+      "corner": "fr",
+      "condition": "dry",
+      "hot_temp_c": 39.0,
+      "hot_pressure_bar": 1.5413929224014282,
+      "n_laps_used": 252
+    },
+    {
+      "car": "KK-SII",
+      "corner": "fr",
+      "condition": "wet",
+      "hot_temp_c": 22.5,
+      "hot_pressure_bar": 1.406614065170288,
+      "n_laps_used": 14
+    },
+    {
+      "car": "KK-SII",
+      "corner": "rl",
+      "condition": "damp",
+      "hot_temp_c": 38.0,
+      "hot_pressure_bar": 1.5836442708969116,
+      "n_laps_used": 69
+    },
+    {
+      "car": "KK-SII",
+      "corner": "rl",
+      "condition": "dry",
+      "hot_temp_c": 43.0,
+      "hot_pressure_bar": 1.6022546291351318,
+      "n_laps_used": 226
+    },
+    {
+      "car": "KK-SII",
+      "corner": "rl",
+      "condition": "wet",
+      "hot_temp_c": 21.5,
+      "hot_pressure_bar": 1.4102553129196167,
+      "n_laps_used": 14
+    },
+    {
+      "car": "KK-SII",
+      "corner": "rr",
+      "condition": "damp",
+      "hot_temp_c": 39.0,
+      "hot_pressure_bar": 1.5692331790924072,
+      "n_laps_used": 69
+    },
+    {
+      "car": "KK-SII",
+      "corner": "rr",
+      "condition": "dry",
+      "hot_temp_c": 43.0,
+      "hot_pressure_bar": 1.5990227460861206,
+      "n_laps_used": 225
+    },
+    {
+      "car": "KK-SII",
+      "corner": "rr",
+      "condition": "wet",
+      "hot_temp_c": 23.0,
+      "hot_pressure_bar": 1.4287058115005493,
+      "n_laps_used": 7
     }
   ],
   "lap_time_typ_by_track_car_cond": [

--- a/src/motorsports_data_notebook/tire_model/warmup_table.py
+++ b/src/motorsports_data_notebook/tire_model/warmup_table.py
@@ -70,6 +70,14 @@ G2_TYP_PERCENTILE = 75.0
 MIN_LAPS_FOR_TAU_FIT = 30  # per (car, track, corner) bucket to participate in Pass 1
 MIN_LAPS_FOR_K_BUCKET = 5  # per (car, track, corner) bucket to factor in Pass 2
 
+# Laps this deep into a stint count as steady-state for the UI prefill
+# medians (hot temp / hot pressure per car+corner+condition). Buckets with
+# fewer than CORNER_DEFAULTS_MIN_LAPS steady laps are dropped so a couple
+# of outlier laps (e.g. two crawling wet laps) can't seed the prefill —
+# the UI's condition chain falls back to a denser bucket instead.
+CORNER_DEFAULTS_MIN_LAP_IN_STINT = 4
+CORNER_DEFAULTS_MIN_LAPS = 5
+
 # ---- Target-lap-time feature: g² as a function of pace ----
 # Energy into the tires scales strongly with pace (log(g²) vs log(lap time)
 # slopes of -2.4…-3.6, |r| 0.8-0.97 on the 2026-08 dataset; pure v²-scaling
@@ -268,6 +276,7 @@ def build_warmup_table(
 
     lap_time_lookup = _build_lap_time_typ(laps)
     g2_lookup = _build_g2_typ(laps)
+    corner_defaults = _build_corner_defaults(laps)
     from .sectors import build_pace_model
 
     g2_curves, g2_exponent_default = build_pace_model(root, laps)
@@ -359,6 +368,7 @@ def build_warmup_table(
         g2_exponent_default=g2_exponent_default,
         k_by_compound=k_by_compound,
         compound_multipliers=compound_multipliers,
+        corner_defaults=corner_defaults,
     )
 
     if write_artifacts:
@@ -686,6 +696,36 @@ def _build_g2_typ_per_corner(
     return out
 
 
+def _build_corner_defaults(
+    laps: pd.DataFrame,
+    *,
+    min_lap_within_stint: int = CORNER_DEFAULTS_MIN_LAP_IN_STINT,
+    min_laps: int = CORNER_DEFAULTS_MIN_LAPS,
+) -> dict[tuple[str, str, str], tuple[float, float, int]]:
+    """Median steady-state hot temp/pressure per (car, corner, condition).
+
+    UI prefill values: what this car's tires actually settle at once warm
+    (``lap_within_stint >= min_lap_within_stint``). Blacklisted corners are
+    already NaN-masked upstream, so they drop out of the medians.
+
+    Returns ``{(car, corner, condition): (hot_temp_c, hot_pressure_bar, n)}``.
+    """
+    steady = laps[laps["lap_within_stint"] >= min_lap_within_stint]
+    steady = steady[steady["condition"] != "unknown"]
+    out: dict[tuple[str, str, str], tuple[float, float, int]] = {}
+    for (car, cond), grp in steady.groupby(["car", "condition"]):
+        for c in CORNERS:
+            paired = grp[[f"tpms_temp_{c}_end", f"tpms_press_{c}_mean"]].dropna()
+            if len(paired) < min_laps:
+                continue
+            out[(str(car), c, str(cond))] = (
+                float(paired[f"tpms_temp_{c}_end"].median()),
+                float(paired[f"tpms_press_{c}_mean"].median()),
+                int(len(paired)),
+            )
+    return out
+
+
 def _laps_for_fit(
     laps: pd.DataFrame,
     g2_lookup: dict[tuple[str, str, str], tuple[float, int]],
@@ -945,6 +985,7 @@ def _assemble_model(
     g2_exponent_default: float = G2_LAP_TIME_EXPONENT_FALLBACK,
     k_by_compound: dict[tuple[str, str, str, str], "FitParam"] | None = None,
     compound_multipliers: dict[str, dict[str, float]] | None = None,
+    corner_defaults: dict[tuple[str, str, str], tuple[float, float, int]] | None = None,
 ) -> dict[str, Any]:
     """Build the in-memory model dict that matches the JSON artifact schema.
 
@@ -957,6 +998,7 @@ def _assemble_model(
     g2_curves = g2_curves or {}
     k_by_compound = k_by_compound or {}
     compound_multipliers = compound_multipliers or {}
+    corner_defaults = corner_defaults or {}
 
     def _g2_entry(track: str, car: str, cond: str, value: float, n: int) -> dict[str, Any]:
         entry: dict[str, Any] = {
@@ -1098,6 +1140,20 @@ def _assemble_model(
                 "n_laps": fp.n_samples,
             }
             for (car, compound, corner, cond), fp in sorted(k_by_compound.items())
+        ],
+        # UI prefill medians: what the tires settle at once warm (additive;
+        # calculators use these to seed the target hot temp / hot pressure
+        # inputs when the car or condition selection changes).
+        "corner_defaults_by_car_corner_cond": [
+            {
+                "car": car,
+                "corner": corner,
+                "condition": cond,
+                "hot_temp_c": temp,
+                "hot_pressure_bar": press,
+                "n_laps_used": n,
+            }
+            for (car, corner, cond), (temp, press, n) in sorted(corner_defaults.items())
         ],
         "lap_time_typ_by_track_car_cond": [
             {

--- a/tests/tire_model/test_warmup_table.py
+++ b/tests/tire_model/test_warmup_table.py
@@ -225,3 +225,62 @@ def test_w_road_default_is_zero_point_two() -> None:
 def test_anchor_track_is_tsukuba_2000() -> None:
     """The c_track identifiability anchor must remain stable across runs."""
     assert wt.ANCHOR_TRACK == "tsukuba_2000"
+
+
+def test_build_corner_defaults_medians_and_steady_state_filter() -> None:
+    """Prefills use only steady-state laps and take per-corner medians."""
+    rows = []
+    for lap_within_stint, temp, press in [
+        (1, 40.0, 1.5),  # warmup lap — must be excluded
+        (4, 70.0, 1.9),
+        (5, 71.0, 1.95),
+        (6, 72.0, 2.0),
+        (7, 73.0, 2.05),
+        (8, 74.0, 2.1),
+    ]:
+        row: dict = {
+            "car": "KK-SII",
+            "condition": "dry",
+            "lap_within_stint": lap_within_stint,
+        }
+        for c in ("fl", "fr", "rl", "rr"):
+            row[f"tpms_temp_{c}_end"] = temp
+            row[f"tpms_press_{c}_mean"] = press
+        rows.append(row)
+    # An unknown-condition steady lap must be excluded too.
+    unknown = dict(rows[-1], condition="unknown")
+    laps = pd.DataFrame(rows + [unknown])
+
+    out = wt._build_corner_defaults(laps)
+
+    assert set(out) == {("KK-SII", c, "dry") for c in ("fl", "fr", "rl", "rr")}
+    temp, press, n = out[("KK-SII", "fl", "dry")]
+    assert temp == pytest.approx(72.0)
+    assert press == pytest.approx(2.0)
+    assert n == 5
+
+
+def test_build_corner_defaults_drops_thin_buckets() -> None:
+    """Fewer than min_laps steady laps -> no prefill row for that bucket."""
+    row: dict = {"car": "Inferno 86", "condition": "wet", "lap_within_stint": 5}
+    for c in ("fl", "fr", "rl", "rr"):
+        row[f"tpms_temp_{c}_end"] = 23.0
+        row[f"tpms_press_{c}_mean"] = 2.5
+    laps = pd.DataFrame([row, dict(row)])  # only 2 steady wet laps
+
+    assert wt._build_corner_defaults(laps) == {}
+
+
+def test_build_corner_defaults_skips_nan_masked_corners() -> None:
+    """A blacklist-masked (NaN) corner drops out; the others still fit."""
+    row: dict = {"car": "Inferno 86", "condition": "dry", "lap_within_stint": 5}
+    for c in ("fl", "fr", "rl", "rr"):
+        row[f"tpms_temp_{c}_end"] = 80.0
+        row[f"tpms_press_{c}_mean"] = 1.8
+    row["tpms_temp_fr_end"] = float("nan")
+    laps = pd.DataFrame([row])
+
+    out = wt._build_corner_defaults(laps, min_laps=1)
+
+    assert ("Inferno 86", "fr", "dry") not in out
+    assert out[("Inferno 86", "rl", "dry")][0] == pytest.approx(80.0)

--- a/tire_pressure_calculator/web/js/app.js
+++ b/tire_pressure_calculator/web/js/app.js
@@ -56,11 +56,17 @@ function defaultSettings() {
   };
 }
 
+// True when settings came from storage (vs factory defaults). First run
+// prefills the corner targets from the model; a returning user's tuned
+// values are left alone until they change car/condition or hit Reset.
+let hadSavedSettings = false;
+
 function loadSettings() {
   const defaults = defaultSettings();
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return defaults;
+    hadSavedSettings = true;
     const parsed = JSON.parse(raw);
     // Shallow-merge each section over the defaults so partial/older payloads
     // still produce a complete settings object.
@@ -305,6 +311,22 @@ function snapTargetLap() {
   if (Number.isFinite(typ) && typ > 0) p.TargetLapTimeS = Math.round(typ * 10) / 10;
 }
 
+// Corner-card prefills follow the car: the target hot temp and hot
+// pressure snap to the model's steady-state medians for the selected
+// (car, condition). Buckets missing from the artifact keep whatever the
+// fields currently hold.
+function snapCornerTargets() {
+  const p = settings.Prediction;
+  if (!model || !p.Car) return;
+  for (const c of CORNERS) {
+    const d = model.lookupCornerDefaults(p.Car, c.id, p.Condition);
+    if (!d) continue;
+    const cs = settings[c.settingsKey];
+    cs.TargetHotTemp = Math.round(d.hotTempC * 10) / 10;
+    cs.TargetHotPressure = Math.round(d.hotPressureBar * 100) / 100;
+  }
+}
+
 // Compound choices depend on the selected car. The choice is FORCED —
 // every run has exactly one tire on all four corners, so there is no
 // pooled "default" option; an unset selection snaps to the first compound.
@@ -418,6 +440,8 @@ function wireEvents() {
       TargetLapTimeS: null, // snapped to the selection's typical lap once the model loads
       Compound: null,
     };
+    snapTargetLap();
+    snapCornerTargets();
     saveSettings();
     applyStrings(); // condition + compound selections changed
     render();
@@ -442,6 +466,7 @@ function wireEvents() {
     settings.Prediction.Compound = null;
     fillCompoundSelects();
     snapTargetLap();
+    snapCornerTargets();
     saveSettings();
     render();
   });
@@ -455,6 +480,7 @@ function wireEvents() {
   els.conditionSelect.addEventListener('change', () => {
     settings.Prediction.Condition = els.conditionSelect.value;
     snapTargetLap();
+    snapCornerTargets();
     saveSettings();
     render();
   });
@@ -535,6 +561,7 @@ async function init() {
     fillCompoundSelects();
     if (p.TargetLapTimeS === null) snapTargetLap();
     if (p.CloudCoverPct === null) p.CloudCoverPct = 50;
+    if (!hadSavedSettings) snapCornerTargets();
   } else {
     settings.Mode = MODE_MANUAL;
   }

--- a/tire_pressure_calculator/web/js/model.js
+++ b/tire_pressure_calculator/web/js/model.js
@@ -275,6 +275,26 @@ export class TireModel {
     return null;
   }
 
+  // Steady-state hot temp / hot pressure medians for UI prefills, via the
+  // condition chain; null when the artifact has no entry (caller keeps its
+  // static defaults).
+  lookupCornerDefaults(car, corner, condition) {
+    const rows = this.dto.corner_defaults_by_car_corner_cond ?? [];
+    for (const cond of conditionChain(condition)) {
+      const hit = rows.find(
+        (r) => r.car === car && r.corner === corner && r.condition === cond);
+      if (hit) {
+        return {
+          hotTempC: hit.hot_temp_c,
+          hotPressureBar: hit.hot_pressure_bar,
+          nLapsUsed: hit.n_laps_used ?? 0,
+          source: cond === condition ? 'exact' : `fallback(${cond})`,
+        };
+      }
+    }
+    return null;
+  }
+
   // ---- Target-lap-time pace scaling (schema v3) ----
 
   lookupG2PaceCurve(track, car, condition) {

--- a/tire_pressure_calculator/web/tests/model.test.mjs
+++ b/tire_pressure_calculator/web/tests/model.test.mjs
@@ -232,3 +232,22 @@ test('compound K overrides pooled K per axle', () => {
   const unknown = predictCorner(model, { ...args, compound: 'SLICKS9000' });
   assert.equal(unknown.kKelvinPerG2, pooled.kKelvinPerG2);
 });
+
+test('corner defaults: per-car steady-state medians with condition fallback', () => {
+  const model = new TireModel(modelDto);
+  const kk = model.lookupCornerDefaults('KK-SII', 'fl', 'dry');
+  const inferno = model.lookupCornerDefaults('Inferno 86', 'fl', 'dry');
+  assert.ok(kk && inferno, 'both cars carry dry FL defaults');
+  assert.ok(inferno.hotTempC > kk.hotTempC, 'Inferno runs hotter than KK-SII');
+  assert.ok(kk.hotTempC > 20 && kk.hotTempC < 100);
+  assert.ok(kk.hotPressureBar > 1.0 && kk.hotPressureBar < 3.0);
+  assert.equal(kk.source, 'exact');
+  // Wet KK-SII data exists and is cooler than dry.
+  const wet = model.lookupCornerDefaults('KK-SII', 'fl', 'wet');
+  assert.ok(wet.hotTempC < kk.hotTempC);
+  // Inferno has no wet laps: the condition chain falls back toward dry.
+  const infernoWet = model.lookupCornerDefaults('Inferno 86', 'fl', 'wet');
+  assert.ok(infernoWet && infernoWet.source.startsWith('fallback('));
+  // Unknown car -> null (caller keeps its static defaults).
+  assert.equal(model.lookupCornerDefaults('NoSuchCar', 'fl', 'dry'), null);
+});


### PR DESCRIPTION

The corner-card targets (hot temp / hot pressure) were one-size-fits-all
(80.0 degC / 1.8 bar) regardless of car. They now prefill from the data:
the artifact gains an additive corner_defaults_by_car_corner_cond table -
median steady-state TPMS temp and pressure per (car, corner, condition),
computed over laps >= 4 into a stint so warmup laps don't drag the
medians down. Buckets under 5 steady laps are dropped (the Inferno's two
crawling wet laps would otherwise seed a 23 degC / 2.55 bar prefill);
the UI's condition chain falls back to a denser bucket instead.

The web app snaps the corner targets on car change, condition change,
Reset, and first-ever load - a returning user's tuned values are left
alone until they change the selection. Reset now also re-snaps the
target lap time instead of leaving it blank. Fitted prefills: Inferno 86
settles ~61-67 degC at ~1.87 bar; KK-SII ~39-47 degC at ~1.6 bar dry,
~22-26 degC / ~1.4 bar wet.

Artifact rebuilt (fit parameters unchanged - parity fixtures still pass).
601 Python / 20 web tests pass; browser-verified.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/146).
* __->__ #146
* #145
* #144
* #143
* #142
* #141
* #140
* #139
* #138
* #137
* #136
* #135
* #133
* #132
* #131
* #130
* #129