### PR TITLE
tire-pressure-calculator: Desktop/Android parity with the web calculator

### DIFF
--- a/scripts/regen_tire_predict_fixture.py
+++ b/scripts/regen_tire_predict_fixture.py
@@ -134,6 +134,57 @@ CASES: list[tuple[str, dict]] = [
             "target_lap_time_s": 120.0,
         },
     ),
+    # Compound-aware K: the fitted compound replaces the pooled K on every
+    # corner (one tire per run), an unknown compound falls back to pooled,
+    # and the KK-SII's WET compound rides the wet condition chain.
+    (
+        "sodegaura_Inferno_dry_A050",
+        {
+            "track": "sodegaura",
+            "car": "Inferno 86",
+            "lap_within_stint": 5,
+            "track_condition": "dry",
+            "ambient_temp_c": 22.0,
+            "target_hot_pressure_bar": 1.7,
+            "compound": "A050",
+        },
+    ),
+    (
+        "sodegaura_Inferno_dry_A052",
+        {
+            "track": "sodegaura",
+            "car": "Inferno 86",
+            "lap_within_stint": 5,
+            "track_condition": "dry",
+            "ambient_temp_c": 22.0,
+            "target_hot_pressure_bar": 1.7,
+            "compound": "A052",
+        },
+    ),
+    (
+        "sodegaura_Inferno_unknown_compound_pooled",
+        {
+            "track": "sodegaura",
+            "car": "Inferno 86",
+            "lap_within_stint": 5,
+            "track_condition": "dry",
+            "ambient_temp_c": 22.0,
+            "target_hot_pressure_bar": 1.7,
+            "compound": "SLICKS9000",
+        },
+    ),
+    (
+        "tsukuba_KKSII_wet_compound_WET",
+        {
+            "track": "tsukuba_2000",
+            "car": "KK-SII",
+            "lap_within_stint": 10,
+            "track_condition": "wet",
+            "ambient_temp_c": 15.0,
+            "target_hot_pressure_bar": 1.7,
+            "compound": "WET",
+        },
+    ),
 ]
 
 

--- a/tire_pressure_calculator/Core/Services/CircuitPredictor.cs
+++ b/tire_pressure_calculator/Core/Services/CircuitPredictor.cs
@@ -34,7 +34,8 @@ public sealed class CircuitPredictor
         string corner,
         double targetHotPressureBar,
         double? coldTireTempC = null,
-        double? targetLapTimeS = null)
+        double? targetLapTimeS = null,
+        string? compound = null)
     {
         ArgumentNullException.ThrowIfNull(track);
         ArgumentNullException.ThrowIfNull(car);
@@ -46,7 +47,10 @@ public sealed class CircuitPredictor
             throw new ArgumentException(
                 $"track_condition must be dry/damp/wet; got '{condition}'", nameof(condition));
 
+        // One tire on all four corners — the compound applies to every corner.
         var k = _model.LookupK(car, corner, cond);
+        if (compound is not null && _model.LookupCompoundK(car, compound, corner, cond) is KLookup ck)
+            k = ck;
         var tau = _model.LookupTau(car, corner, cond);
         var c = _model.LookupCTrack(track);
         var g2 = _model.LookupG2(track, car, cond);

--- a/tire_pressure_calculator/Core/Services/Modeling/TireModel.cs
+++ b/tire_pressure_calculator/Core/Services/Modeling/TireModel.cs
@@ -130,6 +130,54 @@ public sealed class TireModel
             SourceBucket: "(prior)", FromPrior: true);
     }
 
