### PR TITLE
notebooks: single-package %pip install now that dependencies resolve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     "ipywidgets>=8.0.0,<9.0.0",
     "pyyaml>=6.0,<7.0",
     "libibt>=0.0.5",
+    # Styler.format lap-time tables render through jinja2 (pandas imports it
+    # lazily, which Pyodide's auto-loader can't see — declaring it here keeps
+    # the notebooks to a single %pip install).
+    "jinja2>=3.0,<4.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1531,6 +1531,7 @@ version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "ipywidgets" },
+    { name = "jinja2" },
     { name = "libibt" },
     { name = "libxrk" },
     { name = "numpy" },
@@ -1580,6 +1581,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'tire-etl'", specifier = ">=0.27.0,<1.0.0" },
     { name = "ipykernel", marker = "extra == 'app'", specifier = ">=7.1.0,<8.0.0" },
     { name = "ipywidgets", specifier = ">=8.0.0,<9.0.0" },
+    { name = "jinja2", specifier = ">=3.0,<4.0" },
     { name = "jupyterlab", marker = "extra == 'app'", specifier = ">=4.4.10,<5.0.0" },
     { name = "jupyterlite-core", marker = "extra == 'jupyterlite'", specifier = "==0.8.1" },
     { name = "jupyterlite-pyodide-kernel", marker = "extra == 'jupyterlite'", specifier = "==0.8.3" },

--- a/workspace_template/en/basics.ipynb
+++ b/workspace_template/en/basics.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Use the Rust parser backend for ~3x faster file loading\n",
     "import os\n",

--- a/workspace_template/en/braking_analysis.ipynb
+++ b/workspace_template/en/braking_analysis.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Use the Rust parser backend for ~3x faster file loading\n",
     "import os\n",

--- a/workspace_template/en/consistency_analysis.ipynb
+++ b/workspace_template/en/consistency_analysis.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Use the Rust parser backend for ~3x faster file loading\n",
     "import os\n",

--- a/workspace_template/en/suspension_analysis.ipynb
+++ b/workspace_template/en/suspension_analysis.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Use the Rust parser backend for ~3x faster file loading\n",
     "import os\n",

--- a/workspace_template/en/tire_analysis.ipynb
+++ b/workspace_template/en/tire_analysis.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Use the Rust parser backend for ~3x faster file loading\n",
     "import os\n",

--- a/workspace_template/en/tire_grip_analysis.ipynb
+++ b/workspace_template/en/tire_grip_analysis.ipynb
@@ -12,7 +12,7 @@
    "outputs": [],
    "source": [
     "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
-    "%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Use the Rust parser backend for ~3x faster file loading\n",
     "import os\n",

--- a/workspace_template/en/track_analysis.ipynb
+++ b/workspace_template/en/track_analysis.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "# Install required packages (needed for JupyterLite, skipped in regular JupyterLab if already installed)\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Use the Rust parser backend for ~3x faster file loading\n",
     "import os\n",

--- a/workspace_template/ja/basics.ipynb
+++ b/workspace_template/ja/basics.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "# 必要なパッケージをインストール（JupyterLiteで必要、通常のJupyterLabでは既にインストール済みならスキップ）\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Rustパーサーバックエンドを使用（ファイル読み込みが約3倍高速）\n",
     "import os\n",

--- a/workspace_template/ja/braking_analysis.ipynb
+++ b/workspace_template/ja/braking_analysis.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "# 必要なパッケージをインストール（JupyterLiteで必要、通常のJupyterLabでは既にインストール済みならスキップ）\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Rustパーサーバックエンドを使用（ファイル読み込みが約3倍高速）\n",
     "import os\n",

--- a/workspace_template/ja/consistency_analysis.ipynb
+++ b/workspace_template/ja/consistency_analysis.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "# 必要なパッケージをインストール（JupyterLiteで必要、通常のJupyterLabでは既にインストール済みならスキップ）\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Rustパーサーバックエンドを使用（ファイル読み込みが約3倍高速）\n",
     "import os\n",

--- a/workspace_template/ja/suspension_analysis.ipynb
+++ b/workspace_template/ja/suspension_analysis.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "# 必要なパッケージをインストール（JupyterLiteで必要、通常のJupyterLabでは既にインストール済みならスキップ）\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Rustパーサーバックエンドを使用（ファイル読み込みが約3倍高速）\n",
     "import os\n",

--- a/workspace_template/ja/tire_analysis.ipynb
+++ b/workspace_template/ja/tire_analysis.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "# 必要なパッケージをインストール（JupyterLiteで必要、通常のJupyterLabでは既にインストール済みならスキップ）\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Rustパーサーバックエンドを使用（ファイル読み込みが約3倍高速）\n",
     "import os\n",

--- a/workspace_template/ja/tire_grip_analysis.ipynb
+++ b/workspace_template/ja/tire_grip_analysis.ipynb
@@ -12,7 +12,7 @@
    "outputs": [],
    "source": [
     "# 必要なパッケージをインストール（JupyterLite用、通常のJupyterLabではインストール済みならスキップ）\n",
-    "%pip install -q pandas plotly libxrk motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Rustパーサーバックエンドを使用して読み込みを高速化\n",
     "import os\n",

--- a/workspace_template/ja/track_analysis.ipynb
+++ b/workspace_template/ja/track_analysis.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "# 必要なパッケージをインストール（JupyterLiteで必要、通常のJupyterLabでは既にインストール済みならスキップ）\n",
-    "%pip install -q pandas plotly libxrk libibt motorsports-data-notebook jinja2 ipywidgets\n",
+    "%pip install -q motorsports-data-notebook\n",
     "\n",
     "# Rustパーサーバックエンドを使用（ファイル読み込みが約3倍高速）\n",
     "import os\n",


### PR DESCRIPTION

The seven-package install line in every notebook was a fossil of the
stripped-metadata era: locally hosted wasm wheels had their
Requires-Dist removed, so installing motorsports-data-notebook pulled
nothing and each notebook had to enumerate the world. With wheels
resolving from PyPI with full metadata, the notebooks now install just
motorsports-data-notebook; pandas/numpy/pyarrow/pyyaml arrive from the
Pyodide lock and plotly/ipywidgets/libxrk/libibt from PyPI as declared
dependencies.

jinja2 becomes an explicit project dependency: the package's
format_lap_time is designed for Styler.format tables, and pandas
imports jinja2 lazily at render time - a code path Pyodide's
import-scanning auto-loader can't see, so it must be an installed
dependency rather than a notebook line item.

All 14 notebooks (en + ja) updated. Verified in-browser on the rebuilt
site: basics runs end-to-end from the single install (styler lap
table, both Plotly plots, zero tracebacks); 601 tests + notebook lint
pass.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/154).
* __->__ #154
* #153
* #152
* #150
* #149