### PR TITLE
jupyterlite: stop vendoring the Pyodide distribution (481 MB -> 105 MB site)

### DIFF
--- a/jupyter_lite_config.json
+++ b/jupyter_lite_config.json
@@ -1,8 +1,0 @@
-{
-  "LiteBuildConfig": {
-    "output_dir": "dist"
-  },
-  "PyodideAddon": {
-    "pyodide_url": "https://github.com/pyodide/pyodide/releases/download/314.0.5/pyodide-314.0.5.tar.bz2"
-  }
-}


### PR DESCRIPTION

Drop the PyodideAddon pyodide_url pin so the pyodide-kernel extension
loads its bundled Pyodide runtime from the jsDelivr CDN at page load
instead of us vendoring the full 450 MB distribution into
dist/static/pyodide. This is JupyterLite's default deployment mode;
vendoring was the opt-in.

With the pin gone the config file's only other key (output_dir) was
already redundant with the --output-dir CLI flag, so
jupyter_lite_config.json is deleted outright.

The local piplite index is unaffected - it's a separate addon - so
motorsports-data-notebook still distributes from the site itself
without PyPI. Runtime sourcing after this change, verified in-browser:
Pyodide/stdlib/numpy/pandas from cdn.jsdelivr.net, libxrk/libibt/plotly
from PyPI, the project wheel from ./pypi/. The basics notebook runs
end-to-end on the slim build (both plots, zero tracebacks).

Site artifact drops 481 MB -> 105 MB, which also speeds the CI
artifact upload and the git-LFS push to the releases repo.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/157).
* #158
* __->__ #157