+    // ---- Compound-aware K (decomposed c_track × base × multiplier) ----
+
+    /// <summary>Distinct compounds fitted for a car, for UI enumeration.
+    /// One tire runs on all four corners — the choice is forced, so an
+    /// empty list means the car predates compound labeling.</summary>
+    public IReadOnlyList<string> AvailableCompounds(string car) =>
+        (Dto.KByCarCompoundCornerCond ?? Array.Empty<KCompoundEntryDto>())
+            .Where(r => r.Car == car).Select(r => r.Compound)
+            .Distinct().OrderBy(s => s).ToList();
+
+    /// <summary>Compound-specific K via the condition chain, or null when
+    /// the artifact has no fitted bucket (caller falls back to pooled K).</summary>
+    public KLookup? LookupCompoundK(string car, string compound, string corner, string condition)
+    {
+        var rows = Dto.KByCarCompoundCornerCond ?? Array.Empty<KCompoundEntryDto>();
+        foreach (var cond in ConditionChain(condition))
+        {
+            var hit = rows.FirstOrDefault(
+                r => r.Car == car && r.Compound == compound
+                     && r.Corner == corner && r.Condition == cond);
+            if (hit is not null)
+            {
+                return new KLookup(hit.ValueKelvinPerG2, hit.StderrKelvinPerG2, hit.NLaps,
+                    SourceBucket: $"({car}, {compound}, {corner}, {cond})", FromPrior: false);
+            }
+        }
+        return null;
+    }
+
+    /// <summary>Steady-state hot temp / hot pressure medians for UI
+    /// prefills, via the condition chain; null when the artifact has no
+    /// entry (caller keeps its static defaults).</summary>
+    public CornerDefaultsLookup? LookupCornerDefaults(string car, string corner, string condition)
+    {
+        var rows = Dto.CornerDefaultsByCarCornerCond ?? Array.Empty<CornerDefaultsEntryDto>();
+        foreach (var cond in ConditionChain(condition))
+        {
+            var hit = rows.FirstOrDefault(
+                r => r.Car == car && r.Corner == corner && r.Condition == cond);
+            if (hit is not null)
+            {
+                return new CornerDefaultsLookup(hit.HotTempC, hit.HotPressureBar, hit.NLapsUsed,
+                    Source: cond == condition ? "exact" : $"fallback({cond})");
+            }
+        }
+        return null;
+    }
+
     public CTrackLookup LookupCTrack(string track)
     {
         var hit = Dto.CTrackByTrack.FirstOrDefault(r => r.TrackCanonical == track);
@@ -275,6 +323,9 @@ public readonly record struct G2Lookup(
 
 public readonly record struct LapTimeLookup(
     double ValueSeconds, int NLapsUsed, string Source);
+
+public readonly record struct CornerDefaultsLookup(
+    double HotTempC, double HotPressureBar, int NLapsUsed, string Source);
 
 public readonly record struct G2PaceScale(
     double Scale, string Source);

--- a/tire_pressure_calculator/Core/Services/Modeling/TireModelDtos.cs
+++ b/tire_pressure_calculator/Core/Services/Modeling/TireModelDtos.cs
@@ -21,7 +21,30 @@ public sealed record TireModelDto(
     [property: JsonPropertyName("c_track_by_track")] IReadOnlyList<CTrackEntryDto> CTrackByTrack,
     [property: JsonPropertyName("g2_typ_by_track_car_cond")] IReadOnlyList<G2EntryDto> G2TypByTrackCarCond,
     [property: JsonPropertyName("lap_time_typ_by_track_car_cond")] IReadOnlyList<LapTimeEntryDto> LapTimeTypByTrackCarCond,
-    [property: JsonPropertyName("g2_lap_time_model")] G2LapTimeModelDto? G2LapTimeModel = null
+    [property: JsonPropertyName("g2_lap_time_model")] G2LapTimeModelDto? G2LapTimeModel = null,
+    [property: JsonPropertyName("K_by_car_compound_corner_cond")] IReadOnlyList<KCompoundEntryDto>? KByCarCompoundCornerCond = null,
+    [property: JsonPropertyName("corner_defaults_by_car_corner_cond")] IReadOnlyList<CornerDefaultsEntryDto>? CornerDefaultsByCarCornerCond = null
+);
+
+// ---- Compound-aware K + UI prefill medians (schema v3 additive) ----
+
+public sealed record KCompoundEntryDto(
+    [property: JsonPropertyName("car")] string Car,
+    [property: JsonPropertyName("compound")] string Compound,
+    [property: JsonPropertyName("corner")] string Corner,
+    [property: JsonPropertyName("condition")] string Condition,
+    [property: JsonPropertyName("value_kelvin_per_g2")] double ValueKelvinPerG2,
+    [property: JsonPropertyName("stderr_kelvin_per_g2")] double StderrKelvinPerG2,
+    [property: JsonPropertyName("n_laps")] int NLaps
+);
+
+public sealed record CornerDefaultsEntryDto(
+    [property: JsonPropertyName("car")] string Car,
+    [property: JsonPropertyName("corner")] string Corner,
+    [property: JsonPropertyName("condition")] string Condition,
+    [property: JsonPropertyName("hot_temp_c")] double HotTempC,
+    [property: JsonPropertyName("hot_pressure_bar")] double HotPressureBar,
+    [property: JsonPropertyName("n_laps_used")] int NLapsUsed
 );
 
 // ---- Target-lap-time feature (schema v3) ----

--- a/tire_pressure_calculator/Core/Settings.cs
+++ b/tire_pressure_calculator/Core/Settings.cs
@@ -34,6 +34,8 @@ public class PredictionSettings
     public double? TrackTempC { get; set; }
     public double? CloudCoverPct { get; set; }
     public double? TargetLapTimeS { get; set; }
+    /// <summary>Selected tire compound — one tire on all four corners.</summary>
+    public string? Compound { get; set; }
 }
 
 public class AppSettings
@@ -48,6 +50,13 @@ public class AppSettings
     /// <summary>UI language preference: "auto", "en", or "ja".</summary>
     public string UiLanguage { get; set; } = "auto";
 
+    /// <summary>True when these settings came from storage (vs factory
+    /// defaults). First run prefills the corner targets from the model; a
+    /// returning user's tuned values are left alone until they change the
+    /// selection or hit Reset.</summary>
+    [JsonIgnore]
+    public bool LoadedFromStorage { get; set; }
+
     public static ISettingsStorage Storage { get; set; } = new FileSettingsStorage();
 
     public static AppSettings Load()
@@ -57,7 +66,12 @@ public class AppSettings
             var json = Storage.Read();
             if (!string.IsNullOrEmpty(json))
             {
-                return JsonSerializer.Deserialize(json, SettingsContext.Default.AppSettings) ?? new();
+                var loaded = JsonSerializer.Deserialize(json, SettingsContext.Default.AppSettings);
+                if (loaded is not null)
+                {
+                    loaded.LoadedFromStorage = true;
+                    return loaded;
+                }
             }
         }
         catch { }

--- a/tire_pressure_calculator/Core/ViewModels/MainViewModel.cs
+++ b/tire_pressure_calculator/Core/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -36,6 +37,7 @@ public class MainViewModel : INotifyPropertyChanged
     private double? _trackTempC;
     private double? _cloudCoverPct;
     private double? _targetLapTimeS;
