### PR TITLE
tire-web: installable PWA with full offline support

### DIFF
--- a/.github/workflows/build-tire-pressure-web.yml
+++ b/.github/workflows/build-tire-pressure-web.yml
@@ -18,6 +18,9 @@ jobs:
           cp -r tire_pressure_calculator/web/. site/
           rm -rf site/tests
           cp data/tire_dataset/tire_model.json site/
+          # Stamp the service-worker cache version so each deploy busts the
+          # previous one (the repo copy keeps the __BUILD__ placeholder).
+          sed -i "s/__BUILD__/${GITHUB_SHA::12}/" site/sw.js
 
       - name: Upload site artifact
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,7 @@ tire_pressure_calculator/
     js/model.js   # JS port of the modeling layer (pinned to the same parity fixture)
     js/strings.js # Must stay in sync with Core/Localization/strings.json (tested)
     js/app.js     # DOM wiring, localStorage settings (same key/shape as C# AppSettings)
+    sw.js         # Service worker (installable PWA, offline); cache version stamped at deploy
     tests/        # node --test suites
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Analyze AiM motorsports telemetry data in your browser — no software installat
 
 Upload your `.xrk` or `.xrz` files and start analyzing immediately.
 
+**[Tire Pressure Calculator →](https://tires.inferno.racing/)**
+
+Cold tire pressures from target hot pressure and temperature — manually via Gay-Lussac, or predicted per corner by the fitted tire warmup model (track, car, tire compound, condition, target lap time).
+
 ---
 
 ## How It Works

--- a/tire_pressure_calculator/web/app.css
+++ b/tire_pressure_calculator/web/app.css
@@ -390,3 +390,20 @@ select,
 select:focus, .pred-field > input:focus, .adjust-group input:focus, .btn:focus-visible {
   outline: 1px solid var(--accent);
 }
+
+/* Phone-width viewports: the prediction inputs flow into a strict
+   two-column grid (equal columns, full-width controls) instead of the
+   ragged centered flex-wrap. */
+@media (max-width: 640px) {
+  .pred-panel {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 10px;
+  }
+  .pred-panel[hidden] { display: none; }
+  .pred-field,
+  .pred-field:nth-child(-n+2) {
+    margin: 0;
+    min-width: 0;
+  }
+}

--- a/tire_pressure_calculator/web/js/app.js
+++ b/tire_pressure_calculator/web/js/app.js
@@ -569,3 +569,9 @@ async function init() {
 }
 
 init();
+
+// Offline support is progressive — registration failure (old browser,
+// file:// serve) just means the app needs a network connection.
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('./sw.js').catch(() => {});
+}

--- a/tire_pressure_calculator/web/sw.js
+++ b/tire_pressure_calculator/web/sw.js
@@ -1,0 +1,70 @@
+// Service worker: makes the calculator installable and fully usable
+// offline. The app shell is precached and served cache-first; the model
+// artifact is network-first so a fresh deploy is picked up when online,
+// falling back to the last-synced copy trackside with no signal.
+//
+// __BUILD__ is stamped with the git SHA by the deploy workflow
+// (.github/workflows/build-tire-pressure-web.yml); locally it stays as-is,
+// which simply means one long-lived dev cache.
+const CACHE = 'tire-pressure-calculator-__BUILD__';
+
+const SHELL = [
+  './',
+  './index.html',
+  './app.css',
+  './js/app.js',
+  './js/model.js',
+  './js/strings.js',
+  './fonts/NotoSansJP-Subset.ttf',
+  './icon.svg',
+  './icon-192.png',
+  './icon-512.png',
+  './favicon.ico',
+  './manifest.webmanifest',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE).then(async (cache) => {
+    await cache.addAll(SHELL);
+    // Best-effort model precache so offline works from the very first
+    // visit. Present next to index.html on the deployed site; absent in
+    // local dev (the app falls back to the repo's data dir there).
+    try { await cache.add('./tire_model.json'); } catch { /* dev serve */ }
+  }));
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(caches.keys().then((keys) =>
+    Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)))));
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  if (event.request.method !== 'GET' || url.origin !== self.location.origin) return;
+
+  if (url.pathname.endsWith('tire_model.json')) {
+    // Network-first: fresh model when online, last-synced model offline.
+    event.respondWith(
+      fetch(event.request)
+        .then((resp) => {
+          if (resp.ok) {
+            const copy = resp.clone();
+            caches.open(CACHE).then((cache) => cache.put(event.request, copy));
+          }
+          return resp;
+        })
+        .catch(() => caches.match(event.request)));
+    return;
+  }
+
+  // App shell: cache-first, network fallback (also fills the cache for
+  // anything fetched before the worker took control).
+  event.respondWith(caches.match(event.request).then((hit) =>
+    hit ?? fetch(event.request).then((resp) => {
+      if (resp.ok) {
+        const copy = resp.clone();
+        caches.open(CACHE).then((cache) => cache.put(event.request, copy));
+      }
+      return resp;
+    })));
+});

