### PR TITLE
version: 0.19.1 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motorsports-data-notebook"
-version = "0.19.0"
+version = "0.19.1"
 description = ""
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/uv.lock
+++ b/uv.lock
@@ -1527,7 +1527,7 @@ wheels = [
 
 [[package]]
 name = "motorsports-data-notebook"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "ipywidgets" },


### PR DESCRIPTION

The de-vendored (CDN-runtime) JupyterLite site releases as 0.19.1.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/motorsports_data_notebook/pull/158).
* __->__ #158
* #157