+    private string? _selectedCompound;
 
     public AppMode Mode
     {
@@ -58,6 +60,8 @@ public class MainViewModel : INotifyPropertyChanged
 
     public ObservableCollection<string> AvailableTracks { get; } = new();
     public ObservableCollection<string> AvailableCars { get; } = new();
+    public ObservableCollection<string> AvailableCompounds { get; } = new();
+    public bool HasCompounds => AvailableCompounds.Count > 0;
     public IReadOnlyList<ConditionOption> AvailableConditions { get; } = new[]
     {
         new ConditionOption("dry", "ConditionDry"),
@@ -80,6 +84,7 @@ public class MainViewModel : INotifyPropertyChanged
     public string T_Ambient => Localizer.Instance["Ambient"];
     public string T_CloudCover => Localizer.Instance["CloudCover"];
     public string T_TargetLapTime => Localizer.Instance["TargetLapTime"];
+    public string T_Compound => Localizer.Instance["Compound"];
     public string T_ResetButton => Localizer.Instance["ResetButton"];
 
     // ---- Language picker ----
@@ -117,6 +122,7 @@ public class MainViewModel : INotifyPropertyChanged
             OnPropertyChanged();
             _settings.Prediction.Track = value;
             _settings.Save();
+            SnapTargetLap();
             RefreshPredictions();
         }
     }
@@ -131,6 +137,9 @@ public class MainViewModel : INotifyPropertyChanged
             OnPropertyChanged();
             _settings.Prediction.Car = value;
             _settings.Save();
+            RefreshCompounds();
+            SnapTargetLap();
+            SnapCornerTargets();
             RefreshPredictions();
         }
     }
@@ -145,6 +154,8 @@ public class MainViewModel : INotifyPropertyChanged
             OnPropertyChanged();
             _settings.Prediction.Condition = value;
             _settings.Save();
+            SnapTargetLap();
+            SnapCornerTargets();
             RefreshPredictions();
         }
     }
@@ -213,7 +224,68 @@ public class MainViewModel : INotifyPropertyChanged
             if (_targetLapTimeS == value) return;
             _targetLapTimeS = value;
             OnPropertyChanged();
+            OnPropertyChanged(nameof(TargetLapTimeText));
             _settings.Prediction.TargetLapTimeS = value;
+            _settings.Save();
+            RefreshPredictions();
+        }
+    }
+
+    /// <summary>Target lap time as text in the form everyone thinks about
+    /// lap times: "1:05.2" (sub-minute laps as plain "58.4"). Accepts either
+    /// form on input; blank/invalid input snaps back to the selection's
+    /// typical lap.</summary>
+    public string TargetLapTimeText
+    {
+        get => FormatLapTime(_targetLapTimeS);
+        set
+        {
+            var parsed = ParseLapTime(value);
+            if (parsed is null)
+                SnapTargetLap();
+            else
+                TargetLapTimeS = Math.Min(900.0, Math.Max(20.0, parsed.Value));
+            OnPropertyChanged(); // re-render the normalized m:ss form
+        }
+    }
+
+    public static string FormatLapTime(double? seconds)
+    {
+        if (seconds is not double v || !double.IsFinite(v) || v <= 0) return "";
+        if (v < 60) return v.ToString("0.0", CultureInfo.InvariantCulture);
+        var m = (int)(v / 60);
+        var s = v - m * 60;
+        return $"{m}:{s.ToString("00.0", CultureInfo.InvariantCulture)}";
+    }
+
+    public static double? ParseLapTime(string? raw)
+    {
+        var t = raw?.Trim().Replace(',', '.');
+        if (string.IsNullOrEmpty(t)) return null;
+        if (t.Contains(':'))
+        {
+            var parts = t.Split(':', 2);
+            if (int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var m)
+                && double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var s))
+                return m * 60 + s;
+            return null;
+        }
+        return double.TryParse(t, NumberStyles.Float, CultureInfo.InvariantCulture, out var v)
+            ? v : null;
+    }
+
+    /// <summary>Tire compound — a FORCED choice: every run has exactly one
+    /// tire on all four corners, so there is no pooled "default" option; an
+    /// unset selection snaps to the car's first compound.</summary>
+    public string? SelectedCompound
+    {
+        get => _selectedCompound;
+        set
+        {
+            if (_selectedCompound == value) return;
+            _selectedCompound = value;
+            OnPropertyChanged();
+            _settings.Prediction.Compound = value;
             _settings.Save();
             RefreshPredictions();
         }
@@ -295,8 +367,14 @@ public class MainViewModel : INotifyPropertyChanged
         _lapWithinStint = _settings.Prediction.LapWithinStint;
         _ambientTempC = _settings.Prediction.AmbientTempC;
         _trackTempC = _settings.Prediction.TrackTempC;
-        _cloudCoverPct = _settings.Prediction.CloudCoverPct;
+        // Cloud cover always carries a value (50% = neutral sky).
+        _cloudCoverPct = _settings.Prediction.CloudCoverPct ?? 50.0;
         _targetLapTimeS = _settings.Prediction.TargetLapTimeS;
+        _selectedCompound = _settings.Prediction.Compound;
+
+        RefreshCompounds();
+        if (_targetLapTimeS is null) SnapTargetLap();
+        if (!_settings.LoadedFromStorage) SnapCornerTargets();
 
         ResetCommand = new RelayCommand(() =>
         {
@@ -314,8 +392,14 @@ public class MainViewModel : INotifyPropertyChanged
             LapWithinStint = 5;
             AmbientTempC = 20.0;
             TrackTempC = null;
-            CloudCoverPct = null;
-            TargetLapTimeS = null;
+            CloudCoverPct = 50.0;
+            // Forced defaults: first compound, typical lap, car prefills.
+            // The Selected* setters above may have early-returned when the
+            // value didn't change, so snap explicitly.
+            RefreshCompounds();
+            SelectedCompound = AvailableCompounds.FirstOrDefault();
+            SnapTargetLap();
+            SnapCornerTargets();
         });
 
         RefreshPredictions();
@@ -365,6 +449,59 @@ public class MainViewModel : INotifyPropertyChanged
         return vm;
     }
 
