### PR TITLE
tire-web: two-column prediction inputs on phone viewports

### DIFF
--- a/tire_pressure_calculator/web/app.css
+++ b/tire_pressure_calculator/web/app.css
@@ -390,3 +390,20 @@ select,
 select:focus, .pred-field > input:focus, .adjust-group input:focus, .btn:focus-visible {
   outline: 1px solid var(--accent);
 }
+
+/* Phone-width viewports: the prediction inputs flow into a strict
+   two-column grid (equal columns, full-width controls) instead of the
+   ragged centered flex-wrap. */
+@media (max-width: 640px) {
+  .pred-panel {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 10px;
+  }
+  .pred-panel[hidden] { display: none; }
+  .pred-field,
+  .pred-field:nth-child(-n+2) {
+    margin: 0;
+    min-width: 0;
+  }
+}


### PR DESCRIPTION

On phone-width screens the prediction panel's centered flex-wrap put
the eight input fields at ragged, unaligned positions. Under 640px the
panel now flows into a strict two-column grid - Track|Car,
Tire|Condition, Lap|Ambient, Cloud|Target lap time - with full-width
controls. Desktop keeps the existing single-row wrap.

Verified at 390x844 (screenshots) with no page errors; desktop layout
unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/149).
* #150
* __->__ #149