### PR TITLE
README: link the tire pressure calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Analyze AiM motorsports telemetry data in your browser — no software installat
 
 Upload your `.xrk` or `.xrz` files and start analyzing immediately.
 
+**[Tire Pressure Calculator →](https://tires.inferno.racing/)**
+
+Cold tire pressures from target hot pressure and temperature — manually via Gay-Lussac, or predicted per corner by the fitted tire warmup model (track, car, tire compound, condition, target lap time).
+
 ---
 
 ## How It Works


### PR DESCRIPTION

The front page linked only the analysis tool; add tires.inferno.racing
alongside it with a one-line description.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/150).
* __->__ #150
* #149