+    /// <summary>Compound choices depend on the selected car; snap an unset
+    /// or foreign selection to the car's first compound.</summary>
+    private void RefreshCompounds()
+    {
+        AvailableCompounds.Clear();
+        if (_tireModel is not null && _selectedCar is not null)
+        {
+            foreach (var c in _tireModel.AvailableCompounds(_selectedCar))
+                AvailableCompounds.Add(c);
+        }
+        OnPropertyChanged(nameof(HasCompounds));
+        if (AvailableCompounds.Count > 0
+            && (_selectedCompound is null || !AvailableCompounds.Contains(_selectedCompound)))
+        {
+            SelectedCompound = AvailableCompounds[0];
+        }
+        else if (AvailableCompounds.Count == 0)
+        {
+            SelectedCompound = null;
+        }
+    }
+
+    /// <summary>Target lap time always carries a value: the typical lap for
+    /// the current (track, car, condition) selection.</summary>
+    private void SnapTargetLap()
+    {
+        if (_tireModel is null || _selectedTrack is null || _selectedCar is null) return;
+        var typ = _tireModel.LookupLapTime(_selectedTrack, _selectedCar, _selectedCondition);
+        if (typ.ValueSeconds > 0) TargetLapTimeS = Math.Round(typ.ValueSeconds, 1);
+    }
+
+    /// <summary>Corner-card prefills follow the car: target hot temp and hot
+    /// pressure snap to the model's steady-state medians for the selected
+    /// (car, condition). Buckets missing from the artifact keep whatever the
+    /// fields currently hold.</summary>
+    private void SnapCornerTargets()
+    {
+        if (_tireModel is null || _selectedCar is null) return;
+        foreach (var (corner, vm) in new[]
+                 {
+                     ("fl", FrontLeft), ("fr", FrontRight),
+                     ("rl", RearLeft), ("rr", RearRight),
+                 })
+        {
+            if (_tireModel.LookupCornerDefaults(_selectedCar, corner, _selectedCondition)
+                is CornerDefaultsLookup d)
+            {
+                vm.TargetHotTemp = Math.Round(d.HotTempC, 1);
+                vm.TargetHotPressure = Math.Round(d.HotPressureBar, 2);
+            }
+        }
+    }
+
     /// <summary>
     /// Recompute per-corner predicted hot temps + push into each corner VM
     /// (or clear them in Manual mode so the corner falls back to AdjustedHotTemp).
@@ -399,7 +536,8 @@ public class MainViewModel : INotifyPropertyChanged
                     corner: corner,
                     targetHotPressureBar: vm.TargetHotPressure,
                     coldTireTempC: vm.CurrentTemp,
-                    targetLapTimeS: _targetLapTimeS);
+                    targetLapTimeS: _targetLapTimeS,
+                    compound: _selectedCompound);
                 vm.PredictedHotTempC = prediction.PredictedHotTempC;
             }
             catch (Exception)

--- a/tire_pressure_calculator/Core/Views/MainView.axaml
+++ b/tire_pressure_calculator/Core/Views/MainView.axaml
@@ -350,6 +350,14 @@
                       SelectedItem="{Binding SelectedCar}"
                       HorizontalAlignment="Stretch" />
           </StackPanel>
+          <!-- Tire: forced per-car choice (hidden for cars without fitted
+               compounds — one tire always runs on all four corners). -->
+          <StackPanel Margin="6,4" MinWidth="120" IsVisible="{Binding HasCompounds}">
+            <TextBlock Text="{Binding T_Compound}" FontSize="11" />
+            <ComboBox ItemsSource="{Binding AvailableCompounds}"
+                      SelectedItem="{Binding SelectedCompound}"
+                      HorizontalAlignment="Stretch" />
+          </StackPanel>
           <StackPanel Margin="6,4" MinWidth="120">
             <TextBlock Text="{Binding T_Condition}" FontSize="11" />
             <ComboBox ItemsSource="{Binding AvailableConditions}"
@@ -386,10 +394,9 @@
           </StackPanel>
           <StackPanel Margin="6,4" MinWidth="120">
             <TextBlock Text="{Binding T_TargetLapTime}" FontSize="11" />
-            <NumericUpDown Value="{Binding TargetLapTimeS}"
-                           Minimum="20" Maximum="900" Increment="0.5"
-                           FormatString="F1"
-                           ShowButtonSpinner="True" />
+            <!-- m:ss.s text ("1:05.2"); parse accepts plain seconds too. -->
+            <TextBox Text="{Binding TargetLapTimeText}"
+                     Watermark="1:05.2" />
           </StackPanel>
         </WrapPanel>
       </Border>