--- a/tire_pressure_calculator/web/tests/sw.test.mjs
+++ b/tire_pressure_calculator/web/tests/sw.test.mjs
@@ -1,0 +1,43 @@
+// Guards the service worker's precache manifest: a renamed or added asset
+// that isn't reflected in sw.js would silently break offline mode (addAll
+// is atomic — one 404 fails the whole install).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const webDir = fileURLToPath(new URL('..', import.meta.url));
+const swSource = readFileSync(new URL('../sw.js', import.meta.url), 'utf8');
+
+const shellMatch = swSource.match(/const SHELL = \[([\s\S]*?)\];/);
+const shell = [...shellMatch[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+
+test('every precached shell asset exists on disk', () => {
+  assert.ok(shell.length >= 10, `SHELL list parsed (${shell.length} entries)`);
+  for (const entry of shell) {
+    if (entry === './') continue;
+    assert.ok(existsSync(webDir + entry.slice(2)), `${entry} missing from web/`);
+  }
+});
+
+test('assets referenced by index.html and app.css are precached', () => {
+  const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  const css = readFileSync(new URL('../app.css', import.meta.url), 'utf8');
+  const referenced = [
+    ...[...html.matchAll(/(?:href|src)="([^"#]+)"/g)].map((m) => m[1]),
+    ...[...css.matchAll(/url\("?([^")]+)"?\)/g)].map((m) => m[1]),
+  ].filter((u) => !u.startsWith('http') && !u.startsWith('data:'));
+  for (const asset of referenced) {
+    const normalized = './' + asset.replace(/^\.\//, '');
+    assert.ok(shell.includes(normalized), `${normalized} referenced but not in SHELL`);
+  }
+});
+
+test('cache name carries the deploy-stamped build placeholder', () => {
+  assert.match(swSource, /const CACHE = 'tire-pressure-calculator-__BUILD__'/);
+  // The deploy workflow substitutes it — keep the two in sync.
+  const workflow = readFileSync(
+    new URL('../../../.github/workflows/build-tire-pressure-web.yml', import.meta.url), 'utf8');
+  assert.match(workflow, /sed -i "s\/__BUILD__\//);
+});


### PR DESCRIPTION

The calculator already shipped a manifest + icons; this adds the missing
piece - a service worker - so it installs from Chrome/Android and works
with no signal trackside:

- App shell (html/css/js/font/icons) precached and served cache-first.
- tire_model.json is network-first with cache fallback: a fresh deploy
  is picked up when online, the last-synced model keeps predictions
  working offline. Best-effort precache so offline works from the very
  first visit.
- Cache version is __BUILD__, stamped with the git SHA by the deploy
  workflow so each release busts the previous cache; the repo copy keeps
  the placeholder (one long-lived cache under local dev serve).
- New sw.test.mjs guards the precache manifest: every SHELL entry must
  exist on disk, every asset referenced by index.html/app.css must be
  precached (addAll is atomic - one 404 breaks offline install), and the
  workflow must keep stamping the placeholder.

Verified with Playwright: SW installs, page becomes controlled, then
with the network cut the app reloads and predicts identically to online
(all tracks, tire picker, prefills; zero page errors). 23 web tests pass.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/152).
* __->__ #152
* #150
* #149