--- a/tire_pressure_calculator/Tests/CircuitPredictorTests.cs
+++ b/tire_pressure_calculator/Tests/CircuitPredictorTests.cs
@@ -44,7 +44,8 @@ public class CircuitPredictorTests
                     corner: corner,
                     targetHotPressureBar: c.Inputs.TargetHotPressureBar,
                     coldTireTempC: c.Inputs.ColdTireTempC,
-                    targetLapTimeS: c.Inputs.TargetLapTimeS);
+                    targetLapTimeS: c.Inputs.TargetLapTimeS,
+                    compound: c.Inputs.Compound);
                 var py = c.Corners[corner];
                 Assert.True(
                     Math.Abs(prediction.ColdPressureBar - py.ColdPressureBar) < 1e-3,
@@ -165,7 +166,8 @@ public class CircuitPredictorTests
         [property: System.Text.Json.Serialization.JsonPropertyName("cloud_cover_pct")] double? CloudCoverPct,
         [property: System.Text.Json.Serialization.JsonPropertyName("cold_tire_temp_c")] double? ColdTireTempC,
         [property: System.Text.Json.Serialization.JsonPropertyName("target_hot_pressure_bar")] double TargetHotPressureBar,
-        [property: System.Text.Json.Serialization.JsonPropertyName("target_lap_time_s")] double? TargetLapTimeS = null);
+        [property: System.Text.Json.Serialization.JsonPropertyName("target_lap_time_s")] double? TargetLapTimeS = null,
+        [property: System.Text.Json.Serialization.JsonPropertyName("compound")] string? Compound = null);
 
     private sealed record FixtureCornerOutput(
         [property: System.Text.Json.Serialization.JsonPropertyName("cold_pressure_bar")] double ColdPressureBar,

--- a/tire_pressure_calculator/Tests/CompoundAndPrefillTests.cs
+++ b/tire_pressure_calculator/Tests/CompoundAndPrefillTests.cs
@@ -1,0 +1,169 @@
+using TirePressureCalculator.Services;
+using TirePressureCalculator.Services.Modeling;
+using TirePressureCalculator.ViewModels;
+
+namespace TirePressureCalculator.Tests;
+
+/// <summary>
+/// Tests for the compound picker (forced per-car choice, one tire on all
+/// four corners) and the car-based input prefills: corner target hot
+/// temp/pressure, snap-to-typical target lap time (m:ss text form), and
+/// the cloud-cover default. Mirrors the web app's behavior in
+/// ../web/js/app.js.
+/// </summary>
+public class CompoundAndPrefillTests : IDisposable
+{
+    private sealed class InMemoryStorage : ISettingsStorage
+    {
+        public string? Contents;
+        public string? Read() => Contents;
+        public void Write(string contents) => Contents = contents;
+    }
+
+    private static readonly TireModel Model =
+        TireModelLoader.LoadEmbedded(typeof(TireModel).Assembly);
+
+    private readonly ISettingsStorage _originalStorage;
+    private readonly InMemoryStorage _storage = new();
+
+    public CompoundAndPrefillTests()
+    {
+        _originalStorage = AppSettings.Storage;
+        AppSettings.Storage = _storage;
+    }
+
+    public void Dispose() => AppSettings.Storage = _originalStorage;
+
+    // ---------- CircuitPredictor compound override ----------
+
+    [Fact]
+    public void Predict_CompoundK_OverridesPooledK_OnEveryCorner()
+    {
+        var predictor = new CircuitPredictor(Model);
+        CornerPrediction Predict(string corner, string? compound) => predictor.Predict(
+            track: "sodegaura", car: "Inferno 86", condition: "dry",
+            lapWithinStint: 5, ambientTempC: 22.0, trackTempC: null,
+            cloudCoverPct: null, corner: corner, targetHotPressureBar: 1.9,
+            compound: compound);
+
+        var pooled = Predict("rr", null);
+        var a052 = Predict("rr", "A052");
+        var rs71 = Predict("rr", "RE-71RS");
+        Assert.True(a052.KKelvinPerG2 < pooled.KKelvinPerG2, "A052 cooler than pooled");
+        Assert.True(rs71.KKelvinPerG2 > a052.KKelvinPerG2, "71RS hotter than A052");
+        Assert.True(a052.PredictedHotTempC < rs71.PredictedHotTempC);
+        Assert.True(a052.ColdPressureBar > rs71.ColdPressureBar);
+        // One tire on all four corners: a front corner moves too.
+        Assert.NotEqual(Predict("fl", "A052").KKelvinPerG2, Predict("fl", null).KKelvinPerG2);
+        // Unknown compound falls back to pooled.
+        Assert.Equal(pooled.KKelvinPerG2, Predict("rr", "SLICKS9000").KKelvinPerG2);
+    }
+
+    // ---------- Forced compound selection ----------
+
+    [Fact]
+    public void Compounds_EnumeratePerCar_AndSelectionIsForced()
+    {
+        var vm = new MainViewModel(Model);
+        vm.SelectedCar = "Inferno 86";
+        Assert.True(vm.HasCompounds);
+        Assert.Contains("A052", vm.AvailableCompounds);
+        Assert.Contains("RE-71RS", vm.AvailableCompounds);
+        Assert.Equal(vm.AvailableCompounds[0], vm.SelectedCompound);
+
+        vm.SelectedCompound = "RE-71RS";
+        vm.SelectedCar = "KK-SII";
+        // Foreign compound snaps to the new car's first compound.
+        Assert.Contains("DRY", vm.AvailableCompounds);
+        Assert.Contains("WET", vm.AvailableCompounds);
+        Assert.Equal(vm.AvailableCompounds[0], vm.SelectedCompound);
+    }
+
+    // ---------- Corner prefills ----------
+
+    [Fact]
+    public void FreshSettings_PrefillCornerTargetsFromModel()
+    {
+        var vm = new MainViewModel(Model); // in-memory storage is empty
+        var d = Model.LookupCornerDefaults(vm.SelectedCar!, "fl", vm.SelectedCondition);
+        Assert.Equal(Math.Round(d!.Value.HotTempC, 1), vm.FrontLeft.TargetHotTemp);
+        Assert.Equal(Math.Round(d!.Value.HotPressureBar, 2), vm.FrontLeft.TargetHotPressure);
+    }
+
+    [Fact]
+    public void SavedSettings_KeepUserTunedTargets_UntilSelectionChanges()
+    {
+        var vm1 = new MainViewModel(Model);
+        vm1.FrontLeft.TargetHotTemp = 95.0; // persists to storage
+
+        var vm2 = new MainViewModel(Model);
+        Assert.Equal(95.0, vm2.FrontLeft.TargetHotTemp); // no snap on load
+
+        vm2.SelectedCar = vm2.SelectedCar == "KK-SII" ? "Inferno 86" : "KK-SII";
+        var d = Model.LookupCornerDefaults(vm2.SelectedCar!, "fl", vm2.SelectedCondition);
+        Assert.Equal(Math.Round(d!.Value.HotTempC, 1), vm2.FrontLeft.TargetHotTemp);
+    }
+
+    [Fact]
+    public void ConditionChange_ResnapsCornerTargets_WetCoolerThanDry()
+    {
+        var vm = new MainViewModel(Model);
+        vm.SelectedCar = "KK-SII";
+        var dryTemp = vm.FrontLeft.TargetHotTemp;
+        vm.SelectedCondition = "wet";
+        Assert.True(vm.FrontLeft.TargetHotTemp < dryTemp,
+            $"wet prefill {vm.FrontLeft.TargetHotTemp} should be cooler than dry {dryTemp}");
+    }
+
+    // ---------- Target lap time: snap + m:ss text ----------
+
+    [Fact]
+    public void FreshSettings_SnapTargetLapToTypical_AndCloudTo50()
+    {
+        var vm = new MainViewModel(Model);
+        var typ = Model.LookupLapTime(vm.SelectedTrack!, vm.SelectedCar!, vm.SelectedCondition);
+        Assert.Equal(Math.Round(typ.ValueSeconds, 1), vm.TargetLapTimeS);
+        Assert.Equal(50.0, vm.CloudCoverPct);
+    }
+
+    [Fact]
+    public void LapTimeText_FormatsAndParses_MinutesSeconds()
+    {
+        Assert.Equal("2:09.2", MainViewModel.FormatLapTime(129.24));
+        Assert.Equal("1:05.2", MainViewModel.FormatLapTime(65.2));
+        Assert.Equal("58.4", MainViewModel.FormatLapTime(58.4));
+        Assert.Equal("", MainViewModel.FormatLapTime(null));
+
+        Assert.Equal(65.2, MainViewModel.ParseLapTime("1:05.2")!.Value, 3);
+        Assert.Equal(65.2, MainViewModel.ParseLapTime("65.2")!.Value, 3);
+        Assert.Equal(65.2, MainViewModel.ParseLapTime("1:05,2")!.Value, 3);
+        Assert.Null(MainViewModel.ParseLapTime(""));
+        Assert.Null(MainViewModel.ParseLapTime("abc"));
+    }
+
+    [Fact]
+    public void LapTimeText_BlankInput_SnapsBackToTypical()
+    {
+        var vm = new MainViewModel(Model);
+        vm.TargetLapTimeText = "1:00.5";
+        Assert.Equal(60.5, vm.TargetLapTimeS);
+
+        vm.TargetLapTimeText = "";
+        var typ = Model.LookupLapTime(vm.SelectedTrack!, vm.SelectedCar!, vm.SelectedCondition);
+        Assert.Equal(Math.Round(typ.ValueSeconds, 1), vm.TargetLapTimeS);
+    }
+
+    // ---------- Model lookups ----------
+
+    [Fact]
+    public void LookupCornerDefaults_ConditionChain_FallsBackForMissingWet()
+    {
+        // Inferno 86 has no wet prefill bucket (under the 5-lap minimum);
+        // the chain falls back toward damp/dry instead of returning null.
+        var wet = Model.LookupCornerDefaults("Inferno 86", "fl", "wet");
+        Assert.NotNull(wet);
+        Assert.StartsWith("fallback(", wet!.Value.Source);
+        // Unknown car -> null (caller keeps its static defaults).
+        Assert.Null(Model.LookupCornerDefaults("NoSuchCar", "fl", "dry"));
+    }
+}

--- a/tire_pressure_calculator/Tests/Fixtures/python_predictions.json
+++ b/tire_pressure_calculator/Tests/Fixtures/python_predictions.json
@@ -462,5 +462,225 @@
         ]
       }
     }
+  },
+  {
+    "label": "sodegaura_Inferno_dry_A050",
+    "inputs": {
+      "track": "sodegaura",
+      "car": "Inferno 86",
+      "lap_within_stint": 5,
+      "track_condition": "dry",
+      "ambient_temp_c": 22.0,
+      "target_hot_pressure_bar": 1.7,
+      "compound": "A050"
+    },
+    "g2_scale": 1.0,
+    "g2_pace_source": null,
+    "corners": {
+      "fl": {
+        "cold_pressure_bar": 1.3827673445286028,
+        "predicted_hot_temp_c": 61.29515757271994,
+        "K_source_bucket": [
+          "Inferno 86",
+          "A050",
+          "fl",
+          "dry"
+        ]
+      },
+      "fr": {
+        "cold_pressure_bar": 1.4047344807463533,
+        "predicted_hot_temp_c": 58.24001681078151,
+        "K_source_bucket": [
+          "Inferno 86",
+          "A050",
+          "fr",
+          "dry"
+        ]
+      },
+      "rl": {
+        "cold_pressure_bar": 1.4159818559441173,
+        "predicted_hot_temp_c": 56.697261906934116,
+        "K_source_bucket": [
+          "Inferno 86",
+          "A050",
+          "rl",
+          "dry"
+        ]
+      },
+      "rr": {
+        "cold_pressure_bar": 1.436162938907425,
+        "predicted_hot_temp_c": 53.96481948633429,
+        "K_source_bucket": [
+          "Inferno 86",
+          "A050",
+          "rr",
+          "dry"
+        ]
+      }
+    }
+  },
+  {
+    "label": "sodegaura_Inferno_dry_A052",
+    "inputs": {
+      "track": "sodegaura",
+      "car": "Inferno 86",
+      "lap_within_stint": 5,
+      "track_condition": "dry",
+      "ambient_temp_c": 22.0,
+      "target_hot_pressure_bar": 1.7,
+      "compound": "A052"
+    },
+    "g2_scale": 1.0,
+    "g2_pace_source": null,
+    "corners": {
+      "fl": {
+        "cold_pressure_bar": 1.4608252330207638,
+        "predicted_hot_temp_c": 50.686487576066654,
+        "K_source_bucket": [
+          "Inferno 86",
+          "A052",
+          "fl",
+          "dry"
+        ]
+      },
+      "fr": {
+        "cold_pressure_bar": 1.477891006816753,
+        "predicted_hot_temp_c": 48.45615531824858,
+        "K_source_bucket": [
+          "Inferno 86",
+          "A052",
+          "fr",
+          "dry"
+        ]
+      },
+      "rl": {
+        "cold_pressure_bar": 1.48659897180318,
+        "predicted_hot_temp_c": 47.329904092503185,
+        "K_source_bucket": [
+          "Inferno 86",
+          "A052",
+          "rl",
+          "dry"
+        ]
+      },
+      "rr": {
+        "cold_pressure_bar": 1.5021731780805632,
+        "predicted_hot_temp_c": 45.33515002119564,
+        "K_source_bucket": [
+          "Inferno 86",
+          "A052",
+          "rr",
+          "dry"
+        ]
+      }
+    }
+  },
+  {
+    "label": "sodegaura_Inferno_unknown_compound_pooled",
+    "inputs": {
+      "track": "sodegaura",
+      "car": "Inferno 86",
+      "lap_within_stint": 5,
+      "track_condition": "dry",
+      "ambient_temp_c": 22.0,
+      "target_hot_pressure_bar": 1.7,
+      "compound": "SLICKS9000"
+    },
+    "g2_scale": 1.0,
+    "g2_pace_source": null,
+    "corners": {
+      "fl": {
+        "cold_pressure_bar": 1.4216805785525888,
+        "predicted_hot_temp_c": 55.92106207883994,
+        "K_source_bucket": [
+          "Inferno 86",
+          "fl",
+          "dry"
+        ]
+      },
+      "fr": {
+        "cold_pressure_bar": 1.4420991095575362,
+        "predicted_hot_temp_c": 53.16968001674779,
+        "K_source_bucket": [
+          "Inferno 86",
+          "fr",
+          "dry"
+        ]
+      },
+      "rl": {
+        "cold_pressure_bar": 1.4743701234856528,
+        "predicted_hot_temp_c": 48.91378198480571,
+        "K_source_bucket": [
+          "Inferno 86",
+          "rl",
+          "dry"
+        ]
+      },
+      "rr": {
+        "cold_pressure_bar": 1.4909342481531764,
+        "predicted_hot_temp_c": 46.772133870390135,
+        "K_source_bucket": [
+          "Inferno 86",
+          "rr",
+          "dry"
+        ]
+      }
+    }
+  },
+  {
+    "label": "tsukuba_KKSII_wet_compound_WET",
+    "inputs": {
+      "track": "tsukuba_2000",
+      "car": "KK-SII",
+      "lap_within_stint": 10,
+      "track_condition": "wet",
+      "ambient_temp_c": 15.0,
+      "target_hot_pressure_bar": 1.7,
+      "compound": "WET"
+    },
+    "g2_scale": 1.0,
+    "g2_pace_source": null,
+    "corners": {
+      "fl": {
+        "cold_pressure_bar": 1.4544865636126576,
+        "predicted_hot_temp_c": 43.82260499763608,
+        "K_source_bucket": [
+          "KK-SII",
+          "WET",
+          "fl",
+          "wet"
+        ]
+      },
+      "fr": {
+        "cold_pressure_bar": 1.4923524121609226,
+        "predicted_hot_temp_c": 39.006898921630935,
+        "K_source_bucket": [
+          "KK-SII",
+          "WET",
+          "fr",
+          "wet"
+        ]
+      },
+      "rl": {
+        "cold_pressure_bar": 1.508800973297157,
+        "predicted_hot_temp_c": 36.960291043740185,
+        "K_source_bucket": [
+          "KK-SII",
+          "WET",
+          "rl",
+          "wet"
+        ]
+      },
+      "rr": {
+        "cold_pressure_bar": 1.5050681728118098,
+        "predicted_hot_temp_c": 37.422386190484254,
+        "K_source_bucket": [
+          "KK-SII",
+          "WET",
+          "rr",
+          "wet"
+        ]
+      }
+    }
   }
 ]

--- a/tire_pressure_calculator/Tests/MainViewModelTests.cs
+++ b/tire_pressure_calculator/Tests/MainViewModelTests.cs
@@ -83,13 +83,20 @@ public class MainViewModelTests
 
         Assert.Equal(0.0, vm.TempAdjustPercent);
         Assert.Equal(20.0, vm.FrontLeft.CurrentTemp);
-        Assert.Equal(80.0, vm.FrontLeft.TargetHotTemp);
-        Assert.Equal(1.80, vm.RearRight.TargetHotPressure);
         Assert.Equal("dry", vm.SelectedCondition);
         Assert.Equal(5, vm.LapWithinStint);
         Assert.Equal(20.0, vm.AmbientTempC);
         Assert.Null(vm.TrackTempC);
-        Assert.Null(vm.CloudCoverPct);
+        // Forced defaults: neutral sky, typical lap, car-based corner
+        // prefills (the embedded model is loaded by the default ctor).
+        Assert.Equal(50.0, vm.CloudCoverPct);
+        Assert.NotNull(vm.TargetLapTimeS);
+        var model = TirePressureCalculator.Services.Modeling.TireModelLoader
+            .LoadEmbedded(typeof(MainViewModel).Assembly);
+        var fl = model.LookupCornerDefaults(vm.SelectedCar!, "fl", "dry");
+        var rr = model.LookupCornerDefaults(vm.SelectedCar!, "rr", "dry");
+        Assert.Equal(Math.Round(fl!.Value.HotTempC, 1), vm.FrontLeft.TargetHotTemp);
+        Assert.Equal(Math.Round(rr!.Value.HotPressureBar, 2), vm.RearRight.TargetHotPressure);
     }
 
     [Fact]

--- a/tire_pressure_calculator/Tests/PredictionModeTests.cs
+++ b/tire_pressure_calculator/Tests/PredictionModeTests.cs
@@ -212,17 +212,22 @@ public class PredictionModeTests
         vm.FrontLeft.TargetHotPressure = 1.7;
         vm.Mode = AppMode.CircuitPrediction;
 
+        // Feed the VM's own (possibly snapped/forced) inputs into the direct
+        // call: the VM always carries a cloud cover, target lap time, and —
+        // for cars with fitted compounds — a forced compound selection.
         var direct = directPredictor.Predict(
             track: "tsukuba_2000",
             car: "KK-SII",
             condition: "dry",
             lapWithinStint: 10,
             ambientTempC: 15.0,
-            trackTempC: null,
-            cloudCoverPct: null,
+            trackTempC: vm.TrackTempC,
+            cloudCoverPct: vm.CloudCoverPct,
             corner: "fl",
             targetHotPressureBar: 1.7,
-            coldTireTempC: 15.0);
+            coldTireTempC: 15.0,
+            targetLapTimeS: vm.TargetLapTimeS,
+            compound: vm.SelectedCompound);
 
         Assert.Equal(direct.PredictedHotTempC, vm.FrontLeft.PredictedHotTempC!.Value, precision: 6);
         // Corner's cold pressure should agree (rounded to 3 decimals).

--- a/tire_pressure_calculator/web/tests/model.test.mjs
+++ b/tire_pressure_calculator/web/tests/model.test.mjs
@@ -37,6 +37,7 @@ test('parity with Python predictor fixture', () => {
         targetHotPressureBar: inputs.target_hot_pressure_bar,
         coldTireTempC: inputs.cold_tire_temp_c ?? null,
         targetLapTimeS: inputs.target_lap_time_s ?? null,
+        compound: inputs.compound ?? null,
       });
       const label = `${testCase.label}/${corner}`;
       assert.ok(


### PR DESCRIPTION

The Avalonia heads (Desktop, Android, Browser) were behind the web app.
This brings the shared Core to parity:

- Tire picker: new K_by_car_compound_corner_cond + corner-defaults DTOs,
  TireModel.AvailableCompounds/LookupCompoundK/LookupCornerDefaults, and
  a forced per-car compound ComboBox between Car and Condition (one tire
  on all four corners - no pooled "default" option; an unset or foreign
  selection snaps to the car's first compound). CircuitPredictor.Predict
  takes the compound and overrides the pooled K per corner.
- Forced input defaults: cloud cover always carries a value (50 percent
  neutral sky), target lap time snaps to the selection's typical lap on
  track/car/condition change and Reset.
- Target lap time reads and edits as m:ss.s text ("1:05.2", sub-minute
  as "58.4"), replacing the raw-seconds NumericUpDown.
- Car-based corner prefills: target hot temp / hot pressure snap to the
  artifact's steady-state medians on car or condition change, Reset, and
  first-ever launch; a returning user's tuned values are left alone
  (AppSettings.LoadedFromStorage distinguishes the two).

89 C# tests pass (7 new in CompoundAndPrefillTests); desktop head
smoke-ran clean under WSLg.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/147).
* __->__ #147
* #146
* #145
* #144
* #143
* #142
* #141
* #140
* #139
* #138
* #137
* #136
* #135
* #133
* #132
* #131
* #130
* #129